### PR TITLE
[LM-3] Add scripts/release.sh and expand versioning policy in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,9 +31,43 @@ pytest tests/
 
 ## Versioning
 
-loop-monitor independently versioned. The bounty event API contract is
-shared with Loop core; bumping it requires coordination across both
-repos.
+loop-monitor is independently versioned from Loop core using
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Use `scripts/release.sh patch|minor|major` to cut a release — it bumps
+`VERSION`, commits, tags, pushes, and creates a GitHub Release with the
+CHANGELOG excerpt automatically.
+
+### Pre-1.0 policy (current)
+
+While the major version is **0**, a MINOR bump (`0.X.0`) may introduce
+breaking changes to loop-monitor's own HTTP API or database schema.
+Every such change **must**:
+
+1. Include the word **BREAKING** in the CHANGELOG entry for that version.
+2. Include a migration recipe explaining how existing deployments should
+   update (SQL `ALTER TABLE` statements, config key renames, etc.).
+
+Patch bumps (`0.X.Y`) must remain backwards-compatible.
+
+### Post-1.0 policy
+
+Once `1.0.0` ships, strict semver applies:
+
+- **MAJOR** — any backwards-incompatible change to a public interface.
+- **MINOR** — new backwards-compatible functionality.
+- **PATCH** — backwards-compatible bug fixes only.
+
+### Bounty event API contract
+
+The bounty event API (`/api/report`, `/api/verdict`) is a **shared
+contract** between loop-monitor and Loop core. Its version (`api: "1.x"`)
+is baked into every payload.
+
+- Changing the API contract requires a coordinated bump in **both** repos.
+- Additive-only changes (new optional fields) may be shipped as a MINOR
+  bump without breaking Loop core clients.
+- Any removal or rename of an existing field is a **major API version**
+  bump and requires updating the spec in Loop core first.
 
 ## Reporting issues
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# release.sh — bump VERSION, commit, tag, push, create GitHub Release.
+# Usage: release.sh patch|minor|major
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION_FILE="${REPO_ROOT}/VERSION"
+CHANGELOG_FILE="${REPO_ROOT}/CHANGELOG.md"
+
+# ---------------------------------------------------------------------------
+# Guards
+# ---------------------------------------------------------------------------
+BUMP="${1:?Usage: release.sh patch|minor|major}"
+
+if ! [[ "$BUMP" =~ ^(patch|minor|major)$ ]]; then
+    echo "error: argument must be one of: patch, minor, major" >&2
+    exit 1
+fi
+
+if ! git -C "$REPO_ROOT" diff --quiet || ! git -C "$REPO_ROOT" diff --cached --quiet; then
+    echo "error: working tree is dirty — commit or stash changes first" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Compute new version
+# ---------------------------------------------------------------------------
+CURRENT="$(tr -d '[:space:]' < "$VERSION_FILE")"
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+
+case "$BUMP" in
+    major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+    minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+    patch) PATCH=$((PATCH + 1)) ;;
+esac
+
+NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+TAG="v${NEW_VERSION}"
+
+echo "Bumping ${CURRENT} → ${NEW_VERSION} (${BUMP})"
+
+# ---------------------------------------------------------------------------
+# Write new VERSION
+# ---------------------------------------------------------------------------
+printf '%s\n' "$NEW_VERSION" > "$VERSION_FILE"
+
+# ---------------------------------------------------------------------------
+# Extract CHANGELOG entry for the new version (if present)
+# ---------------------------------------------------------------------------
+RELEASE_NOTES="$(python3 - "$NEW_VERSION" "$CHANGELOG_FILE" <<'PYEOF'
+import re, sys
+
+tag = sys.argv[1]
+
+with open(sys.argv[2]) as f:
+    text = f.read()
+
+pattern = rf'## \[{re.escape(tag)}\][^\n]*\n(.*?)(?=\n## |\Z)'
+m = re.search(pattern, text, re.DOTALL)
+if m:
+    print(m.group(1).strip())
+PYEOF
+)" || true
+
+if [[ -z "$RELEASE_NOTES" ]]; then
+    RELEASE_NOTES="Release ${TAG}"
+fi
+
+# ---------------------------------------------------------------------------
+# Commit, tag, push
+# ---------------------------------------------------------------------------
+git -C "$REPO_ROOT" add "$VERSION_FILE"
+git -C "$REPO_ROOT" commit -m "release: v${NEW_VERSION}"
+git -C "$REPO_ROOT" tag "$TAG"
+git -C "$REPO_ROOT" push origin HEAD
+git -C "$REPO_ROOT" push origin "$TAG"
+
+# ---------------------------------------------------------------------------
+# Create GitHub Release
+# ---------------------------------------------------------------------------
+gh release create "$TAG" \
+    --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)" \
+    --title "$TAG" \
+    --notes "$RELEASE_NOTES"
+
+echo "Released ${TAG}"


### PR DESCRIPTION
Closes #3

## Changes

### `scripts/release.sh` (new, executable)
- Accepts `patch`, `minor`, or `major` as the sole argument; aborts with a clear error on invalid input or missing argument
- Aborts immediately with a clear error if the working tree is dirty (uncommitted or staged changes)
- Reads the current `VERSION` file, computes the bumped version, writes it back
- Extracts the matching CHANGELOG section for the new version using Python; positional args (`$NEW_VERSION`, `$CHANGELOG_FILE`) are placed **before** the heredoc redirection (`<<'PYEOF'`) so `sys.argv[1]` and `sys.argv[2]` are populated correctly — this was the bug in PR #13
- Falls back to `"Release vX.Y.Z"` if no CHANGELOG entry is found
- Commits the VERSION bump, creates a git tag, pushes branch + tag, then runs `gh release create`
- Follows `scripts/judge.sh` conventions: `#!/usr/bin/env bash`, `set -euo pipefail`

### `CONTRIBUTING.md` — versioning section expanded
- Documents the pre-1.0 policy: MINOR may break; CHANGELOG must include **BREAKING** + migration recipe
- Documents the post-1.0 strict semver policy (MAJOR/MINOR/PATCH semantics)
- Documents the bounty event API contract versioning separately (coordination with Loop core required for breaking changes)

### What was fixed vs PR #13
PR #13 had the Python positional arguments (`"$NEW_VERSION" "$CHANGELOG_FILE"`) placed **after** the heredoc closing delimiter on a new line. In bash, everything after a heredoc's closing delimiter is a separate command, so `sys.argv[1]` raised `IndexError`, `|| true` swallowed it, and `RELEASE_NOTES` was always empty. This PR places the args before the `<<'PYEOF'` redirection.

## Test Plan
- [ ] Run `scripts/release.sh` with no arguments — should print usage error and exit non-zero
- [ ] Run `scripts/release.sh invalid` — should print error and exit non-zero
- [ ] Make a dirty change, run `scripts/release.sh patch` — should abort with "working tree is dirty"
- [ ] On a clean tree with a CHANGELOG entry for the new version, run `scripts/release.sh patch` — GitHub Release body should contain the CHANGELOG excerpt (not the fallback "Release vX.Y.Z")
- [ ] Verify `scripts/release.sh` is executable (`ls -la scripts/release.sh` shows `x` bit)
- [ ] Read CONTRIBUTING.md and confirm pre-1.0, post-1.0, and bounty API contract sections are present