### PR TITLE
[LM-9] Add check-version.sh to notify when loop core has a newer release

### DIFF
--- a/scripts/check-version.sh
+++ b/scripts/check-version.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# check-version.sh — detect when loop core is behind the latest GitHub release and notify.
+# Invoke via a separate launchd StartInterval plist or cron entry, NOT from run.sh.
+# Example cron: 0 * * * * /path/to/scripts/check-version.sh
+# Example launchd key: <key>StartInterval</key><integer>3600</integer>
+set -euo pipefail
+
+LOOP_ROOT="${LOOP_ROOT:-/Users/vadim/.openclaw/workspace/projects/loop}"
+LOOP_ENV="$LOOP_ROOT/loop.env"
+[[ -f "$LOOP_ENV" ]] && source "$LOOP_ENV"
+
+installed=$(cat "$LOOP_ROOT/VERSION" 2>/dev/null | sed 's/^v//')
+[[ -z "$installed" ]] && exit 0
+
+latest=$(gh release view --repo svv2014/loop --json tagName --jq .tagName 2>/dev/null | sed 's/^v//')
+[[ -z "$latest" ]] && exit 0
+
+[[ "$installed" == "$latest" ]] && exit 0
+
+STATE_FILE="/tmp/loop-version-last-notified"
+now=$(date +%s)
+if [[ -f "$STATE_FILE" ]]; then
+    last=$(cat "$STATE_FILE")
+    (( now - last < 3600 )) && exit 0
+fi
+
+msg="Loop update available: v${installed} → v${latest}. Run update.sh to apply."
+"${LOOP_NOTIFY:-echo}" "$msg"
+echo "$now" > "$STATE_FILE"


### PR DESCRIPTION
Closes #9

## Changes
- Created `scripts/check-version.sh` (executable) that:
  - Sources `$LOOP_ROOT/loop.env` if it exists
  - Reads the installed version from `$LOOP_ROOT/VERSION` (strips leading `v`)
  - Fetches the latest GitHub release tag from `svv2014/loop` via `gh release view` (silent exit on failure)
  - Exits 0 with no notification when installed == latest
  - Applies a 1-hour throttle via `/tmp/loop-version-last-notified` (state file stores last notification epoch)
  - Sends a Signal notification via `$LOOP_NOTIFY` (falls back to `echo` when unset) with the text: `Loop update available: v{installed} → v{latest}. Run update.sh to apply.`
  - Documents in the header that it should be wired via launchd `StartInterval` or cron (`0 * * * * /path/to/check-version.sh`), not `run.sh`

No other files were touched.

## Test Plan
- [ ] Run `bash -x scripts/check-version.sh` with `LOOP_ROOT` pointing to a valid loop checkout — should complete without errors
- [ ] When installed version matches latest: script exits 0, no notification, no state file written
- [ ] When installed version is behind: notification sent via `$LOOP_NOTIFY` (or `echo`), `/tmp/loop-version-last-notified` written with current epoch
- [ ] Running again within 1 hour while still outdated: throttle kicks in, no second notification
- [ ] Running after 1 hour while still outdated: new notification sent, state file updated
- [ ] With `gh` unavailable (network down): script exits 0 silently with no output or crash
- [ ] With missing `$LOOP_ROOT/VERSION`: script exits 0 silently