### PR TITLE
Draft: [LM-18] Timeline: per-event cumulative time and feed age_seconds

### DIFF
--- a/server.py
+++ b/server.py
@@ -445,11 +445,19 @@ def feed():
            FROM events ORDER BY id DESC LIMIT 50"""
     ).fetchall()
     conn.close()
+    now = datetime.now(timezone.utc)
     result = []
     for r in rows:
         entry = dict(r)
         if entry["payload"]:
             entry["payload"] = json.loads(entry["payload"])
+        try:
+            created = datetime.fromisoformat(entry["created_at"].replace(" ", "T"))
+            if created.tzinfo is None:
+                created = created.replace(tzinfo=timezone.utc)
+            entry["age_seconds"] = int((now - created).total_seconds())
+        except Exception:
+            entry["age_seconds"] = None
         result.append(entry)
     return result
 
@@ -622,6 +630,16 @@ def get_timeline(project: str, issue: int):
 
     events = _build_timeline_events(history_rows)
 
+    # Compute total elapsed seconds from first to last event in the set
+    total_elapsed_seconds = None
+    ts_candidates = []
+    for e in events:
+        ts_candidates.append(_parse_ts(e.get("started_at")))
+        ts_candidates.append(_parse_ts(e.get("completed_at")))
+    ts_valid = [t for t in ts_candidates if t is not None]
+    if len(ts_valid) >= 2:
+        total_elapsed_seconds = int((max(ts_valid) - min(ts_valid)).total_seconds())
+
     summary: dict = {}
     if summary_row:
         summary = dict(summary_row)
@@ -631,8 +649,31 @@ def get_timeline(project: str, issue: int):
         "project": project,
         "repo": PROJECTS.get(project, project),
         "summary": summary,
+        "total_elapsed_seconds": total_elapsed_seconds,
         "events": events,
     }
+
+
+_TS_FORMATS = (
+    "%Y-%m-%dT%H:%M:%S.%f%z",
+    "%Y-%m-%dT%H:%M:%S%z",
+    "%Y-%m-%d %H:%M:%S",
+)
+
+
+def _parse_ts(s: Optional[str]) -> Optional[datetime]:
+    if not s:
+        return None
+    normalized = s.replace("+00:00", "+0000")
+    for fmt in _TS_FORMATS:
+        try:
+            dt = datetime.strptime(normalized, fmt)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt
+        except ValueError:
+            continue
+    return None
 
 
 def _build_timeline_events(history_rows) -> list:
@@ -640,11 +681,15 @@ def _build_timeline_events(history_rows) -> list:
     # key: (role, prefix) -> start row
     pending: dict = {}
     result = []
+    first_event_ts: Optional[datetime] = None
 
     for row in history_rows:
         role = row["role"]
         event_type = row["event_type"]
         created_at = row["created_at"]
+
+        if first_event_ts is None:
+            first_event_ts = _parse_ts(created_at)
 
         if event_type.endswith("_start"):
             prefix = event_type[: -len("_start")]
@@ -658,19 +703,14 @@ def _build_timeline_events(history_rows) -> list:
                 status = "failed"
             started_at = pending.pop((role, prefix), None)
             duration_seconds = None
-            if started_at:
-                try:
-                    from datetime import datetime
-                    for fmt in ("%Y-%m-%dT%H:%M:%S.%f%z", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%d %H:%M:%S"):
-                        try:
-                            t_start = datetime.strptime(started_at.replace("+00:00", "+0000"), fmt)
-                            t_end = datetime.strptime(created_at.replace("+00:00", "+0000"), fmt)
-                            duration_seconds = int((t_end - t_start).total_seconds())
-                            break
-                        except ValueError:
-                            continue
-                except Exception:
-                    pass
+            t_end = _parse_ts(created_at)
+            if started_at and t_end:
+                t_start = _parse_ts(started_at)
+                if t_start:
+                    duration_seconds = int((t_end - t_start).total_seconds())
+            cumulative_seconds = None
+            if first_event_ts and t_end:
+                cumulative_seconds = int((t_end - first_event_ts).total_seconds())
             result.append({
                 "role": role,
                 "event_type": f"{prefix}_{status}",
@@ -678,10 +718,15 @@ def _build_timeline_events(history_rows) -> list:
                 "started_at": started_at,
                 "completed_at": created_at,
                 "duration_seconds": duration_seconds,
+                "cumulative_seconds": cumulative_seconds,
             })
 
     # Any still-pending starts are running
     for (role, prefix), started_at in pending.items():
+        t_start = _parse_ts(started_at)
+        cumulative_seconds = None
+        if first_event_ts and t_start:
+            cumulative_seconds = int((t_start - first_event_ts).total_seconds())
         result.append({
             "role": role,
             "event_type": f"{prefix}_start",
@@ -689,6 +734,7 @@ def _build_timeline_events(history_rows) -> list:
             "started_at": started_at,
             "completed_at": None,
             "duration_seconds": None,
+            "cumulative_seconds": cumulative_seconds,
         })
 
     # Sort by started_at

--- a/static/index.html
+++ b/static/index.html
@@ -1054,7 +1054,7 @@
     list.innerHTML = items.map(item => {
       const emoji = eventEmoji(item.event_type);
       const role = (item.role || '').charAt(0).toUpperCase() + (item.role || '').slice(1);
-      const when = timeAgo(item.created_at);
+      const when = item.age_seconds != null ? fmtDur(item.age_seconds) + ' ago' : timeAgo(item.created_at);
       const taskHtml = item.issue_number != null
         ? ' ' + timelineLink(item.project, item.issue_number, null)
         : item.pr_number != null
@@ -1108,9 +1108,12 @@
   }
 
   function fmtDur(s) {
+    if (s == null) return '';
     if (s < 60) return `${s}s`;
-    if (s < 3600) return `${Math.floor(s/60)}m ${s%60}s`;
-    return `${Math.floor(s/3600)}h ${Math.floor((s%3600)/60)}m`;
+    const m = Math.floor(s / 60), r = s % 60;
+    if (m < 60) return r ? `${m}m ${r}s` : `${m}m`;
+    const h = Math.floor(m / 60), rm = m % 60;
+    return `${h}h ${rm}m`;
   }
 
   // ── Render verdicts ──
@@ -1282,7 +1285,8 @@
 
     const outcomeClass = sum.outcome === 'clean' ? 'pos' : sum.outcome ? 'neg' : 'zero';
     const outcomeLabel = sum.outcome || 'in progress';
-    const dur          = sum.total_duration_seconds != null ? fmtDur(sum.total_duration_seconds) : null;
+    const durSecs      = sum.total_duration_seconds != null ? sum.total_duration_seconds : data.total_elapsed_seconds;
+    const dur          = durSecs != null ? fmtDur(durSecs) : null;
     const reworkCount  = sum.rework_count || 0;
 
     document.getElementById('drawer-meta').innerHTML = [
@@ -1302,8 +1306,9 @@
         const time   = s.started_at
           ? new Date(s.started_at).toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'})
           : '';
-        const durMin = s.duration_seconds != null
-          ? (s.duration_seconds / 60).toFixed(1) + 'm'
+        const durFmt = fmtDur(s.duration_seconds);
+        const cumFmt = s.cumulative_seconds != null
+          ? '+' + fmtDur(s.cumulative_seconds) + ' since opened'
           : '';
         return `
           <div class="stage-row">
@@ -1311,10 +1316,11 @@
             <div class="stage-body">
               <span class="stage-role">${escHtml(role)}</span>
               <span class="stage-event">${escHtml(s.event_type)}</span>
+              ${cumFmt ? `<div style="font-size:0.68rem;color:var(--muted)">${escHtml(cumFmt)}</div>` : ''}
             </div>
             <div class="stage-time">
-              ${time   ? `<div>${escHtml(time)}</div>`               : ''}
-              ${durMin ? `<div class="stage-dur">${escHtml(durMin)}</div>` : ''}
+              ${time   ? `<div>${escHtml(time)}</div>`                   : ''}
+              ${durFmt ? `<div class="stage-dur">${escHtml(durFmt)}</div>` : ''}
             </div>
           </div>`;
       }).join('');

--- a/test_server.py
+++ b/test_server.py
@@ -285,3 +285,66 @@ def test_health_core_version_counts(isolated_client):
     counts = resp.json()["core_version_counts"]
     assert counts["0.1.0"] == 2
     assert counts["0.2.0"] == 1
+
+
+# ── Timeline cumulative_seconds and feed age_seconds tests ──
+
+def test_timeline_cumulative_seconds(isolated_client):
+    """cumulative_seconds on each event is elapsed from the first event."""
+    import time as _time
+    # Insert start then done events with a known gap via _insert_event
+    # Use direct DB insertion with controlled timestamps for determinism
+    import sqlite3, server as _srv
+    conn = sqlite3.connect(_srv.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "INSERT INTO events (project, role, event_type, issue_number, created_at) VALUES (?,?,?,?,?)",
+        ("proj-cum", "builder", "build_start", 77, "2024-01-01T10:00:00+0000"),
+    )
+    conn.execute(
+        "INSERT INTO events (project, role, event_type, issue_number, created_at) VALUES (?,?,?,?,?)",
+        ("proj-cum", "builder", "build_done", 77, "2024-01-01T10:05:00+0000"),
+    )
+    conn.execute(
+        "INSERT INTO events (project, role, event_type, issue_number, created_at) VALUES (?,?,?,?,?)",
+        ("proj-cum", "tester", "test_start", 77, "2024-01-01T10:06:00+0000"),
+    )
+    conn.execute(
+        "INSERT INTO events (project, role, event_type, issue_number, created_at) VALUES (?,?,?,?,?)",
+        ("proj-cum", "tester", "test_done", 77, "2024-01-01T10:08:00+0000"),
+    )
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/stats/timeline/proj-cum/77")
+    assert resp.status_code == 200
+    data = resp.json()
+    events = data["events"]
+    assert len(events) == 2
+
+    build_ev = next(e for e in events if e["role"] == "builder")
+    test_ev  = next(e for e in events if e["role"] == "tester")
+
+    # build_done at +5m from first event → cumulative 300s
+    assert build_ev["cumulative_seconds"] == 300
+    # test_done at +8m from first event → cumulative 480s
+    assert test_ev["cumulative_seconds"] == 480
+
+    # total_elapsed_seconds = 8m = 480s
+    assert data["total_elapsed_seconds"] == 480
+
+
+def test_feed_age_seconds(isolated_client):
+    """Each feed item includes age_seconds computed server-side."""
+    isolated_client.post("/api/report", json={
+        "project": "proj-age", "role": "builder", "event_type": "started",
+    })
+    resp = isolated_client.get("/api/feed")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) >= 1
+    item = next((i for i in data if i["project"] == "proj-age"), None)
+    assert item is not None
+    assert "age_seconds" in item
+    assert isinstance(item["age_seconds"], int)
+    assert item["age_seconds"] >= 0


### PR DESCRIPTION
Closes #18

## Changes

**server.py**
- Added `_parse_ts()` helper to parse ISO 8601 timestamps (replaces inline parsing in `_build_timeline_events`)
- `_build_timeline_events`: tracks `first_event_ts` from the first row; computes `cumulative_seconds` per event (elapsed from first event to `completed_at` for paired events, or `started_at` for unpaired running starts)
- `get_timeline`: computes `total_elapsed_seconds` (min→max timestamp span across all events) and includes it at the top level of the response
- `feed()`: computes `age_seconds` server-side (`now - created_at`) for each feed item

**static/index.html**
- `fmtDur`: updated to handle `null` input and use `Ns`/`Nm Ns`/`Nh Nm` format per spec
- Feed rendering: uses `age_seconds` (formatted as `Xm Ys ago`) when present, falls back to `timeAgo(created_at)`
- Timeline drawer stage rows: shows formatted `duration_seconds` and `+Xm Ys since opened` from `cumulative_seconds`
- Timeline drawer header: uses `total_elapsed_seconds` from response when `summary.total_duration_seconds` is absent

**test_server.py**
- `test_timeline_cumulative_seconds`: inserts events with known timestamps, verifies `cumulative_seconds` and `total_elapsed_seconds` are correct
- `test_feed_age_seconds`: verifies `age_seconds` is present and a non-negative int in `/api/feed` response

## Test Plan
- All 25 tests pass (`test_report_accepted` was already failing before this PR)
- Verify `/api/stats/timeline/{project}/{issue}` returns `cumulative_seconds` on each event and `total_elapsed_seconds` at top level
- Verify `/api/feed` items include `age_seconds` as a non-negative integer
- Verify timeline drawer shows formatted duration and `+Xm Ys since opened` labels
- Verify feed shows `Xm Ys ago` formatted timestamps