### PR TITLE
Draft: [LM-30] Feed filter controls — role and status filtering

### DIFF
--- a/server.py
+++ b/server.py
@@ -436,13 +436,46 @@ def active():
     return [dict(r) for r in rows]
 
 
+VALID_FEED_STATUSES = {'done', 'fail', 'pass', 'skip'}
+
+
+def _derive_status(event_type: str) -> str:
+    if not event_type:
+        return 'unknown'
+    suffix = event_type.rsplit('_', 1)[-1].lower()
+    if suffix in ('fail', 'failed'):
+        return 'fail'
+    if suffix in ('done', 'pass', 'skip', 'start'):
+        return suffix
+    return 'unknown'
+
+
 @app.get("/api/feed")
-def feed():
+def feed(role: Optional[str] = None, status: Optional[str] = None):
+    status_lower = status.lower() if status else None
+    if status_lower is not None and status_lower not in VALID_FEED_STATUSES:
+        return []
+
+    where_clauses = []
+    params: list = []
+
+    if role:
+        where_clauses.append("lower(role) = lower(?)")
+        params.append(role)
+
+    if status_lower == 'fail':
+        where_clauses.append("(event_type LIKE '%_fail' OR event_type LIKE '%_failed')")
+    elif status_lower:
+        where_clauses.append(f"event_type LIKE '%_{status_lower}'")
+
+    where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+
     conn = get_db()
     rows = conn.execute(
-        """SELECT id, project, role, model, event_type, issue_number, pr_number,
+        f"""SELECT id, project, role, model, event_type, issue_number, pr_number,
                   detail, payload, created_at
-           FROM events ORDER BY id DESC LIMIT 50"""
+           FROM events {where_sql} ORDER BY id DESC LIMIT 50""",
+        params,
     ).fetchall()
     conn.close()
     result = []
@@ -450,6 +483,7 @@ def feed():
         entry = dict(r)
         if entry["payload"]:
             entry["payload"] = json.loads(entry["payload"])
+        entry["status"] = _derive_status(entry["event_type"])
         result.append(entry)
     return result
 

--- a/static/index.html
+++ b/static/index.html
@@ -669,7 +669,24 @@
   <!-- Activity feed + history + verdicts -->
   <div id="bottom-section">
     <div class="scroll-panel">
-      <div class="scroll-panel-header">Activity Feed</div>
+      <div class="scroll-panel-header" style="display:flex;align-items:center;justify-content:space-between;gap:8px;">
+        <span>Activity Feed</span>
+        <div style="display:flex;gap:6px;align-items:center;">
+          <select id="feed-role-filter" style="background:var(--surface2);border:1px solid var(--border);color:var(--text);font-size:0.68rem;padding:2px 6px;border-radius:4px;cursor:pointer;">
+            <option value="">All Roles</option>
+            <option value="dev">dev</option>
+            <option value="review">review</option>
+            <option value="qa">qa</option>
+          </select>
+          <select id="feed-status-filter" style="background:var(--surface2);border:1px solid var(--border);color:var(--text);font-size:0.68rem;padding:2px 6px;border-radius:4px;cursor:pointer;">
+            <option value="">All Status</option>
+            <option value="done">done</option>
+            <option value="fail">fail</option>
+            <option value="pass">pass</option>
+            <option value="skip">skip</option>
+          </select>
+        </div>
+      </div>
       <div class="scroll-inner" id="feed-list"></div>
     </div>
     <div class="scroll-panel">
@@ -1140,12 +1157,22 @@
   }
 
   // ── Fetch all data ──
+  function feedUrl() {
+    const role   = document.getElementById('feed-role-filter').value;
+    const status = document.getElementById('feed-status-filter').value;
+    const params = new URLSearchParams();
+    if (role)   params.set('role',   role);
+    if (status) params.set('status', status);
+    const qs = params.toString();
+    return qs ? `/api/feed?${qs}` : '/api/feed';
+  }
+
   async function fetchAll() {
     try {
       const [boardRes, feedRes, statusRes, verdictsRes, activeRes, historyRes,
              activityRes, stagesRes, reworkRes, projectsRes] = await Promise.all([
         fetch('/api/board'),
-        fetch('/api/feed'),
+        fetch(feedUrl()),
         fetch('/api/status'),
         fetch('/api/verdicts'),
         fetch('/api/active'),
@@ -1363,6 +1390,10 @@
     if (m) openDrawer(decodeURIComponent(m[1]), parseInt(m[2], 10), null);
     else if (!window.location.hash) closeDrawer();
   });
+
+  // ── Feed filter wiring ──
+  document.getElementById('feed-role-filter').addEventListener('change', fetchAll);
+  document.getElementById('feed-status-filter').addEventListener('change', fetchAll);
 
   // ── Init ──
   initCharts();

--- a/test_server.py
+++ b/test_server.py
@@ -24,7 +24,7 @@ def test_report_accepted():
         "event_type": "started",
     })
     assert resp.status_code == 202
-    assert resp.json() == {"status": "accepted"}
+    assert resp.json()["status"] == "accepted"
 
 
 def test_verdict_accepted():
@@ -265,6 +265,101 @@ def test_missing_api_accepted_with_warning(isolated_client, caplog):
         })
     assert resp.status_code == 202
     assert any("no 'api' field" in r.message for r in caplog.records)
+
+
+def test_feed_role_filter(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="proj-filt", role="dev", event_type="dev_done"
+    ))
+    server._insert_event(server.ReportPayload(
+        project="proj-filt", role="qa", event_type="qa_pass"
+    ))
+    resp = isolated_client.get("/api/feed?role=dev")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) >= 1
+    assert all(item["role"] == "dev" for item in data)
+
+
+def test_feed_role_filter_case_insensitive(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="proj-filt2", role="review", event_type="review_done"
+    ))
+    resp = isolated_client.get("/api/feed?role=REVIEW")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert any(item["event_type"] == "review_done" for item in data)
+
+
+def test_feed_status_filter_done(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="proj-sf", role="dev", event_type="dev_done"
+    ))
+    server._insert_event(server.ReportPayload(
+        project="proj-sf", role="dev", event_type="dev_start"
+    ))
+    resp = isolated_client.get("/api/feed?status=done")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) >= 1
+    assert all(item["status"] == "done" for item in data)
+
+
+def test_feed_status_filter_fail(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="proj-sf2", role="dev", event_type="dev_failed"
+    ))
+    server._insert_event(server.ReportPayload(
+        project="proj-sf2", role="qa", event_type="qa_fail"
+    ))
+    server._insert_event(server.ReportPayload(
+        project="proj-sf2", role="dev", event_type="dev_done"
+    ))
+    resp = isolated_client.get("/api/feed?status=fail")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) >= 2
+    assert all(item["status"] == "fail" for item in data)
+
+
+def test_feed_unknown_status_returns_empty(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="proj-unk", role="dev", event_type="dev_done"
+    ))
+    resp = isolated_client.get("/api/feed?status=nonexistent")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_feed_status_field_present(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="proj-fd", role="dev", event_type="dev_done"
+    ))
+    server._insert_event(server.ReportPayload(
+        project="proj-fd", role="qa", event_type="qa_pass"
+    ))
+    resp = isolated_client.get("/api/feed")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert all("status" in item for item in data)
+    done_items = [i for i in data if i["event_type"] == "dev_done"]
+    assert done_items and done_items[0]["status"] == "done"
+    pass_items = [i for i in data if i["event_type"] == "qa_pass"]
+    assert pass_items and pass_items[0]["status"] == "pass"
+
+
+def test_feed_role_and_status_combined(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="proj-comb", role="qa", event_type="qa_pass"
+    ))
+    server._insert_event(server.ReportPayload(
+        project="proj-comb", role="dev", event_type="dev_pass"
+    ))
+    resp = isolated_client.get("/api/feed?role=qa&status=pass")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert all(item["role"] == "qa" for item in data)
+    assert all(item["status"] == "pass" for item in data)
 
 
 def test_health_core_version_counts(isolated_client):


### PR DESCRIPTION
Closes #30

## Changes

**server.py**
- Extended `GET /api/feed` with optional `?role=X` (case-insensitive exact match via `lower()`) and `?status=Y` query params
- Added `VALID_FEED_STATUSES` constant; unrecognized status values return `[]` (not 400)
- `?status` maps: `done` → `LIKE '%_done'`, `fail` → `LIKE '%_fail' OR LIKE '%_failed'`, `pass` → `LIKE '%_pass'`, `skip` → `LIKE '%_skip'`
- Added `_derive_status()` helper that extracts `status` from `event_type` suffix
- Each feed response item now includes a derived `status` field (`done`/`fail`/`pass`/`skip`/`start`/`unknown`)

**static/index.html**
- Added Role (`All`, `dev`, `review`, `qa`) and Status (`All`, `done`, `fail`, `pass`, `skip`) `<select>` dropdowns inside the Activity Feed panel header
- Added `feedUrl()` helper that builds `/api/feed?role=X&status=Y` from current dropdown values
- `fetchAll()` now calls `feedUrl()` instead of `/api/feed` directly — auto-refresh carries filters
- Filter change events trigger immediate re-fetch

**test_server.py**
- Added 7 tests covering: role filter, case-insensitive role filter, status=done, status=fail (covers `_fail` and `_failed`), unknown status → `[]`, `status` field presence/values, combined role+status filters
- Fixed pre-existing `test_report_accepted` assertion (server already returned `monitor_version` but test expected exact dict equality)

## Test Plan
- `pytest test_server.py` — all 31 tests pass
- UI: start the server, open the dashboard, select "dev" in Role dropdown → feed shows only dev events; select "fail" in Status → shows only failed events; auto-refresh retains selections