### PR TITLE
[LM-56] Add Claude usage panel to dashboard

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -486,6 +486,29 @@
     }
     a.gh-link:hover { text-decoration: underline; }
 
+    /* ── Claude Usage Panel ── */
+    #claude-usage-section {
+      display: none;
+      max-width: 1400px;
+      width: 100%;
+      margin: 0 auto;
+      padding: 0 24px 20px;
+    }
+    #claude-usage-section.visible { display: block; }
+    .usage-bar {
+      height: 8px;
+      background: var(--surface2);
+      border-radius: 4px;
+      overflow: hidden;
+      margin: 8px 0 4px;
+    }
+    .usage-fill {
+      height: 100%;
+      background: var(--accent);
+      border-radius: 4px;
+      transition: width 0.3s ease;
+    }
+
     /* ── Project link in card ── */
     .project-name-link {
       color: var(--text);
@@ -796,6 +819,13 @@
     </div>
   </div>
 </main>
+
+<section id="claude-usage-section">
+  <div class="chart-card" style="max-width:480px">
+    <div class="section-title" style="margin-bottom:10px">Claude Usage</div>
+    <div id="claude-usage-body"></div>
+  </div>
+</section>
 
 <section id="charts-section">
   <div class="charts-grid">
@@ -1611,10 +1641,50 @@
     else { closeDrawer(); showHome(); }
   });
 
+  // ── Claude Usage Panel ──
+  let claudeUsageTimer = null;
+
+  async function fetchClaudeUsage() {
+    const section = document.getElementById('claude-usage-section');
+    const body    = document.getElementById('claude-usage-body');
+    let refreshSeconds = 300;
+    try {
+      const res  = await fetch('/api/claude_usage');
+      const data = res.ok ? await res.json() : null;
+      if (!data || !data.enabled) {
+        section.classList.remove('visible');
+      } else {
+        refreshSeconds = data.refresh_seconds || 300;
+        if (data.error) {
+          body.innerHTML = `<span style="color:var(--muted);font-size:0.82rem">Claude usage unavailable: ${escHtml(data.error)}</span>`;
+        } else {
+          const pct = Math.min(100, Math.max(0, data.quota_pct || 0));
+          const resetSecs = data.reset_at
+            ? Math.max(0, Math.floor((new Date(data.reset_at).getTime() - Date.now()) / 1000))
+            : null;
+          const resetStr = resetSecs != null ? `resets in ${fmtDur(resetSecs)}` : '';
+          body.innerHTML = `
+            <div class="usage-bar"><div class="usage-fill" style="width:${pct}%"></div></div>
+            <div style="display:flex;justify-content:space-between;font-size:0.75rem;color:var(--muted)">
+              <span>${data.quota_used != null ? data.quota_used.toLocaleString() : '?'} / ${data.quota_limit != null ? data.quota_limit.toLocaleString() : '?'} &middot; ${pct}%</span>
+              ${resetStr ? `<span>${escHtml(resetStr)}</span>` : ''}
+            </div>
+          `;
+        }
+        section.classList.add('visible');
+      }
+    } catch (e) {
+      section.classList.remove('visible');
+    }
+    if (claudeUsageTimer) clearTimeout(claudeUsageTimer);
+    claudeUsageTimer = setTimeout(fetchClaudeUsage, refreshSeconds * 1000);
+  }
+
   // ── Init ──
   initCharts();
   fetchAll();
   setInterval(fetchAll, 5000);
+  fetchClaudeUsage();
   checkHash();
 </script>
 </body>


### PR DESCRIPTION
Closes #56

## Changes
Added an optional Claude usage panel to the dashboard (`static/index.html` only):

- **CSS**: `.usage-bar` / `.usage-fill` styles for the progress bar; `#claude-usage-section` hidden by default, revealed with `.visible` class.
- **HTML**: `<section id="claude-usage-section">` placed between `</main>` and `#charts-section`. Contains a `chart-card`-styled container with a title and a `#claude-usage-body` div.
- **JS**: `fetchClaudeUsage()` async function that:
  - Fetches `GET /api/claude_usage` on each call.
  - Hides the panel (no empty space, no error) when `enabled: false` or the fetch throws.
  - Shows `Claude usage unavailable: <error>` when `enabled: true` and `error` is present.
  - Renders quota progress bar (`width: quota_pct%`), `quota_used / quota_limit · quota_pct%` text, and "resets in Xh Ym" countdown (using existing `fmtDur()`) when `enabled: true` and no error.
  - Schedules itself via `setTimeout(fetchClaudeUsage, refreshSeconds * 1000)` using `data.refresh_seconds` (default 300s) — not tied to the main 5s `setInterval`.
- `fetchClaudeUsage()` called once at init alongside `fetchAll()`.

No external libraries added; no files outside `static/index.html` touched.

## Test Plan
- With `GET /api/claude_usage` returning `{"enabled": false}`: panel is fully hidden — no empty space.
- With the endpoint returning a non-OK status or a network error: panel is fully hidden.
- With `{"enabled": true, "error": "quota API timeout"}`: panel shows "Claude usage unavailable: quota API timeout".
- With `{"enabled": true, "quota_used": 1200, "quota_limit": 5000, "quota_pct": 24, "reset_at": "<future ISO>", "refresh_seconds": 600}`: panel shows progress bar at 24% width, "1,200 / 5,000 · 24%" text, and "resets in Xh Ym" countdown. Verify auto-refresh fires after ~600s (not 5s).
- Confirm no regression on main dashboard sections (active workers, agents, leaderboard, charts).