### PR TITLE
Draft: [LM-27] Add /api/loops endpoint and expose loop_ids in health

### DIFF
--- a/server.py
+++ b/server.py
@@ -93,6 +93,7 @@ def init_db():
         ("pr_number", "INTEGER"),
         ("detail", "TEXT"),
         ("core_version", "TEXT"),
+        ("loop_id", "TEXT"),
     ]:
         if col not in cols:
             conn.execute(f"ALTER TABLE events ADD COLUMN {col} {defn}")
@@ -334,14 +335,41 @@ def health():
     rows = conn.execute(
         "SELECT core_version, COUNT(*) as cnt FROM events WHERE core_version IS NOT NULL GROUP BY core_version"
     ).fetchall()
-    conn.close()
     core_version_counts = {r["core_version"]: r["cnt"] for r in rows}
+    loop_rows = conn.execute(
+        "SELECT DISTINCT COALESCE(loop_id, '(unknown)') AS loop_id FROM events ORDER BY loop_id"
+    ).fetchall()
+    loop_ids = [r["loop_id"] for r in loop_rows]
+    conn.close()
     return {
         "status": "ok",
         "monitor_version": MONITOR_VERSION,
         "supported_bounty_api": f"{SUPPORTED_API_MAJOR}.x",
         "core_version_counts": core_version_counts,
+        "loop_ids": loop_ids,
     }
+
+
+@app.get("/api/loops")
+def get_loops():
+    conn = get_db()
+    rows = conn.execute("""
+        SELECT COALESCE(loop_id, '(unknown)') AS loop_id,
+               MAX(created_at) AS last_seen,
+               COUNT(*) AS event_count,
+               GROUP_CONCAT(DISTINCT core_version) AS core_versions
+        FROM events
+        GROUP BY COALESCE(loop_id, '(unknown)')
+        ORDER BY 1
+    """).fetchall()
+    conn.close()
+    result = []
+    for r in rows:
+        entry = dict(r)
+        raw = entry.get("core_versions") or ""
+        entry["core_versions"] = sorted(set(v for v in raw.split(",") if v)) if raw else []
+        result.append(entry)
+    return result
 
 
 @app.post("/api/report", status_code=202)

--- a/test_server.py
+++ b/test_server.py
@@ -285,3 +285,71 @@ def test_health_core_version_counts(isolated_client):
     counts = resp.json()["core_version_counts"]
     assert counts["0.1.0"] == 2
     assert counts["0.2.0"] == 1
+
+
+# ── /api/loops and health loop_ids tests ──
+
+def test_loops_empty_db(isolated_client):
+    resp = isolated_client.get("/api/loops")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_loops_with_data(isolated_client):
+    import sqlite3
+    now = "2026-01-01T00:00:00+00:00"
+    conn = sqlite3.connect(server.DB_PATH)
+    conn.executemany(
+        "INSERT INTO events (project, role, event_type, created_at, loop_id, core_version) VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            ("p", "dev", "dev_done", now, "loop-1", "0.1.0"),
+            ("p", "dev", "dev_done", now, "loop-1", "0.2.0"),
+            ("p", "dev", "dev_done", now, None, "0.1.0"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/loops")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 2
+
+    unknown = next(r for r in data if r["loop_id"] == "(unknown)")
+    assert unknown["event_count"] == 1
+    assert unknown["core_versions"] == ["0.1.0"]
+
+    loop1 = next(r for r in data if r["loop_id"] == "loop-1")
+    assert loop1["event_count"] == 2
+    assert sorted(loop1["core_versions"]) == ["0.1.0", "0.2.0"]
+    assert "last_seen" in loop1
+
+
+def test_health_loop_ids_field(isolated_client):
+    import sqlite3
+    now = "2026-01-01T00:00:00+00:00"
+    conn = sqlite3.connect(server.DB_PATH)
+    conn.executemany(
+        "INSERT INTO events (project, role, event_type, created_at, loop_id) VALUES (?, ?, ?, ?, ?)",
+        [
+            ("p", "dev", "dev_done", now, "loop-a"),
+            ("p", "dev", "dev_done", now, None),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "loop_ids" in data
+    assert "(unknown)" in data["loop_ids"]
+    assert "loop-a" in data["loop_ids"]
+
+
+def test_health_loop_ids_empty_db(isolated_client):
+    resp = isolated_client.get("/api/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "loop_ids" in data
+    assert data["loop_ids"] == []


### PR DESCRIPTION
Closes #27

## Changes
- **`server.py`**: Added `loop_id TEXT` migration to `init_db()` so the column exists for querying (complementing issue #26's write-side work).
- **`server.py`**: New `GET /api/loops` endpoint — returns a JSON array with `loop_id`, `last_seen` (ISO 8601), `event_count`, and `core_versions` (deduplicated, sorted string array). NULL `loop_id` values are grouped as `"(unknown)"`. Returns `[]` on empty DB.
- **`server.py`**: Extended `GET /api/health` to include `"loop_ids"` — a sorted list of distinct loop IDs (including `"(unknown)"` if applicable). Existing fields unchanged.
- **`test_server.py`**: Four new tests covering `/api/loops` with data, `/api/loops` on empty DB, `/api/health` `loop_ids` field with data, and `/api/health` `loop_ids` on empty DB. Test setup uses direct `sqlite3` inserts to set `loop_id` values, since the write path is owned by issue #26.

## Test Plan
- All 4 new tests pass: `test_loops_empty_db`, `test_loops_with_data`, `test_health_loop_ids_field`, `test_health_loop_ids_empty_db`
- All existing `test_health_*` tests still pass
- Verified: `GET /api/loops` returns `[]` on empty DB (not 500); groups NULL rows as `"(unknown)"`; `core_versions` is a deduplicated sorted array