### PR TITLE
[LM-2] Implement /api/report version negotiation and core_version telemetry

### DIFF
--- a/server.py
+++ b/server.py
@@ -2,6 +2,7 @@
 """Loop Monitor — FastAPI service tracking agent performance across Loop pipeline runs."""
 
 import json
+import logging
 import os
 import sqlite3
 import time
@@ -11,9 +12,11 @@ from pathlib import Path
 from typing import Optional
 
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
 
 DB_PATH = Path(__file__).parent / "bounties.db"
 STATIC_DIR = Path(__file__).parent / "static"
@@ -157,6 +160,9 @@ def _upsert_score(conn: sqlite3.Connection, model: str, role: str, project: str,
 SUPPORTED_API_MAJOR = "1"
 MONITOR_VERSION = (Path(__file__).parent / "VERSION").read_text().strip() if (Path(__file__).parent / "VERSION").exists() else "unknown"
 
+# In-memory counter: core_version string → number of /api/report calls seen
+core_version_counts: dict = {}
+
 
 @app.get("/api/health")
 def get_health():
@@ -164,23 +170,28 @@ def get_health():
         "status": "ok",
         "monitor_version": MONITOR_VERSION,
         "supported_bounty_api": f"{SUPPORTED_API_MAJOR}.x",
+        "core_version_counts": core_version_counts,
     }
 
 
 @app.post("/api/report", status_code=201)
 def post_report(payload: ReportPayload):
     # Version negotiation: accept v1.x; reject other majors with 426.
+    if payload.api is None:
+        logger.warning("Missing 'api' field in /api/report payload; treating as v1.0 (legacy)")
     api = (payload.api or "1.0").strip()
     major = api.split(".", 1)[0] if api else "1"
     if major != SUPPORTED_API_MAJOR:
-        raise HTTPException(
+        return JSONResponse(
             status_code=426,
-            detail={
+            content={
                 "error": "version_unsupported",
                 "supported": [f"{SUPPORTED_API_MAJOR}.x"],
-                "received": api,
             },
         )
+
+    cv = payload.core_version or "unknown"
+    core_version_counts[cv] = core_version_counts.get(cv, 0) + 1
 
     conn = get_db()
     try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,56 @@
+"""Tests for /api/report version negotiation and /api/health core_version counter."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from server import app, core_version_counts
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+def _report(client, **kwargs):
+    return client.post("/api/report", json={"event": "dev_done", **kwargs})
+
+
+def test_v1_0_accepted(client):
+    resp = _report(client, api="1.0")
+    assert resp.status_code == 201
+    assert resp.json()["ok"] is True
+
+
+def test_v1_5_unknown_fields_ignored(client):
+    """api=1.5 with extra unknown fields must be accepted (extra='ignore')."""
+    resp = _report(client, api="1.5", future_field="whatever", another_unknown=42)
+    assert resp.status_code == 201
+    assert resp.json()["ok"] is True
+
+
+def test_v2_0_rejected_426(client):
+    resp = _report(client, api="2.0")
+    assert resp.status_code == 426
+    body = resp.json()
+    assert body == {"error": "version_unsupported", "supported": ["1.x"]}
+
+
+def test_missing_api_warned_and_accepted(client, caplog):
+    with caplog.at_level("WARNING", logger="server"):
+        resp = _report(client)  # no api field
+    assert resp.status_code == 201
+    assert resp.json()["ok"] is True
+    assert any("Missing 'api'" in r.message for r in caplog.records)
+
+
+def test_health_exposes_core_version_counts(client):
+    core_version_counts.clear()
+    _report(client, api="1.0", core_version="0.1.0")
+    _report(client, api="1.0", core_version="0.1.0")
+    _report(client, api="1.0", core_version="0.2.0")
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    counts = resp.json()["core_version_counts"]
+    assert counts["0.1.0"] == 2
+    assert counts["0.2.0"] == 1


### PR DESCRIPTION
## Summary

- Adds proper version negotiation to `POST /api/report`: accepts `api=1.x`, rejects `api=2.x+` with HTTP 426 and exact error body `{"error":"version_unsupported","supported":["1.x"]}`
- Logs a warning when `api` field is missing and falls back to v1.0 for backwards compatibility
- Tracks `core_version` field distribution in an in-memory counter exposed at `GET /api/health` as `core_version_counts`
- Adds `tests/test_api.py` with pytest covering all four acceptance criteria from issue #2

## Test plan

- [x] `test_v1_0_accepted` — 201 on api=1.0
- [x] `test_v1_5_unknown_fields_ignored` — 201 on api=1.5 with unknown fields
- [x] `test_v2_0_rejected_426` — 426 with exact body on api=2.0
- [x] `test_missing_api_warned_and_accepted` — warning logged, 201 returned when api missing
- [x] `test_health_exposes_core_version_counts` — /api/health returns correct counts

Run: `pytest tests/test_api.py -v`

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)