### PR TITLE
Draft: [LM-26] Add loop_id column to events table and ingest from bounty payload

### DIFF
--- a/server.py
+++ b/server.py
@@ -93,6 +93,7 @@ def init_db():
         ("pr_number", "INTEGER"),
         ("detail", "TEXT"),
         ("core_version", "TEXT"),
+        ("loop_id", "TEXT"),
     ]:
         if col not in cols:
             conn.execute(f"ALTER TABLE events ADD COLUMN {col} {defn}")
@@ -137,6 +138,7 @@ class ReportPayload(BaseModel):
     detail: Optional[str] = None
     duration_seconds: Optional[int] = None
     rework_count: Optional[int] = None
+    loop_id: Optional[str] = None
 
     class Config:
         extra = "ignore"
@@ -225,8 +227,8 @@ def _insert_event(data: ReportPayload):
     now = datetime.now(timezone.utc).isoformat()
     conn.execute(
         """INSERT INTO events
-           (project, role, model, event_type, issue_number, pr_number, detail, payload, core_version, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           (project, role, model, event_type, issue_number, pr_number, detail, payload, core_version, loop_id, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             data.project,
             data.role,
@@ -237,6 +239,7 @@ def _insert_event(data: ReportPayload):
             data.detail,
             json.dumps(data.payload) if data.payload else None,
             data.core_version,
+            data.loop_id,
             now,
         ),
     )

--- a/test_server.py
+++ b/test_server.py
@@ -267,6 +267,37 @@ def test_missing_api_accepted_with_warning(isolated_client, caplog):
     assert any("no 'api' field" in r.message for r in caplog.records)
 
 
+def test_loop_id_persisted(isolated_client):
+    import sqlite3
+    isolated_client.post("/api/report", json={
+        "project": "proj-li", "role": "dev", "event_type": "dev_start",
+        "loop_id": "my-loop",
+    })
+    import time; time.sleep(0.05)  # background task
+    conn = sqlite3.connect(server.DB_PATH)
+    row = conn.execute(
+        "SELECT loop_id FROM events WHERE project='proj-li' AND loop_id='my-loop'"
+    ).fetchone()
+    conn.close()
+    assert row is not None
+    assert row[0] == "my-loop"
+
+
+def test_loop_id_null_when_absent(isolated_client):
+    import sqlite3
+    isolated_client.post("/api/report", json={
+        "project": "proj-li2", "role": "dev", "event_type": "dev_start",
+    })
+    import time; time.sleep(0.05)  # background task
+    conn = sqlite3.connect(server.DB_PATH)
+    row = conn.execute(
+        "SELECT loop_id FROM events WHERE project='proj-li2'"
+    ).fetchone()
+    conn.close()
+    assert row is not None
+    assert row[0] is None
+
+
 def test_health_core_version_counts(isolated_client):
     isolated_client.post("/api/report", json={
         "api": "1.0", "project": "p", "role": "dev", "event_type": "dev_done",


### PR DESCRIPTION
Closes #26

## Changes
- `server.py` `init_db()`: added `("loop_id", "TEXT")` to the additive migration loop so the column is created idempotently on existing DBs via `ALTER TABLE events ADD COLUMN loop_id TEXT`
- `server.py` `ReportPayload`: added `loop_id: Optional[str] = None` field (ignored if absent — backward-compatible)
- `server.py` `_insert_event`: updated `INSERT INTO events` to include `loop_id` column and bind `data.loop_id`
- `test_server.py`: added two new tests using the `isolated_client` fixture:
  - `test_loop_id_persisted` — POST with `loop_id: "my-loop"`, reads DB directly via `sqlite3.connect` and asserts the value was stored
  - `test_loop_id_null_when_absent` — POST without `loop_id`, asserts the column is `NULL` (backward-compat)

## Test Plan
- `pytest test_server.py` — 25 tests pass (1 pre-existing unrelated failure in `test_report_accepted`)
- New tests verify both the round-trip with `loop_id` and the NULL case without it