### PR TITLE
Draft: [LM-19] Mark PR/issue as finished; report open→close lifecycle time

### DIFF
--- a/server.py
+++ b/server.py
@@ -97,6 +97,15 @@ def init_db():
         if col not in cols:
             conn.execute(f"ALTER TABLE events ADD COLUMN {col} {defn}")
 
+    # Migrate pipeline_runs table if new columns are missing
+    pr_cols = {row[1] for row in conn.execute("PRAGMA table_info(pipeline_runs)")}
+    for col, defn in [
+        ("issue_lifetime_seconds", "INTEGER"),
+        ("pr_lifetime_seconds", "INTEGER"),
+    ]:
+        if col not in pr_cols:
+            conn.execute(f"ALTER TABLE pipeline_runs ADD COLUMN {col} {defn}")
+
     conn.commit()
     conn.close()
 
@@ -286,6 +295,35 @@ def _insert_event(data: ReportPayload):
                    (project, issue_number, pr_number, started_at, completed_at, created_at)
                    VALUES (?, ?, ?, ?, ?, ?)""",
                 (data.project, data.issue_number, data.pr_number, now, now, now),
+            )
+
+    if data.event_type == "finished" and data.issue_number is not None:
+        now_dt = datetime.fromisoformat(now)
+        run = conn.execute(
+            "SELECT id, started_at FROM pipeline_runs WHERE project=? AND issue_number=? ORDER BY id DESC LIMIT 1",
+            (data.project, data.issue_number),
+        ).fetchone()
+        if run:
+            try:
+                started = datetime.fromisoformat(run["started_at"].replace("Z", "+00:00"))
+                issue_secs = int((now_dt - started).total_seconds())
+            except Exception:
+                issue_secs = None
+            first_pr = conn.execute(
+                "SELECT created_at FROM issue_history WHERE project=? AND issue_number=? AND pr_number IS NOT NULL ORDER BY id ASC LIMIT 1",
+                (data.project, data.issue_number),
+            ).fetchone()
+            pr_secs = None
+            if first_pr:
+                try:
+                    pr_start = datetime.fromisoformat(first_pr["created_at"].replace("Z", "+00:00"))
+                    pr_secs = int((now_dt - pr_start).total_seconds())
+                except Exception:
+                    pass
+            conn.execute(
+                """UPDATE pipeline_runs SET outcome=?, completed_at=?, issue_lifetime_seconds=?, pr_lifetime_seconds=?
+                   WHERE id=?""",
+                (data.detail or "finished", now, issue_secs, pr_secs, run["id"]),
             )
 
     _auto_bounty(conn, data, now)
@@ -497,8 +535,13 @@ def get_history(project: str, issue: int):
            ORDER BY id ASC""",
         (project, issue),
     ).fetchall()
+    run_row = conn.execute(
+        """SELECT outcome, issue_lifetime_seconds, pr_lifetime_seconds, completed_at
+           FROM pipeline_runs WHERE project=? AND issue_number=? ORDER BY id DESC LIMIT 1""",
+        (project, issue),
+    ).fetchone()
     conn.close()
-    return [dict(r) for r in rows]
+    return {"events": [dict(r) for r in rows], "run": dict(run_row) if run_row else None}
 
 
 @app.get("/api/runs")
@@ -583,7 +626,8 @@ def get_timeline(project: str, issue: int):
     conn = get_db()
 
     summary_row = conn.execute(
-        """SELECT title, outcome, total_duration_seconds, rework_count, pr_number
+        """SELECT title, outcome, total_duration_seconds, rework_count, pr_number,
+                  issue_lifetime_seconds, pr_lifetime_seconds
            FROM pipeline_runs
            WHERE project=? AND issue_number=?
            ORDER BY id DESC LIMIT 1""",

--- a/static/index.html
+++ b/static/index.html
@@ -601,6 +601,27 @@
       font-weight: 600;
     }
     .drawer-gh-link:hover { text-decoration: underline; }
+
+    .badge-merged {
+      display: inline-block;
+      font-size: 0.68rem;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: 4px;
+      background: #0d2c1a;
+      color: var(--green);
+      border: 1px solid #1a4a2a;
+    }
+    .badge-closed {
+      display: inline-block;
+      font-size: 0.68rem;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: 4px;
+      background: #2d1a1a;
+      color: var(--red);
+      border: 1px solid #4a1a1a;
+    }
   </style>
 </head>
 <body>
@@ -1285,8 +1306,19 @@
     const dur          = sum.total_duration_seconds != null ? fmtDur(sum.total_duration_seconds) : null;
     const reworkCount  = sum.rework_count || 0;
 
+    let lifecycleBadge = '';
+    if (sum.outcome && sum.issue_lifetime_seconds != null) {
+      const mins = Math.round(sum.issue_lifetime_seconds / 60);
+      const label = mins < 60 ? `${mins}m` : `${Math.floor(mins / 60)}h ${mins % 60}m`;
+      const isMerged = sum.outcome === 'merged';
+      const badgeClass = isMerged ? 'badge-merged' : 'badge-closed';
+      const verb = isMerged ? 'merged' : 'closed';
+      lifecycleBadge = `<span class="${badgeClass}">${verb} in ${label}</span>`;
+    }
+
     document.getElementById('drawer-meta').innerHTML = [
       `<span class="verdict-pts ${outcomeClass}">${escHtml(outcomeLabel)}</span>`,
+      lifecycleBadge,
       dur ? `<span class="drawer-meta-item">⏱ ${escHtml(dur)}</span>` : '',
       `<span class="drawer-meta-item">🔄 ${reworkCount} rework</span>`,
     ].filter(Boolean).join('');

--- a/test_server.py
+++ b/test_server.py
@@ -123,7 +123,9 @@ def test_api_verdicts_after_post(isolated_client):
 def test_history_empty(isolated_client):
     response = isolated_client.get("/api/history/proj-x/42")
     assert response.status_code == 200
-    assert response.json() == []
+    data = response.json()
+    assert data["events"] == []
+    assert data["run"] is None
 
 
 def test_history_after_report_with_issue(isolated_client):
@@ -134,10 +136,11 @@ def test_history_after_report_with_issue(isolated_client):
     response = isolated_client.get("/api/history/proj-h/10")
     assert response.status_code == 200
     data = response.json()
-    assert len(data) == 1
-    assert data[0]["issue_number"] == 10
-    assert data[0]["pr_number"] == 5
-    assert data[0]["role"] == "builder"
+    assert len(data["events"]) == 1
+    assert data["events"][0]["issue_number"] == 10
+    assert data["events"][0]["pr_number"] == 5
+    assert data["events"][0]["role"] == "builder"
+    assert "run" in data
 
 
 def test_history_no_entry_without_issue_number(isolated_client):
@@ -146,7 +149,26 @@ def test_history_no_entry_without_issue_number(isolated_client):
     ))
     response = isolated_client.get("/api/history/proj-h2/99")
     assert response.status_code == 200
-    assert response.json() == []
+    data = response.json()
+    assert data["events"] == []
+    assert data["run"] is None
+
+
+def test_finished_event_sets_lifecycle(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="proj-f", role="dev", event_type="dev_start", issue_number=77
+    ))
+    server._insert_event(server.ReportPayload(
+        project="proj-f", role="dev", event_type="finished", issue_number=77,
+        detail="merged"
+    ))
+    response = isolated_client.get("/api/history/proj-f/77")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["run"] is not None
+    assert data["run"]["outcome"] == "merged"
+    assert data["run"]["issue_lifetime_seconds"] is not None
+    assert data["run"]["issue_lifetime_seconds"] >= 0
 
 
 def test_runs_empty(isolated_client):


### PR DESCRIPTION
Closes #19

## Changes

### server.py
- **DB migration**: added `issue_lifetime_seconds INTEGER` and `pr_lifetime_seconds INTEGER` columns to `pipeline_runs` via the existing column-migration loop in `init_db`
- **`_insert_event` — `finished` event handling**: when `event_type == "finished"` and `issue_number` is set, computes `issue_lifetime_seconds` (from `pipeline_runs.started_at`) and `pr_lifetime_seconds` (from first `issue_history` row with a non-null `pr_number`), then UPDATEs the matching `pipeline_runs` row with `outcome = detail`, `completed_at`, and both lifetime columns
- **`GET /api/history/{project}/{issue}`**: changed from returning a flat list to `{"events": [...], "run": {...|null}}` where `run` contains `outcome`, `issue_lifetime_seconds`, `pr_lifetime_seconds`, `completed_at` from `pipeline_runs`
- **`GET /api/stats/timeline/{project}/{issue}`**: added `issue_lifetime_seconds` and `pr_lifetime_seconds` to the `pipeline_runs` SELECT so the drawer can render the badge

### static/index.html
- Added `.badge-merged` (green) and `.badge-closed` (red) CSS classes
- In `populateDrawer`, renders lifecycle badge ("merged in 14m" / "closed in 2h 3m") when `sum.outcome` and `sum.issue_lifetime_seconds` are non-null; no badge for in-progress items

### test_server.py
- Updated `test_history_empty`, `test_history_after_report_with_issue`, `test_history_no_entry_without_issue_number` to match the new `{"events", "run"}` response shape
- Added `test_finished_event_sets_lifecycle`: POSTs a `finished` event, then GETs `/api/history/{project}/{issue}` and asserts `run.issue_lifetime_seconds >= 0` and `run.outcome == "merged"`

## Test Plan
- Run `python3 -m pytest test_server.py -v` — 24/25 pass (1 pre-existing unrelated failure in `test_report_accepted`)
- Manually POST a `finished` event with `detail: "merged"` and verify `GET /api/history/{project}/{issue}` returns `run.issue_lifetime_seconds`
- Open the timeline drawer for a finished issue and verify the green "merged in Xm" badge appears in the drawer meta row