### PR TITLE
Draft: [LM-40] Add indexes to events table to prevent full scans

### DIFF
--- a/server.py
+++ b/server.py
@@ -107,6 +107,14 @@ def init_db():
         if col not in pr_cols:
             conn.execute(f"ALTER TABLE pipeline_runs ADD COLUMN {col} {defn}")
 
+    conn.executescript("""
+        CREATE INDEX IF NOT EXISTS idx_events_project_role ON events (project, role);
+        CREATE INDEX IF NOT EXISTS idx_events_event_type ON events (event_type);
+        CREATE INDEX IF NOT EXISTS idx_events_created_at ON events (created_at);
+        CREATE INDEX IF NOT EXISTS idx_events_issue_number ON events (project, issue_number) WHERE issue_number IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_events_pr_number ON events (project, pr_number) WHERE pr_number IS NOT NULL;
+    """)
+
     conn.commit()
     conn.close()
 


### PR DESCRIPTION
Closes #40

## Changes

Added five `CREATE INDEX IF NOT EXISTS` statements to `init_db()` in `server.py`, placed after the column-migration block so they run idempotently on both fresh and existing databases:

- `idx_events_project_role` on `(project, role)` — used by `/api/active`, `/api/history`, `/api/stats/stages`
- `idx_events_event_type` on `(event_type)` — used by `/api/active`, `/api/history`, `/api/stats/stages`
- `idx_events_created_at` on `(created_at)` — used by `/api/stats/activity`
- `idx_events_issue_number` on `(project, issue_number) WHERE issue_number IS NOT NULL` — used by `/api/feed` sub-queries and `/api/stats/timeline`
- `idx_events_pr_number` on `(project, pr_number) WHERE pr_number IS NOT NULL` — used by `/api/stats/timeline`

No schema migration is required; `CREATE INDEX IF NOT EXISTS` is safe to run against existing databases.

Note: `test_report_accepted` was already failing on `main` before this change (endpoint returns `monitor_version` in addition to `status`). All other 23 tests pass.

## Test Plan

- `pytest test_server.py` passes (23/24; pre-existing failure unrelated to this PR)
- Start the server against an existing `bounty.db` and confirm indexes appear: `sqlite3 bounty.db ".indexes events"`
- Load-test `/api/active` with a large event table and confirm query time no longer scales linearly