### PR TITLE
[LM-7] Fix PR timeline endpoint 404 when no pipeline_runs row exists

### DIFF
--- a/server.py
+++ b/server.py
@@ -542,11 +542,24 @@ def get_timeline_by_pr(project: str, pr_number: int):
         "SELECT issue_number FROM pipeline_runs WHERE project=? AND pr_number=? ORDER BY id DESC LIMIT 1",
         (project, pr_number),
     ).fetchone()
-    conn.close()
 
     if run_row is None:
-        raise HTTPException(status_code=404, detail="PR not found")
+        rows = conn.execute(
+            "SELECT * FROM events WHERE project=? AND pr_number=? ORDER BY created_at",
+            (project, pr_number),
+        ).fetchall()
+        conn.close()
+        if not rows:
+            raise HTTPException(status_code=404, detail="PR not found")
+        return {
+            "pr_number": pr_number,
+            "project": project,
+            "issue_number": None,
+            "summary": {},
+            "events": [dict(r) for r in rows],
+        }
 
+    conn.close()
     return get_timeline(project, run_row["issue_number"])
 
 

--- a/test_server.py
+++ b/test_server.py
@@ -202,6 +202,19 @@ def test_stats_with_runs(isolated_client):
     assert "rework_rate" in data
 
 
+def test_timeline_pr_fallback_no_pipeline_run(isolated_client):
+    isolated_client.post("/api/report", json={
+        "project": "proj-pr", "role": "reviewer", "event_type": "started", "pr_num": 42
+    })
+    response = isolated_client.get("/api/stats/timeline/pr/proj-pr/42")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["pr_number"] == 42
+    assert data["project"] == "proj-pr"
+    assert data["issue_number"] is None
+    assert len(data["events"]) > 0
+
+
 def test_pipeline_run_not_duplicated(isolated_client):
     server._insert_event(server.ReportPayload(
         project="proj-nd", role="planner", event_type="started", issue_number=50


### PR DESCRIPTION
Closes #7

## Changes
- **`server.py`**: Modified `get_timeline_by_pr` to add a fallback query against the `events` table when `pipeline_runs` has no matching row for `(project, pr_number)`. The fallback returns a 200 with `issue_number: null`, `summary: {}`, and the matching events. The original `pipeline_runs`-backed path is unchanged. Moved `conn.close()` into each branch (fallback and non-fallback) so the connection stays open for the fallback query.
- **`test_server.py`**: Added `test_timeline_pr_fallback_no_pipeline_run` — POSTs a PR-stage event with `pr_num=42` but no `issue_num`, then asserts the timeline endpoint returns 200 with events present and `issue_number: null`.

## Test Plan
- Run `pytest test_server.py::test_timeline_pr_fallback_no_pipeline_run` — should pass
- Run full `pytest test_server.py` — 18/19 pass (pre-existing `test_report_accepted` failure unrelated to this fix)
- Manually POST a reviewer event with `pr_num` only, then GET `/api/stats/timeline/pr/<project>/<pr>` — should return 200 with events
- GET the same endpoint for a nonexistent PR — should still return 404