### PR TITLE
Draft: [LM-41] add api field to bounty.sh payload to suppress legacy WARNING

### DIFF
--- a/lib/bounty.sh
+++ b/lib/bounty.sh
@@ -23,7 +23,7 @@ bounty_report() {
         pr_field=",\"pr_number\":${pr_number}"
     fi
     local payload
-    payload="{\"role\":\"${role}\",\"project\":\"${project}\",\"ref\":\"${ref}\",\"event_type\":\"${event_type}\",\"trigger_judge\":${trigger},\"timestamp\":\"${ts}\"${issue_field}${pr_field}}"
+    payload="{\"api\":\"1.0\",\"role\":\"${role}\",\"project\":\"${project}\",\"ref\":\"${ref}\",\"event_type\":\"${event_type}\",\"trigger_judge\":${trigger},\"timestamp\":\"${ts}\"${issue_field}${pr_field}}"
     curl -sf \
         --max-time 3 \
         --connect-timeout 2 \


### PR DESCRIPTION
Closes #41

## Changes
Added `"api":"1.0"` to the JSON payload constructed in `lib/bounty.sh:26`. The server (`server.py:390`) logs a WARNING for every event that arrives without an `api` field. Since `lib/bounty.sh` is the canonical reference implementation for v1.0, it should always include this field.

Single-line change to the payload string — no logic change, no test impact.

## Test Plan
- Run `pytest test_server.py` — should pass unaffected (shell-only change)
- Fire a test event using `lib/bounty.sh` and confirm no `"legacy-api"` WARNING appears in server logs