### PR TITLE
[LM-28] UI: show monitor version in header; add loop_id filter selector

### DIFF
--- a/server.py
+++ b/server.py
@@ -457,10 +457,12 @@ def board():
 
 
 @app.get("/api/history")
-def history(limit: int = 50):
+def history(limit: int = 50, loop_id: Optional[str] = None):
     """Completed jobs: *_done/*_pass events paired with their *_start for duration."""
     conn = get_db()
-    rows = conn.execute("""
+    loop_filter = "AND d.loop_id = ?" if loop_id is not None else ""
+    params = (loop_id, limit) if loop_id is not None else (limit,)
+    rows = conn.execute(f"""
         SELECT
             d.id, d.project, d.role, d.model, d.event_type,
             d.issue_number, d.pr_number, d.detail, d.created_at AS completed_at,
@@ -485,10 +487,11 @@ def history(limit: int = 50):
             AND v.reason LIKE '%auto: ' || d.event_type || '%'
             AND v.created_at >= d.created_at
             AND v.id = (SELECT MIN(v2.id) FROM verdicts v2 WHERE v2.project=d.project AND v2.role=d.role AND v2.created_at >= d.created_at AND v2.reason LIKE '%auto: ' || d.event_type || '%')
-        WHERE d.event_type LIKE '%_done' OR d.event_type LIKE '%_pass' OR d.event_type LIKE '%_failed'
+        WHERE (d.event_type LIKE '%_done' OR d.event_type LIKE '%_pass' OR d.event_type LIKE '%_failed')
+        {loop_filter}
         ORDER BY d.id DESC
         LIMIT ?
-    """, (limit,)).fetchall()
+    """, params).fetchall()
     conn.close()
     return [dict(r) for r in rows]
 
@@ -513,13 +516,21 @@ def active():
 
 
 @app.get("/api/feed")
-def feed():
+def feed(loop_id: Optional[str] = None):
     conn = get_db()
-    rows = conn.execute(
-        """SELECT id, project, role, model, event_type, issue_number, pr_number,
-                  detail, payload, created_at
-           FROM events ORDER BY id DESC LIMIT 50"""
-    ).fetchall()
+    if loop_id is not None:
+        rows = conn.execute(
+            """SELECT id, project, role, model, event_type, issue_number, pr_number,
+                      detail, payload, created_at
+               FROM events WHERE loop_id = ? ORDER BY id DESC LIMIT 50""",
+            (loop_id,),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            """SELECT id, project, role, model, event_type, issue_number, pr_number,
+                      detail, payload, created_at
+               FROM events ORDER BY id DESC LIMIT 50"""
+        ).fetchall()
     conn.close()
     now = datetime.now(timezone.utc)
     result = []

--- a/static/index.html
+++ b/static/index.html
@@ -52,6 +52,36 @@
 
     header h1 span { color: var(--accent); }
 
+    #version-badge {
+      font-size: 0.72rem;
+      color: var(--muted);
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 5px;
+      padding: 2px 8px;
+      font-family: monospace;
+    }
+
+    #loop-selector-wrap {
+      display: none;
+      align-items: center;
+      gap: 6px;
+      font-size: 0.75rem;
+      color: var(--muted);
+    }
+
+    #loop-selector-wrap.visible { display: flex; }
+
+    #loop-selector {
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 5px;
+      color: var(--text);
+      font-size: 0.75rem;
+      padding: 3px 8px;
+      cursor: pointer;
+    }
+
     #refresh-indicator {
       font-size: 0.75rem;
       color: var(--muted);
@@ -809,9 +839,18 @@
 
 <header>
   <h1>Bounty <span>Monitor</span></h1>
-  <div id="refresh-indicator">
-    <span class="dot"></span>
-    <span id="last-update">—</span>
+  <div style="display:flex;align-items:center;gap:12px;">
+    <span id="version-badge">loop-monitor</span>
+    <div id="loop-selector-wrap">
+      <label for="loop-selector" style="white-space:nowrap">Loop:</label>
+      <select id="loop-selector">
+        <option value="">All loops</option>
+      </select>
+    </div>
+    <div id="refresh-indicator">
+      <span class="dot"></span>
+      <span id="last-update">—</span>
+    </div>
   </div>
 </header>
 
@@ -1252,6 +1291,7 @@
   }
 
   // ── State ──
+  let currentLoopId = '';   // '' = all loops
   let projectScores = {};   // project -> total_points
   let activeWorkers = [];   // from /api/active
   let statusEntries = [];   // from /api/status
@@ -1489,14 +1529,15 @@
   // ── Fetch all data ──
   async function fetchAll() {
     try {
+      const loopParam = currentLoopId ? `?loop_id=${encodeURIComponent(currentLoopId)}` : '';
       const [boardRes, feedRes, statusRes, verdictsRes, activeRes, historyRes,
              activityRes, stagesRes, reworkRes, projectsRes, eventsGraphRes] = await Promise.all([
         fetch('/api/board'),
-        fetch('/api/feed'),
+        fetch(`/api/feed${loopParam}`),
         fetch('/api/status'),
         fetch('/api/verdicts'),
         fetch('/api/active'),
-        fetch('/api/history'),
+        fetch(`/api/history${loopParam}`),
         fetch('/api/stats/activity'),
         fetch('/api/stats/stages'),
         fetch('/api/stats/rework'),
@@ -1935,8 +1976,42 @@
     wrap.addEventListener('mouseleave', () => { tip.style.display = 'none'; });
   })();
 
+  // ── Loop selector ──
+  const loopSelectorWrap = document.getElementById('loop-selector-wrap');
+  const loopSelector = document.getElementById('loop-selector');
+
+  async function initLoopSelector() {
+    try {
+      const resp = await fetch('/api/loops');
+      if (!resp.ok) return;
+      const loops = await resp.json();
+      const realLoops = loops.filter(l => l.loop_id !== '(unknown)');
+      if (realLoops.length <= 1) return;
+      loopSelector.innerHTML = '<option value="">All loops</option>' +
+        realLoops.map(l => `<option value="${escHtml(l.loop_id)}">${escHtml(l.loop_id)}</option>`).join('');
+      loopSelectorWrap.classList.add('visible');
+    } catch (_) {}
+  }
+
+  loopSelector.addEventListener('change', () => {
+    currentLoopId = loopSelector.value;
+    fetchAll();
+  });
+
+  async function initVersionBadge() {
+    try {
+      const resp = await fetch('/api/health');
+      if (!resp.ok) return;
+      const data = await resp.json();
+      const ver = data.monitor_version || 'unknown';
+      document.getElementById('version-badge').textContent = `loop-monitor v${ver}`;
+    } catch (_) {}
+  }
+
   // ── Init ──
   initCharts();
+  initVersionBadge();
+  initLoopSelector();
   fetchAll();
   setInterval(fetchAll, 5000);
   checkHash();

--- a/test_server.py
+++ b/test_server.py
@@ -513,3 +513,57 @@ def test_cycle_times_with_data(isolated_client):
     # issue_lifetime and pr_lifetime are null because columns not set
     assert data["issue_lifetime"] is None
     assert data["pr_lifetime"] is None
+
+
+# ── ?loop_id filtering on /api/feed and /api/history ──
+
+def test_feed_loop_id_filter(isolated_client):
+    import sqlite3
+    now = "2026-01-01T00:00:00+00:00"
+    conn = sqlite3.connect(server.DB_PATH)
+    conn.executemany(
+        "INSERT INTO events (project, role, event_type, created_at, loop_id) VALUES (?, ?, ?, ?, ?)",
+        [
+            ("p", "dev", "ev_a", now, "loop-x"),
+            ("p", "dev", "ev_b", now, "loop-y"),
+            ("p", "dev", "ev_c", now, None),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/feed?loop_id=loop-x")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert all(r["event_type"] == "ev_a" for r in data if r["project"] == "p")
+    assert not any(r["event_type"] == "ev_b" for r in data)
+
+    resp_all = isolated_client.get("/api/feed")
+    assert resp_all.status_code == 200
+    types = {r["event_type"] for r in resp_all.json() if r["project"] == "p"}
+    assert {"ev_a", "ev_b", "ev_c"}.issubset(types)
+
+
+def test_history_loop_id_filter(isolated_client):
+    import sqlite3
+    now = "2026-01-01T00:00:00+00:00"
+    conn = sqlite3.connect(server.DB_PATH)
+    conn.executemany(
+        "INSERT INTO events (project, role, event_type, created_at, loop_id) VALUES (?, ?, ?, ?, ?)",
+        [
+            ("ph", "dev", "build_done", now, "loop-alpha"),
+            ("ph", "dev", "build_done", now, "loop-beta"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/history?loop_id=loop-alpha")
+    assert resp.status_code == 200
+    proj_rows = [r for r in resp.json() if r["project"] == "ph"]
+    assert len(proj_rows) == 1
+
+    resp_all = isolated_client.get("/api/history")
+    assert resp_all.status_code == 200
+    all_proj = [r for r in resp_all.json() if r["project"] == "ph"]
+    assert len(all_proj) == 2


### PR DESCRIPTION
Closes #28

## Changes

**server.py:**
- Added `loop_id: Optional[str] = None` query param to `GET /api/feed` — applies `WHERE loop_id = ?` when present; absent preserves existing behaviour (no filter)
- Added `loop_id: Optional[str] = None` query param to `GET /api/history` — applies `AND d.loop_id = ?` in the WHERE clause when present; absent = no filter

Note: `loop_id` column + ingest (#26) and `GET /api/loops` + `loop_ids` in health (#27) are already on main.

**static/index.html:**
- Version badge `loop-monitor vX.Y.Z` fetched from `GET /api/health` on page load (static, no polling)
- Loop selector `<select>` populated from `GET /api/loops`; hidden when ≤1 distinct real loop_id values
- Defaults to "All loops" (no filter); selector change immediately re-fetches feed and history with `?loop_id=X`
- `currentLoopId` state var; `fetchAll()` builds `loopParam` so auto-refresh (5s interval) carries the selection

**test_server.py:**
- `test_feed_loop_id_filter` — `?loop_id=X` returns only matching events; absent param returns all
- `test_history_loop_id_filter` — `?loop_id=X` filters completed jobs; absent returns all

## Test Plan
- `pytest test_server.py` — 37 tests pass
- Load dashboard: header shows `loop-monitor vX.Y.Z`
- With 0 or 1 loop instance: selector is hidden
- With 2+ loop instances: selector appears; changing it refreshes only the feed and history panels
- Auto-refresh continues passing the selected loop_id every 5s