### PR TITLE
[LM-27] Add /api/loops endpoint and expose loop_ids in health

### DIFF
--- a/server.py
+++ b/server.py
@@ -383,14 +383,41 @@ def health():
     rows = conn.execute(
         "SELECT core_version, COUNT(*) as cnt FROM events WHERE core_version IS NOT NULL GROUP BY core_version"
     ).fetchall()
-    conn.close()
     core_version_counts = {r["core_version"]: r["cnt"] for r in rows}
+    loop_rows = conn.execute(
+        "SELECT DISTINCT COALESCE(loop_id, '(unknown)') AS loop_id FROM events ORDER BY loop_id"
+    ).fetchall()
+    loop_ids = [r["loop_id"] for r in loop_rows]
+    conn.close()
     return {
         "status": "ok",
         "monitor_version": MONITOR_VERSION,
         "supported_bounty_api": f"{SUPPORTED_API_MAJOR}.x",
         "core_version_counts": core_version_counts,
+        "loop_ids": loop_ids,
     }
+
+
+@app.get("/api/loops")
+def get_loops():
+    conn = get_db()
+    rows = conn.execute("""
+        SELECT COALESCE(loop_id, '(unknown)') AS loop_id,
+               MAX(created_at) AS last_seen,
+               COUNT(*) AS event_count,
+               GROUP_CONCAT(DISTINCT core_version) AS core_versions
+        FROM events
+        GROUP BY COALESCE(loop_id, '(unknown)')
+        ORDER BY 1
+    """).fetchall()
+    conn.close()
+    result = []
+    for r in rows:
+        entry = dict(r)
+        raw = entry.get("core_versions") or ""
+        entry["core_versions"] = sorted(set(v for v in raw.split(",") if v)) if raw else []
+        result.append(entry)
+    return result
 
 
 @app.post("/api/report", status_code=202)

--- a/test_server.py
+++ b/test_server.py
@@ -341,6 +341,73 @@ def test_health_core_version_counts(isolated_client):
     assert counts["0.2.0"] == 1
 
 
+# ── /api/loops and health loop_ids tests ──
+
+def test_loops_empty_db(isolated_client):
+    resp = isolated_client.get("/api/loops")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_loops_with_data(isolated_client):
+    import sqlite3
+    import time
+    isolated_client.post("/api/report", json={
+        "api": "1.0", "project": "p", "role": "dev", "event_type": "dev_done",
+        "loop_id": "loop-1", "core_version": "0.1.0",
+    })
+    isolated_client.post("/api/report", json={
+        "api": "1.0", "project": "p", "role": "dev", "event_type": "dev_done",
+        "loop_id": "loop-1", "core_version": "0.2.0",
+    })
+    isolated_client.post("/api/report", json={
+        "api": "1.0", "project": "p", "role": "dev", "event_type": "dev_done",
+        "core_version": "0.1.0",
+    })
+    time.sleep(0.1)  # background tasks
+
+    resp = isolated_client.get("/api/loops")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 2
+
+    unknown = next(r for r in data if r["loop_id"] == "(unknown)")
+    assert unknown["event_count"] == 1
+    assert unknown["core_versions"] == ["0.1.0"]
+
+    loop1 = next(r for r in data if r["loop_id"] == "loop-1")
+    assert loop1["event_count"] == 2
+    assert sorted(loop1["core_versions"]) == ["0.1.0", "0.2.0"]
+    assert "last_seen" in loop1
+
+
+def test_health_loop_ids_field(isolated_client):
+    import time
+    isolated_client.post("/api/report", json={
+        "api": "1.0", "project": "p", "role": "dev", "event_type": "dev_done",
+        "loop_id": "loop-a",
+    })
+    isolated_client.post("/api/report", json={
+        "api": "1.0", "project": "p", "role": "dev", "event_type": "dev_done",
+    })
+    time.sleep(0.1)  # background tasks
+
+    resp = isolated_client.get("/api/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "loop_ids" in data
+    assert "(unknown)" in data["loop_ids"]
+    assert "loop-a" in data["loop_ids"]
+
+
+def test_health_loop_ids_empty_db(isolated_client):
+    resp = isolated_client.get("/api/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "loop_ids" in data
+    assert data["loop_ids"] == []
+
+
 # ── Timeline cumulative_seconds and feed age_seconds tests ──
 
 def test_timeline_cumulative_seconds(isolated_client):


### PR DESCRIPTION
Closes #27

## Changes
- **`server.py`**: Extended `GET /api/health` to query distinct `loop_id` values and return `"loop_ids": [...]` (sorted; NULL rows appear as `"(unknown)"`). Existing fields unchanged.
- **`server.py`**: New `GET /api/loops` endpoint — returns JSON array with `loop_id`, `last_seen` (ISO 8601), `event_count`, and `core_versions` (deduplicated sorted string array). NULL `loop_id` rows grouped as `"(unknown)"`. Returns `[]` on empty DB.
- **`test_server.py`**: Four new tests: `test_loops_empty_db`, `test_loops_with_data`, `test_health_loop_ids_field`, `test_health_loop_ids_empty_db`.

Note: CLAUDE.md absent; conventions derived from existing code. Branch rebased onto current main (includes #26 loop_id column).

## Test Plan
- All 35 tests pass (including all existing `test_health_*` tests)
- `GET /api/loops` returns `[]` on empty DB
- `GET /api/loops` groups NULL loop_id rows under `"(unknown)"`
- `core_versions` is a deduplicated sorted array (not raw comma-string)
- `GET /api/health` includes `loop_ids` field alongside existing fields