### PR TITLE
Draft: [LM-28] UI: show monitor version in header; add loop_id filter selector

### DIFF
--- a/server.py
+++ b/server.py
@@ -93,6 +93,7 @@ def init_db():
         ("pr_number", "INTEGER"),
         ("detail", "TEXT"),
         ("core_version", "TEXT"),
+        ("loop_id", "TEXT"),
     ]:
         if col not in cols:
             conn.execute(f"ALTER TABLE events ADD COLUMN {col} {defn}")
@@ -137,6 +138,7 @@ class ReportPayload(BaseModel):
     detail: Optional[str] = None
     duration_seconds: Optional[int] = None
     rework_count: Optional[int] = None
+    loop_id: Optional[str] = None
 
     class Config:
         extra = "ignore"
@@ -225,8 +227,8 @@ def _insert_event(data: ReportPayload):
     now = datetime.now(timezone.utc).isoformat()
     conn.execute(
         """INSERT INTO events
-           (project, role, model, event_type, issue_number, pr_number, detail, payload, core_version, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           (project, role, model, event_type, issue_number, pr_number, detail, payload, core_version, loop_id, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             data.project,
             data.role,
@@ -237,6 +239,7 @@ def _insert_event(data: ReportPayload):
             data.detail,
             json.dumps(data.payload) if data.payload else None,
             data.core_version,
+            data.loop_id,
             now,
         ),
     )
@@ -334,14 +337,41 @@ def health():
     rows = conn.execute(
         "SELECT core_version, COUNT(*) as cnt FROM events WHERE core_version IS NOT NULL GROUP BY core_version"
     ).fetchall()
-    conn.close()
     core_version_counts = {r["core_version"]: r["cnt"] for r in rows}
+    loop_rows = conn.execute(
+        "SELECT DISTINCT COALESCE(loop_id, '(unknown)') AS loop_id FROM events ORDER BY loop_id"
+    ).fetchall()
+    loop_ids = [r["loop_id"] for r in loop_rows]
+    conn.close()
     return {
         "status": "ok",
         "monitor_version": MONITOR_VERSION,
         "supported_bounty_api": f"{SUPPORTED_API_MAJOR}.x",
         "core_version_counts": core_version_counts,
+        "loop_ids": loop_ids,
     }
+
+
+@app.get("/api/loops")
+def get_loops():
+    conn = get_db()
+    rows = conn.execute("""
+        SELECT COALESCE(loop_id, '(unknown)') AS loop_id,
+               MAX(created_at) AS last_seen,
+               COUNT(*) AS event_count,
+               GROUP_CONCAT(DISTINCT core_version) AS core_versions
+        FROM events
+        GROUP BY COALESCE(loop_id, '(unknown)')
+        ORDER BY 1
+    """).fetchall()
+    conn.close()
+    result = []
+    for r in rows:
+        entry = dict(r)
+        raw = entry.get("core_versions") or ""
+        entry["core_versions"] = sorted(set(v for v in raw.split(",") if v)) if raw else []
+        result.append(entry)
+    return result
 
 
 @app.post("/api/report", status_code=202)
@@ -381,10 +411,12 @@ def board():
 
 
 @app.get("/api/history")
-def history(limit: int = 50):
+def history(limit: int = 50, loop_id: Optional[str] = None):
     """Completed jobs: *_done/*_pass events paired with their *_start for duration."""
     conn = get_db()
-    rows = conn.execute("""
+    loop_filter = "AND d.loop_id = ?" if loop_id is not None else ""
+    params = (loop_id, limit) if loop_id is not None else (limit,)
+    rows = conn.execute(f"""
         SELECT
             d.id, d.project, d.role, d.model, d.event_type,
             d.issue_number, d.pr_number, d.detail, d.created_at AS completed_at,
@@ -409,10 +441,11 @@ def history(limit: int = 50):
             AND v.reason LIKE '%auto: ' || d.event_type || '%'
             AND v.created_at >= d.created_at
             AND v.id = (SELECT MIN(v2.id) FROM verdicts v2 WHERE v2.project=d.project AND v2.role=d.role AND v2.created_at >= d.created_at AND v2.reason LIKE '%auto: ' || d.event_type || '%')
-        WHERE d.event_type LIKE '%_done' OR d.event_type LIKE '%_pass' OR d.event_type LIKE '%_failed'
+        WHERE (d.event_type LIKE '%_done' OR d.event_type LIKE '%_pass' OR d.event_type LIKE '%_failed')
+        {loop_filter}
         ORDER BY d.id DESC
         LIMIT ?
-    """, (limit,)).fetchall()
+    """, params).fetchall()
     conn.close()
     return [dict(r) for r in rows]
 
@@ -437,13 +470,21 @@ def active():
 
 
 @app.get("/api/feed")
-def feed():
+def feed(loop_id: Optional[str] = None):
     conn = get_db()
-    rows = conn.execute(
-        """SELECT id, project, role, model, event_type, issue_number, pr_number,
-                  detail, payload, created_at
-           FROM events ORDER BY id DESC LIMIT 50"""
-    ).fetchall()
+    if loop_id is not None:
+        rows = conn.execute(
+            """SELECT id, project, role, model, event_type, issue_number, pr_number,
+                      detail, payload, created_at
+               FROM events WHERE loop_id = ? ORDER BY id DESC LIMIT 50""",
+            (loop_id,),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            """SELECT id, project, role, model, event_type, issue_number, pr_number,
+                      detail, payload, created_at
+               FROM events ORDER BY id DESC LIMIT 50"""
+        ).fetchall()
     conn.close()
     result = []
     for r in rows:

--- a/static/index.html
+++ b/static/index.html
@@ -52,6 +52,36 @@
 
     header h1 span { color: var(--accent); }
 
+    #version-badge {
+      font-size: 0.72rem;
+      color: var(--muted);
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 5px;
+      padding: 2px 8px;
+      font-family: monospace;
+    }
+
+    #loop-selector-wrap {
+      display: none;
+      align-items: center;
+      gap: 6px;
+      font-size: 0.75rem;
+      color: var(--muted);
+    }
+
+    #loop-selector-wrap.visible { display: flex; }
+
+    #loop-selector {
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 5px;
+      color: var(--text);
+      font-size: 0.75rem;
+      padding: 3px 8px;
+      cursor: pointer;
+    }
+
     #refresh-indicator {
       font-size: 0.75rem;
       color: var(--muted);
@@ -607,9 +637,18 @@
 
 <header>
   <h1>Bounty <span>Monitor</span></h1>
-  <div id="refresh-indicator">
-    <span class="dot"></span>
-    <span id="last-update">—</span>
+  <div style="display:flex;align-items:center;gap:12px;">
+    <span id="version-badge">loop-monitor</span>
+    <div id="loop-selector-wrap">
+      <label for="loop-selector" style="white-space:nowrap">Loop:</label>
+      <select id="loop-selector">
+        <option value="">All loops</option>
+      </select>
+    </div>
+    <div id="refresh-indicator">
+      <span class="dot"></span>
+      <span id="last-update">—</span>
+    </div>
   </div>
 </header>
 
@@ -912,6 +951,7 @@
   let activeWorkers = [];   // from /api/active
   let statusEntries = [];   // from /api/status
   let projectRepoMap = {};  // project -> "owner/repo"
+  let currentLoopId = '';   // '' = all loops
 
   // ── Render project cards ──
   function renderAgents() {
@@ -1142,14 +1182,15 @@
   // ── Fetch all data ──
   async function fetchAll() {
     try {
+      const loopParam = currentLoopId ? `?loop_id=${encodeURIComponent(currentLoopId)}` : '';
       const [boardRes, feedRes, statusRes, verdictsRes, activeRes, historyRes,
              activityRes, stagesRes, reworkRes, projectsRes] = await Promise.all([
         fetch('/api/board'),
-        fetch('/api/feed'),
+        fetch(`/api/feed${loopParam}`),
         fetch('/api/status'),
         fetch('/api/verdicts'),
         fetch('/api/active'),
-        fetch('/api/history'),
+        fetch(`/api/history${loopParam}`),
         fetch('/api/stats/activity'),
         fetch('/api/stats/stages'),
         fetch('/api/stats/rework'),
@@ -1364,8 +1405,42 @@
     else if (!window.location.hash) closeDrawer();
   });
 
+  // ── Loop selector ──
+  const loopSelectorWrap = document.getElementById('loop-selector-wrap');
+  const loopSelector = document.getElementById('loop-selector');
+
+  async function initLoopSelector() {
+    try {
+      const resp = await fetch('/api/loops');
+      if (!resp.ok) return;
+      const loops = await resp.json();
+      const realLoops = loops.filter(l => l.loop_id !== '(unknown)');
+      if (realLoops.length <= 1) return;
+      loopSelector.innerHTML = '<option value="">All loops</option>' +
+        realLoops.map(l => `<option value="${escHtml(l.loop_id)}">${escHtml(l.loop_id)}</option>`).join('');
+      loopSelectorWrap.classList.add('visible');
+    } catch (_) {}
+  }
+
+  loopSelector.addEventListener('change', () => {
+    currentLoopId = loopSelector.value;
+    fetchAll();
+  });
+
+  async function initVersionBadge() {
+    try {
+      const resp = await fetch('/api/health');
+      if (!resp.ok) return;
+      const data = await resp.json();
+      const ver = data.monitor_version || 'unknown';
+      document.getElementById('version-badge').textContent = `loop-monitor v${ver}`;
+    } catch (_) {}
+  }
+
   // ── Init ──
   initCharts();
+  initVersionBadge();
+  initLoopSelector();
   fetchAll();
   setInterval(fetchAll, 5000);
   checkHash();

--- a/test_server.py
+++ b/test_server.py
@@ -24,7 +24,7 @@ def test_report_accepted():
         "event_type": "started",
     })
     assert resp.status_code == 202
-    assert resp.json() == {"status": "accepted"}
+    assert resp.json()["status"] == "accepted"
 
 
 def test_verdict_accepted():
@@ -285,3 +285,159 @@ def test_health_core_version_counts(isolated_client):
     counts = resp.json()["core_version_counts"]
     assert counts["0.1.0"] == 2
     assert counts["0.2.0"] == 1
+
+
+# ── loop_id column persistence tests (issue #26) ──
+
+def test_loop_id_persisted(isolated_client):
+    import sqlite3
+    isolated_client.post("/api/report", json={
+        "project": "proj-li", "role": "dev", "event_type": "dev_start",
+        "loop_id": "my-loop",
+    })
+    import time; time.sleep(0.05)
+    conn = sqlite3.connect(server.DB_PATH)
+    row = conn.execute(
+        "SELECT loop_id FROM events WHERE project='proj-li' AND loop_id='my-loop'"
+    ).fetchone()
+    conn.close()
+    assert row is not None
+    assert row[0] == "my-loop"
+
+
+def test_loop_id_null_when_absent(isolated_client):
+    import sqlite3
+    isolated_client.post("/api/report", json={
+        "project": "proj-li2", "role": "dev", "event_type": "dev_start",
+    })
+    import time; time.sleep(0.05)
+    conn = sqlite3.connect(server.DB_PATH)
+    row = conn.execute(
+        "SELECT loop_id FROM events WHERE project='proj-li2'"
+    ).fetchone()
+    conn.close()
+    assert row is not None
+    assert row[0] is None
+
+
+# ── /api/loops and health loop_ids tests (issue #27) ──
+
+def test_loops_empty_db(isolated_client):
+    resp = isolated_client.get("/api/loops")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_loops_with_data(isolated_client):
+    import sqlite3
+    now = "2026-01-01T00:00:00+00:00"
+    conn = sqlite3.connect(server.DB_PATH)
+    conn.executemany(
+        "INSERT INTO events (project, role, event_type, created_at, loop_id, core_version) VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            ("p", "dev", "dev_done", now, "loop-1", "0.1.0"),
+            ("p", "dev", "dev_done", now, "loop-1", "0.2.0"),
+            ("p", "dev", "dev_done", now, None, "0.1.0"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/loops")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 2
+
+    unknown = next(r for r in data if r["loop_id"] == "(unknown)")
+    assert unknown["event_count"] == 1
+    assert unknown["core_versions"] == ["0.1.0"]
+
+    loop1 = next(r for r in data if r["loop_id"] == "loop-1")
+    assert loop1["event_count"] == 2
+    assert sorted(loop1["core_versions"]) == ["0.1.0", "0.2.0"]
+    assert "last_seen" in loop1
+
+
+def test_health_loop_ids_field(isolated_client):
+    import sqlite3
+    now = "2026-01-01T00:00:00+00:00"
+    conn = sqlite3.connect(server.DB_PATH)
+    conn.executemany(
+        "INSERT INTO events (project, role, event_type, created_at, loop_id) VALUES (?, ?, ?, ?, ?)",
+        [
+            ("p", "dev", "dev_done", now, "loop-a"),
+            ("p", "dev", "dev_done", now, None),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "loop_ids" in data
+    assert "(unknown)" in data["loop_ids"]
+    assert "loop-a" in data["loop_ids"]
+
+
+def test_health_loop_ids_empty_db(isolated_client):
+    resp = isolated_client.get("/api/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "loop_ids" in data
+    assert data["loop_ids"] == []
+
+
+# ── ?loop_id filtering on /api/feed and /api/history (issue #28) ──
+
+def test_feed_loop_id_filter(isolated_client):
+    import sqlite3
+    now = "2026-01-01T00:00:00+00:00"
+    conn = sqlite3.connect(server.DB_PATH)
+    conn.executemany(
+        "INSERT INTO events (project, role, event_type, created_at, loop_id) VALUES (?, ?, ?, ?, ?)",
+        [
+            ("p", "dev", "ev_a", now, "loop-x"),
+            ("p", "dev", "ev_b", now, "loop-y"),
+            ("p", "dev", "ev_c", now, None),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/feed?loop_id=loop-x")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert all(r["event_type"] == "ev_a" for r in data if r["project"] == "p")
+    assert not any(r["event_type"] == "ev_b" for r in data)
+
+    resp_all = isolated_client.get("/api/feed")
+    assert resp_all.status_code == 200
+    types = {r["event_type"] for r in resp_all.json() if r["project"] == "p"}
+    assert {"ev_a", "ev_b", "ev_c"}.issubset(types)
+
+
+def test_history_loop_id_filter(isolated_client):
+    import sqlite3
+    now = "2026-01-01T00:00:00+00:00"
+    conn = sqlite3.connect(server.DB_PATH)
+    conn.executemany(
+        "INSERT INTO events (project, role, event_type, created_at, loop_id) VALUES (?, ?, ?, ?, ?)",
+        [
+            ("ph", "dev", "build_done", now, "loop-alpha"),
+            ("ph", "dev", "build_done", now, "loop-beta"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/history?loop_id=loop-alpha")
+    assert resp.status_code == 200
+    data = resp.json()
+    proj_rows = [r for r in data if r["project"] == "ph"]
+    assert len(proj_rows) == 1
+
+    resp_all = isolated_client.get("/api/history")
+    assert resp_all.status_code == 200
+    all_proj = [r for r in resp_all.json() if r["project"] == "ph"]
+    assert len(all_proj) == 2


### PR DESCRIPTION
Closes #28

## Changes

**server.py:**
- Added `loop_id TEXT` column migration for `events` table (dependency from #26)
- Added `loop_id: Optional[str] = None` field to `ReportPayload`; persisted in `_insert_event()` (dependency from #26)
- Added `GET /api/loops` endpoint returning per-loop event counts, last_seen, and core_versions (dependency from #27)
- Exposed `loop_ids` list in `GET /api/health` response (dependency from #27)
- Added `loop_id: Optional[str] = None` query param to `GET /api/feed` — filters `WHERE loop_id = ?` when present
- Added `loop_id: Optional[str] = None` query param to `GET /api/history` — filters `AND d.loop_id = ?` in the WHERE clause when present
- Fixed pre-existing `test_report_accepted` exact-equality assertion (response already included `monitor_version`)

**static/index.html:**
- Header: version badge `loop-monitor vX.Y.Z` fetched from `GET /api/health` on page load (static, no polling)
- Header: loop selector `<select>` populated from `GET /api/loops`; hidden when ≤1 distinct loop_id values exist
- Selector defaults to "All loops" (no filter)
- Changing selector re-fetches `/api/feed?loop_id=X` and `/api/history?loop_id=X` immediately
- Auto-refresh (5s interval) carries the current `loop_id` selection through each refresh cycle via `currentLoopId` state variable

**test_server.py:**
- Tests for `loop_id` persistence (null and non-null) from #26
- Tests for `GET /api/loops` and `loop_ids` in health from #27
- `test_feed_loop_id_filter`: verifies `?loop_id=X` returns only matching events; absent param returns all
- `test_history_loop_id_filter`: verifies `?loop_id=X` filters completed jobs; absent param returns all

Note: Dependencies from issues #26 and #27 are included in this PR since those branches are still in draft state and not merged to main.

## Test Plan
- `pytest test_server.py` — 32 tests pass
- Load dashboard: header shows `loop-monitor vX.Y.Z`
- With only one loop instance: selector is hidden
- With 2+ loop instances: selector is visible; changing it updates feed and history panels
- Auto-refresh continues working with the selected filter active