### PR TITLE
[LM-56] Add Claude usage panel to dashboard

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -486,6 +486,29 @@
     }
     a.gh-link:hover { text-decoration: underline; }
 
+    /* ── Claude Usage Panel ── */
+    #claude-usage-section {
+      display: none;
+      max-width: 1400px;
+      width: 100%;
+      margin: 0 auto;
+      padding: 0 24px 20px;
+    }
+    #claude-usage-section.visible { display: block; }
+    .usage-bar {
+      height: 8px;
+      background: var(--surface2);
+      border-radius: 4px;
+      overflow: hidden;
+      margin: 8px 0 4px;
+    }
+    .usage-fill {
+      height: 100%;
+      background: var(--accent);
+      border-radius: 4px;
+      transition: width 0.3s ease;
+    }
+
     /* ── 24h Events Activity Graph ── */
     #events-graph-section {
       max-width: 1400px;
@@ -894,6 +917,13 @@
     </div>
   </div>
 </main>
+
+<section id="claude-usage-section">
+  <div class="chart-card" style="max-width:480px">
+    <div class="section-title" style="margin-bottom:10px">Claude Usage</div>
+    <div id="claude-usage-body"></div>
+  </div>
+</section>
 
 <section id="charts-section">
   <div class="charts-grid">
@@ -1935,10 +1965,50 @@
     wrap.addEventListener('mouseleave', () => { tip.style.display = 'none'; });
   })();
 
+  // ── Claude Usage Panel ──
+  let claudeUsageTimer = null;
+
+  async function fetchClaudeUsage() {
+    const section = document.getElementById('claude-usage-section');
+    const body    = document.getElementById('claude-usage-body');
+    let refreshSeconds = 300;
+    try {
+      const res  = await fetch('/api/claude_usage');
+      const data = res.ok ? await res.json() : null;
+      if (!data || !data.enabled) {
+        section.classList.remove('visible');
+      } else {
+        refreshSeconds = data.refresh_seconds || 300;
+        if (data.error) {
+          body.innerHTML = `<span style="color:var(--muted);font-size:0.82rem">Claude usage unavailable: ${escHtml(data.error)}</span>`;
+        } else {
+          const pct = Math.min(100, Math.max(0, data.quota_pct || 0));
+          const resetSecs = data.reset_at
+            ? Math.max(0, Math.floor((new Date(data.reset_at).getTime() - Date.now()) / 1000))
+            : null;
+          const resetStr = resetSecs != null ? `resets in ${fmtDur(resetSecs)}` : '';
+          body.innerHTML = `
+            <div class="usage-bar"><div class="usage-fill" style="width:${pct}%"></div></div>
+            <div style="display:flex;justify-content:space-between;font-size:0.75rem;color:var(--muted)">
+              <span>${data.quota_used != null ? data.quota_used.toLocaleString() : '?'} / ${data.quota_limit != null ? data.quota_limit.toLocaleString() : '?'} &middot; ${pct}%</span>
+              ${resetStr ? `<span>${escHtml(resetStr)}</span>` : ''}
+            </div>
+          `;
+        }
+        section.classList.add('visible');
+      }
+    } catch (e) {
+      section.classList.remove('visible');
+    }
+    if (claudeUsageTimer) clearTimeout(claudeUsageTimer);
+    claudeUsageTimer = setTimeout(fetchClaudeUsage, refreshSeconds * 1000);
+  }
+
   // ── Init ──
   initCharts();
   fetchAll();
   setInterval(fetchAll, 5000);
+  fetchClaudeUsage();
   checkHash();
 </script>
 </body>


### PR DESCRIPTION
Closes #56

## Changes
Added an optional Claude usage panel to `static/index.html` (fresh branch from current main — resolves prior conflict):

- **CSS**: `.usage-bar` / `.usage-fill` for the plain HTML/CSS progress bar. `#claude-usage-section` is `display:none` by default; toggled visible via `.visible` class.
- **HTML**: `<section id="claude-usage-section">` inserted between `</main>` and `#charts-section`. Contains a `chart-card`-styled panel with a title div and `#claude-usage-body` placeholder.
- **JS**: `fetchClaudeUsage()` async function:
  - Hides the panel (no empty space, no error text) when `enabled: false` or when fetch throws/returns non-OK.
  - Shows `"Claude usage unavailable: <error>"` (via `escHtml`) when `enabled: true` and `error` is present.
  - Renders a progress bar (`width: quota_pct%`, clamped 0–100), quota text (`quota_used / quota_limit · pct%`), and "resets in Xh Ym" countdown via existing `fmtDur()` when `enabled: true` and no error.
  - Schedules next call via `setTimeout(fetchClaudeUsage, refreshSeconds * 1000)` using `data.refresh_seconds || 300` — decoupled from the main 5s poll.
- `fetchClaudeUsage()` called once at init.

No external libraries added. Only `static/index.html` touched.

## Test Plan
- `GET /api/claude_usage` returns `{"enabled": false}` → panel fully hidden, no empty space.
- Endpoint returns 500 / network error → panel fully hidden.
- `{"enabled": true, "error": "quota API down"}` → panel shows "Claude usage unavailable: quota API down".
- `{"enabled": true, "quota_used": 1200, "quota_limit": 5000, "quota_pct": 24, "reset_at": "<future ISO>", "refresh_seconds": 600}` → progress bar at 24%, "1,200 / 5,000 · 24%", countdown displayed; next fetch fires after ~600s not 5s.
- Confirm no regression on active workers, agent cards, leaderboard, activity graph, charts.