### PR TITLE
Draft: [LM-38] fix stale test_report_accepted assertion

### DIFF
--- a/test_server.py
+++ b/test_server.py
@@ -24,7 +24,8 @@ def test_report_accepted():
         "event_type": "started",
     })
     assert resp.status_code == 202
-    assert resp.json() == {"status": "accepted"}
+    assert resp.json()["status"] == "accepted"
+    assert "monitor_version" in resp.json()
 
 
 def test_verdict_accepted():


### PR DESCRIPTION
Closes #38

## Changes
Updated `test_report_accepted` in `test_server.py` to replace the stale exact-equality assertion `resp.json() == {"status": "accepted"}` with two targeted checks:
- `resp.json()["status"] == "accepted"` — verifies the status field
- `"monitor_version" in resp.json()` — verifies the field added in PR #12 is present

The old assertion broke when `monitor_version` was added to the `/api/report` response in commit 5dd601e, but the test was never updated.

No other test assertions were changed.

## Test Plan
- `pytest test_server.py::test_report_accepted` passes
- Full suite `pytest test_server.py` passes (24/24)