### PR TITLE
[LM-2] Persist core_version, warn on missing api, expose counts in health

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,3 +1,4 @@
+import logging
 import sqlite3
 import json
 from datetime import datetime, timezone
@@ -8,6 +9,8 @@ from pathlib import Path
 from fastapi import FastAPI, BackgroundTasks, HTTPException
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, model_validator
+
+logger = logging.getLogger(__name__)
 
 DB_PATH = "bounty.db"
 
@@ -89,6 +92,7 @@ def init_db():
         ("issue_number", "INTEGER"),
         ("pr_number", "INTEGER"),
         ("detail", "TEXT"),
+        ("core_version", "TEXT"),
     ]:
         if col not in cols:
             conn.execute(f"ALTER TABLE events ADD COLUMN {col} {defn}")
@@ -221,8 +225,8 @@ def _insert_event(data: ReportPayload):
     now = datetime.now(timezone.utc).isoformat()
     conn.execute(
         """INSERT INTO events
-           (project, role, model, event_type, issue_number, pr_number, detail, payload, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           (project, role, model, event_type, issue_number, pr_number, detail, payload, core_version, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             data.project,
             data.role,
@@ -232,6 +236,7 @@ def _insert_event(data: ReportPayload):
             data.pr_number,
             data.detail,
             json.dumps(data.payload) if data.payload else None,
+            data.core_version,
             now,
         ),
     )
@@ -325,15 +330,24 @@ MONITOR_VERSION = (Path(__file__).parent / "VERSION").read_text().strip() if (Pa
 
 @app.get("/api/health")
 def health():
+    conn = get_db()
+    rows = conn.execute(
+        "SELECT core_version, COUNT(*) as cnt FROM events WHERE core_version IS NOT NULL GROUP BY core_version"
+    ).fetchall()
+    conn.close()
+    core_version_counts = {r["core_version"]: r["cnt"] for r in rows}
     return {
         "status": "ok",
         "monitor_version": MONITOR_VERSION,
         "supported_bounty_api": f"{SUPPORTED_API_MAJOR}.x",
+        "core_version_counts": core_version_counts,
     }
 
 
 @app.post("/api/report", status_code=202)
 async def report(data: ReportPayload, background_tasks: BackgroundTasks):
+    if not data.api:
+        logger.warning("Received bounty event with no 'api' field — treating as v1.0 legacy")
     # Bounty event API version negotiation: accept 1.x, reject other majors with 426.
     if data.api:
         major = data.api.split(".", 1)[0]

--- a/test_server.py
+++ b/test_server.py
@@ -214,3 +214,61 @@ def test_pipeline_run_not_duplicated(isolated_client):
     data = response.json()
     assert len(data) == 1
     assert data[0]["pr_number"] == 99
+
+
+# ── Version negotiation tests ──
+
+def test_version_v1_0_accepted(isolated_client):
+    resp = isolated_client.post("/api/report", json={
+        "api": "1.0", "project": "p", "role": "dev", "event_type": "dev_done",
+        "core_version": "0.1.0",
+    })
+    assert resp.status_code == 202
+
+
+def test_version_v1_5_accepted_unknown_fields_ignored(isolated_client):
+    resp = isolated_client.post("/api/report", json={
+        "api": "1.5", "project": "p", "role": "dev", "event_type": "dev_done",
+        "future_field": "ignored",
+    })
+    assert resp.status_code == 202
+
+
+def test_version_v2_rejected_426(isolated_client):
+    resp = isolated_client.post("/api/report", json={
+        "api": "2.0", "project": "p", "role": "dev", "event_type": "dev_done",
+    })
+    assert resp.status_code == 426
+    body = resp.json()
+    assert body["detail"]["error"] == "version_unsupported"
+    assert body["detail"]["supported"] == [f"{server.SUPPORTED_API_MAJOR}.x"]
+
+
+def test_missing_api_accepted_with_warning(isolated_client, caplog):
+    import logging
+    with caplog.at_level(logging.WARNING, logger="server"):
+        resp = isolated_client.post("/api/report", json={
+            "project": "p", "role": "dev", "event_type": "dev_done",
+        })
+    assert resp.status_code == 202
+    assert any("no 'api' field" in r.message for r in caplog.records)
+
+
+def test_health_core_version_counts(isolated_client):
+    isolated_client.post("/api/report", json={
+        "api": "1.0", "project": "p", "role": "dev", "event_type": "dev_done",
+        "core_version": "0.1.0",
+    })
+    isolated_client.post("/api/report", json={
+        "api": "1.0", "project": "p", "role": "dev", "event_type": "dev_done",
+        "core_version": "0.1.0",
+    })
+    isolated_client.post("/api/report", json={
+        "api": "1.0", "project": "p", "role": "dev", "event_type": "dev_done",
+        "core_version": "0.2.0",
+    })
+    resp = isolated_client.get("/api/health")
+    assert resp.status_code == 200
+    counts = resp.json()["core_version_counts"]
+    assert counts["0.1.0"] == 2
+    assert counts["0.2.0"] == 1


### PR DESCRIPTION
Closes #2

## Changes

- **`server.py`**:
  1. Added `import logging` and `logger = logging.getLogger(__name__)` at module level
  2. `init_db`: added `("core_version", "TEXT")` to the migration list so the column is added to existing DBs
  3. `_insert_event`: persists `data.core_version` to the new `events.core_version` column
  4. `report()`: logs `WARNING` before processing when `data.api` is absent
  5. `health()`: queries `SELECT core_version, COUNT(*) FROM events GROUP BY core_version` and returns `core_version_counts` dict in the response

- **`test_server.py`**: added 5 new test functions using the `isolated_client` fixture:
  - `test_version_v1_0_accepted` — api=1.0 → 202
  - `test_version_v1_5_accepted_unknown_fields_ignored` — api=1.5 with extra fields → 202
  - `test_version_v2_rejected_426` — api=2.0 → 426 + correct error body
  - `test_missing_api_accepted_with_warning` — no api field → 202 + WARNING log
  - `test_health_core_version_counts` — health endpoint returns correct per-version counts after reports

## Test Plan

Run `pytest test_server.py -v` — all 5 new tests (and all existing tests) should pass.