### PR TITLE
[LM-62] Add GET /api/events_graph — 24h bucketed event counts by stage

### DIFF
--- a/server.py
+++ b/server.py
@@ -937,4 +937,20 @@ def get_cycle_times(slug: str):
     }
 
 
+@app.get("/api/events_graph")
+def get_events_graph(window: int = 24):
+    window = max(1, min(window, 168))
+    conn = get_db()
+    rows = conn.execute(
+        """SELECT strftime('%Y-%m-%dT%H:00:00', created_at) AS hour, role, COUNT(*) AS count
+           FROM events
+           WHERE created_at > datetime('now', ? || ' hours')
+           GROUP BY hour, role
+           ORDER BY hour""",
+        (f"-{window}",),
+    ).fetchall()
+    conn.close()
+    return {"window_hours": window, "buckets": [dict(r) for r in rows]}
+
+
 app.mount("/", StaticFiles(directory="static", html=True), name="static")

--- a/test_server.py
+++ b/test_server.py
@@ -513,3 +513,65 @@ def test_cycle_times_with_data(isolated_client):
     # issue_lifetime and pr_lifetime are null because columns not set
     assert data["issue_lifetime"] is None
     assert data["pr_lifetime"] is None
+
+
+# ── /api/events_graph tests ──
+
+def test_events_graph_empty_db(isolated_client):
+    resp = isolated_client.get("/api/events_graph")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data == {"window_hours": 24, "buckets": []}
+
+
+def test_events_graph_with_data(isolated_client):
+    import sqlite3
+    conn = sqlite3.connect(server.DB_PATH)
+    conn.execute(
+        "INSERT INTO events (project, role, event_type, created_at) VALUES (?,?,?,?)",
+        ("proj-g", "po", "po_done", "2026-04-28T10:00:00"),
+    )
+    conn.execute(
+        "INSERT INTO events (project, role, event_type, created_at) VALUES (?,?,?,?)",
+        ("proj-g", "po", "po_done", "2026-04-28T10:30:00"),
+    )
+    conn.execute(
+        "INSERT INTO events (project, role, event_type, created_at) VALUES (?,?,?,?)",
+        ("proj-g", "dev", "dev_done", "2026-04-28T11:00:00"),
+    )
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/events_graph?window=168")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["window_hours"] == 168
+    buckets = data["buckets"]
+    assert isinstance(buckets, list)
+    po_bucket = next((b for b in buckets if b["role"] == "po" and b["hour"] == "2026-04-28T10:00:00"), None)
+    assert po_bucket is not None
+    assert po_bucket["count"] == 2
+    dev_bucket = next((b for b in buckets if b["role"] == "dev"), None)
+    assert dev_bucket is not None
+    assert dev_bucket["count"] == 1
+
+
+def test_events_graph_window_param(isolated_client):
+    resp = isolated_client.get("/api/events_graph?window=48")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["window_hours"] == 48
+
+
+def test_events_graph_window_clamped_to_max(isolated_client):
+    resp = isolated_client.get("/api/events_graph?window=9999")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["window_hours"] == 168
+
+
+def test_events_graph_default_window(isolated_client):
+    resp = isolated_client.get("/api/events_graph")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["window_hours"] == 24


### PR DESCRIPTION
Closes #62

## Changes
- Added `GET /api/events_graph` endpoint to `server.py` returning per-hour event counts grouped by `role` for a configurable time window
- Supports `?window=N` query param (integer hours, default 24, max 168 clamped server-side)
- SQL uses `strftime` to bucket events into hour slots; only hours with events are returned (client fills gaps as zero)
- Returns `{"window_hours": N, "buckets": []}` on empty DB — not 500
- Added 5 new tests in `test_server.py` using `isolated_client` fixture: empty DB, multi-hour/multi-role data, default window, custom window param, max-clamp behavior
- Fresh branch from current main — no merge conflicts

## Test Plan
- `GET /api/events_graph` → 200, `{"window_hours": 24, "buckets": []}`
- Insert events across multiple hours/roles, call with `?window=168` → buckets have correct hour, role, count grouping
- Call with `?window=9999` → response has `window_hours: 168` (clamped)
- All 40 tests pass: `python3 -m pytest test_server.py -q`