### PR TITLE
[LM-30] Feed filter controls — role and status filtering

### DIFF
--- a/server.py
+++ b/server.py
@@ -512,13 +512,46 @@ def active():
     return [dict(r) for r in rows]
 
 
+VALID_FEED_STATUSES = {'done', 'fail', 'pass', 'skip'}
+
+
+def _derive_status(event_type: str) -> str:
+    if not event_type:
+        return 'unknown'
+    suffix = event_type.rsplit('_', 1)[-1].lower()
+    if suffix in ('fail', 'failed'):
+        return 'fail'
+    if suffix in ('done', 'pass', 'skip', 'start'):
+        return suffix
+    return 'unknown'
+
+
 @app.get("/api/feed")
-def feed():
+def feed(role: Optional[str] = None, status: Optional[str] = None):
+    status_lower = status.lower() if status else None
+    if status_lower is not None and status_lower not in VALID_FEED_STATUSES:
+        return []
+
+    where_clauses: list[str] = []
+    params: list = []
+
+    if role:
+        where_clauses.append("lower(role) = lower(?)")
+        params.append(role)
+
+    if status_lower == 'fail':
+        where_clauses.append("(event_type LIKE '%_fail' OR event_type LIKE '%_failed')")
+    elif status_lower:
+        where_clauses.append(f"event_type LIKE '%_{status_lower}'")
+
+    where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+
     conn = get_db()
     rows = conn.execute(
-        """SELECT id, project, role, model, event_type, issue_number, pr_number,
+        f"""SELECT id, project, role, model, event_type, issue_number, pr_number,
                   detail, payload, created_at
-           FROM events ORDER BY id DESC LIMIT 50"""
+           FROM events {where_sql} ORDER BY id DESC LIMIT 50""",
+        params,
     ).fetchall()
     conn.close()
     now = datetime.now(timezone.utc)
@@ -534,6 +567,7 @@ def feed():
             entry["age_seconds"] = int((now - created).total_seconds())
         except Exception:
             entry["age_seconds"] = None
+        entry["status"] = _derive_status(entry["event_type"])
         result.append(entry)
     return result
 

--- a/static/index.html
+++ b/static/index.html
@@ -881,7 +881,24 @@
   <!-- Activity feed + history + verdicts -->
   <div id="bottom-section">
     <div class="scroll-panel">
-      <div class="scroll-panel-header">Activity Feed</div>
+      <div class="scroll-panel-header" style="display:flex;align-items:center;justify-content:space-between;gap:8px;">
+        <span>Activity Feed</span>
+        <div style="display:flex;gap:6px;">
+          <select id="feed-role-filter" style="background:var(--surface2);border:1px solid var(--border);color:var(--text);font-size:0.68rem;padding:2px 6px;border-radius:4px;cursor:pointer;">
+            <option value="">All Roles</option>
+            <option value="dev">dev</option>
+            <option value="review">review</option>
+            <option value="qa">qa</option>
+          </select>
+          <select id="feed-status-filter" style="background:var(--surface2);border:1px solid var(--border);color:var(--text);font-size:0.68rem;padding:2px 6px;border-radius:4px;cursor:pointer;">
+            <option value="">All Status</option>
+            <option value="done">done</option>
+            <option value="fail">fail</option>
+            <option value="pass">pass</option>
+            <option value="skip">skip</option>
+          </select>
+        </div>
+      </div>
       <div class="scroll-inner" id="feed-list"></div>
     </div>
     <div class="scroll-panel">
@@ -1487,12 +1504,22 @@
   }
 
   // ── Fetch all data ──
+  function feedUrl() {
+    const role   = document.getElementById('feed-role-filter').value;
+    const status = document.getElementById('feed-status-filter').value;
+    const params = new URLSearchParams();
+    if (role)   params.set('role',   role);
+    if (status) params.set('status', status);
+    const qs = params.toString();
+    return qs ? `/api/feed?${qs}` : '/api/feed';
+  }
+
   async function fetchAll() {
     try {
       const [boardRes, feedRes, statusRes, verdictsRes, activeRes, historyRes,
              activityRes, stagesRes, reworkRes, projectsRes, eventsGraphRes] = await Promise.all([
         fetch('/api/board'),
-        fetch('/api/feed'),
+        fetch(feedUrl()),
         fetch('/api/status'),
         fetch('/api/verdicts'),
         fetch('/api/active'),
@@ -1934,6 +1961,10 @@
     });
     wrap.addEventListener('mouseleave', () => { tip.style.display = 'none'; });
   })();
+
+  // ── Feed filter wiring ──
+  document.getElementById('feed-role-filter').addEventListener('change', fetchAll);
+  document.getElementById('feed-status-filter').addEventListener('change', fetchAll);
 
   // ── Init ──
   initCharts();

--- a/test_server.py
+++ b/test_server.py
@@ -513,3 +513,100 @@ def test_cycle_times_with_data(isolated_client):
     # issue_lifetime and pr_lifetime are null because columns not set
     assert data["issue_lifetime"] is None
     assert data["pr_lifetime"] is None
+
+
+# ── Feed filter tests ──
+
+def test_feed_role_filter(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="proj-rf", role="dev", event_type="dev_done"
+    ))
+    server._insert_event(server.ReportPayload(
+        project="proj-rf", role="qa", event_type="qa_pass"
+    ))
+    resp = isolated_client.get("/api/feed?role=dev")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) >= 1
+    assert all(item["role"] == "dev" for item in data)
+
+
+def test_feed_role_filter_case_insensitive(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="proj-rf2", role="review", event_type="review_done"
+    ))
+    resp = isolated_client.get("/api/feed?role=REVIEW")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert any(item["event_type"] == "review_done" for item in data)
+
+
+def test_feed_status_filter_done(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="proj-sf", role="dev", event_type="dev_done"
+    ))
+    server._insert_event(server.ReportPayload(
+        project="proj-sf", role="dev", event_type="dev_start"
+    ))
+    resp = isolated_client.get("/api/feed?status=done")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) >= 1
+    assert all(item["status"] == "done" for item in data)
+
+
+def test_feed_status_filter_fail_covers_failed(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="proj-sf2", role="dev", event_type="dev_failed"
+    ))
+    server._insert_event(server.ReportPayload(
+        project="proj-sf2", role="qa", event_type="qa_fail"
+    ))
+    server._insert_event(server.ReportPayload(
+        project="proj-sf2", role="dev", event_type="dev_done"
+    ))
+    resp = isolated_client.get("/api/feed?status=fail")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) >= 2
+    assert all(item["status"] == "fail" for item in data)
+
+
+def test_feed_unknown_status_returns_empty(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="proj-unk", role="dev", event_type="dev_done"
+    ))
+    resp = isolated_client.get("/api/feed?status=nonexistent")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_feed_status_field_derived(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="proj-fd", role="dev", event_type="dev_done"
+    ))
+    server._insert_event(server.ReportPayload(
+        project="proj-fd", role="qa", event_type="qa_pass"
+    ))
+    resp = isolated_client.get("/api/feed")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert all("status" in item for item in data)
+    done_items = [i for i in data if i["event_type"] == "dev_done"]
+    assert done_items and done_items[0]["status"] == "done"
+    pass_items = [i for i in data if i["event_type"] == "qa_pass"]
+    assert pass_items and pass_items[0]["status"] == "pass"
+
+
+def test_feed_role_and_status_combined(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="proj-comb", role="qa", event_type="qa_pass"
+    ))
+    server._insert_event(server.ReportPayload(
+        project="proj-comb", role="dev", event_type="dev_pass"
+    ))
+    resp = isolated_client.get("/api/feed?role=qa&status=pass")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert all(item["role"] == "qa" for item in data)
+    assert all(item["status"] == "pass" for item in data)


### PR DESCRIPTION
Closes #30

## Changes

**server.py**
- Added `VALID_FEED_STATUSES` constant and `_derive_status()` helper extracting status from `event_type` suffix
- Extended `GET /api/feed` with optional `?role=X` (case-insensitive `lower()` match) and `?status=Y` query params
- Unrecognized `status` values return `[]` immediately (not 400)
- `?status=fail` matches both `_fail` and `_failed` event_type suffixes
- Each response item now includes a derived `status` field (`done`/`fail`/`pass`/`skip`/`start`/`unknown`)
- Existing `age_seconds` field preserved

**static/index.html**
- Role (`All`, `dev`, `review`, `qa`) and Status (`All`, `done`, `fail`, `pass`, `skip`) `<select>` dropdowns added inline in the Activity Feed panel header
- Added `feedUrl()` helper that builds `/api/feed?role=X&status=Y` from current dropdown selections
- `fetchAll()` uses `feedUrl()` instead of hard-coded `/api/feed` — auto-refresh interval carries filter selections through
- Dropdown `change` events trigger immediate re-fetch

**test_server.py**
- 7 new tests: role filter, case-insensitive role, `status=done`, `status=fail` (covers both `_fail`/`_failed`), unknown status → `[]`, `status` field derivation, combined role+status filter
- All 42 tests pass

## Test Plan
- `pytest test_server.py` — all 42 tests pass
- Start server, open dashboard; select "dev" in Role → feed shows only dev role events; select "fail" in Status → only failed events; auto-refresh retains selections; "All" in either dropdown clears that filter