### PR TITLE
Draft: [LM-46] Add rename notice — loop-monitor is the successor to bounty-monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 > Live agent status, bounty leaderboard, AI judge verdicts, PR scorecards.
 > The visibility layer for the [Loop](https://github.com/svv2014/loop) pipeline.
 
+> **Renamed from bounty-monitor** — `loop-monitor` is the direct successor to [`svv2014/bounty-monitor`](https://github.com/svv2014/bounty-monitor) (now archived). The API, event schema, and port (18792) are identical — no migration needed.
+
 ## What it shows
 
 ```


### PR DESCRIPTION
Closes #46

## Changes
Added a brief rename notice to `README.md` immediately after the tagline. The notice:
- States that `loop-monitor` is the direct successor to `svv2014/bounty-monitor` (archived)
- Links to the archived repo at `https://github.com/svv2014/bounty-monitor`
- Confirms the API, event schema, and port (18792) are identical — no migration needed

No source files, scripts, or server code were touched.

## Test Plan
- [ ] Open README.md and verify the rename notice appears after the tagline (first blockquote section)
- [ ] Confirm the hyperlink to `https://github.com/svv2014/bounty-monitor` is present and correct
- [ ] Confirm no other files were modified