### PR TITLE
Draft: [LM-52] Add /api/projects/{slug}/cycle_times endpoint

### DIFF
--- a/server.py
+++ b/server.py
@@ -867,4 +867,47 @@ def get_projects():
     return [{"project": p, "repo": r} for p, r in PROJECTS.items() if p in active]
 
 
+def _percentile_stats(values: list) -> dict:
+    """Return median, P90, sample_size, most_recent for a sorted list of values."""
+    n = len(values)
+    if n == 0:
+        return None
+    sorted_vals = sorted(values)
+    median = sorted_vals[int(0.5 * n)]
+    p90 = sorted_vals[int(0.9 * n)]
+    return {
+        "median_seconds": median,
+        "p90_seconds": p90,
+        "sample_size": n,
+        "most_recent_seconds": values[-1],
+    }
+
+
+@app.get("/api/projects/{slug}/cycle_times")
+def get_cycle_times(slug: str):
+    null_response = {"total_duration": None, "issue_lifetime": None, "pr_lifetime": None}
+    conn = get_db()
+    rows = conn.execute(
+        """SELECT total_duration_seconds, issue_lifetime_seconds, pr_lifetime_seconds
+           FROM pipeline_runs
+           WHERE project=? AND total_duration_seconds IS NOT NULL
+           ORDER BY id ASC""",
+        (slug,),
+    ).fetchall()
+    conn.close()
+
+    if not rows:
+        return null_response
+
+    total_vals = [r["total_duration_seconds"] for r in rows]
+    issue_vals = [r["issue_lifetime_seconds"] for r in rows if r["issue_lifetime_seconds"] is not None]
+    pr_vals = [r["pr_lifetime_seconds"] for r in rows if r["pr_lifetime_seconds"] is not None]
+
+    return {
+        "total_duration": _percentile_stats(total_vals),
+        "issue_lifetime": _percentile_stats(issue_vals) if issue_vals else None,
+        "pr_lifetime": _percentile_stats(pr_vals) if pr_vals else None,
+    }
+
+
 app.mount("/", StaticFiles(directory="static", html=True), name="static")

--- a/test_server.py
+++ b/test_server.py
@@ -402,3 +402,47 @@ def test_feed_age_seconds(isolated_client):
     assert "age_seconds" in item
     assert isinstance(item["age_seconds"], int)
     assert item["age_seconds"] >= 0
+
+
+# ── cycle_times tests ──
+
+def test_cycle_times_empty(isolated_client):
+    """Returns null fields when no completed runs exist for the slug."""
+    resp = isolated_client.get("/api/projects/no-such-project/cycle_times")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data == {"total_duration": None, "issue_lifetime": None, "pr_lifetime": None}
+
+
+def test_cycle_times_with_data(isolated_client):
+    """Median and P90 are computed correctly from pipeline_runs rows."""
+    import sqlite3
+    conn = sqlite3.connect(server.DB_PATH)
+    # Insert 10 rows with total_duration_seconds = 10, 20, ..., 100 (ordered by id)
+    for i in range(1, 11):
+        conn.execute(
+            """INSERT INTO pipeline_runs
+               (project, issue_number, total_duration_seconds, created_at)
+               VALUES (?, ?, ?, datetime('now'))""",
+            ("proj-ct", i, i * 10),
+        )
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/projects/proj-ct/cycle_times")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    td = data["total_duration"]
+    assert td is not None
+    assert td["sample_size"] == 10
+    # sorted: [10,20,30,40,50,60,70,80,90,100]; floor(0.5*10)=5 → index 5 → 60
+    assert td["median_seconds"] == 60
+    # floor(0.9*10)=9 → index 9 → 100
+    assert td["p90_seconds"] == 100
+    # most_recent is the last inserted row
+    assert td["most_recent_seconds"] == 100
+
+    # issue_lifetime and pr_lifetime are null because columns not set
+    assert data["issue_lifetime"] is None
+    assert data["pr_lifetime"] is None


### PR DESCRIPTION
Closes #52

## Changes
- Added `GET /api/projects/{slug}/cycle_times` endpoint in `server.py` that returns median, P90, sample size, and most recent seconds for `total_duration`, `issue_lifetime`, and `pr_lifetime` from `pipeline_runs` rows where `total_duration_seconds IS NOT NULL`.
- Added `_percentile_stats()` helper using pure-Python sorted-list percentile formula (`floor(p * n)`).
- Returns `{"total_duration": null, "issue_lifetime": null, "pr_lifetime": null}` when no completed runs exist — no 404, no 500.
- `issue_lifetime` and `pr_lifetime` gracefully return null when columns have no non-null values (compatible with or without issue #19's migration).
- Added two pytest tests in `test_server.py`:
  - `test_cycle_times_empty`: verifies null response when no data exists for slug.
  - `test_cycle_times_with_data`: inserts 10 rows with known durations and verifies median (60s), P90 (100s), sample_size (10), most_recent (100s).

## Test Plan
- All 31 tests pass (`python3 -m pytest test_server.py`).
- Verify `GET /api/projects/<slug>/cycle_times` returns correct structure.
- Verify unknown slug returns all-null response (not 404/500).