### PR TITLE
[LM-55] Add /api/claude_usage endpoint with env-var config and Anthropic API source

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,6 +1,9 @@
 import logging
+import os
 import sqlite3
 import json
+import urllib.request
+import urllib.error
 from datetime import datetime, timezone
 from contextlib import asynccontextmanager
 from typing import Optional, Any
@@ -935,6 +938,72 @@ def get_cycle_times(slug: str):
         "issue_lifetime": _percentile_stats(issue_vals) if issue_vals else None,
         "pr_lifetime": _percentile_stats(pr_vals) if pr_vals else None,
     }
+
+
+_claude_usage_cache: dict = {}
+
+ANTHROPIC_USAGE_URL = "https://api.anthropic.com/v1/usage"
+
+
+def _fetch_claude_usage() -> dict:
+    key = os.environ.get("ANTHROPIC_ADMIN_KEY", "")
+    if not key:
+        return {"enabled": True, "error": "ANTHROPIC_ADMIN_KEY not set"}
+    req = urllib.request.Request(
+        ANTHROPIC_USAGE_URL,
+        headers={
+            "anthropic-api-key": key,
+            "anthropic-version": "2023-06-01",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            body = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return {"enabled": True, "error": f"upstream HTTP {exc.code}"}
+    except Exception as exc:
+        return {"enabled": True, "error": str(exc)}
+
+    quota_used = body.get("total_tokens_used") or body.get("tokens_used")
+    quota_limit = body.get("token_limit") or body.get("quota")
+    reset_at = body.get("reset_at") or body.get("period_end")
+    cache_tokens_used = body.get("cache_read_tokens")
+    cache_hit_pct = None
+    if cache_tokens_used is not None and quota_used:
+        cache_hit_pct = round(100.0 * cache_tokens_used / quota_used, 2)
+
+    quota_pct = None
+    if quota_used is not None and quota_limit:
+        quota_pct = round(100.0 * quota_used / quota_limit, 2)
+
+    return {
+        "enabled": True,
+        "quota_used": quota_used,
+        "quota_limit": quota_limit,
+        "quota_pct": quota_pct,
+        "reset_at": reset_at,
+        "cache_hit_pct": cache_hit_pct,
+    }
+
+
+@app.get("/api/claude_usage")
+def claude_usage():
+    if os.environ.get("CLAUDE_USAGE_ENABLED", "").lower() not in ("1", "true", "yes"):
+        return {"enabled": False}
+
+    refresh = int(os.environ.get("CLAUDE_USAGE_REFRESH_SECONDS", "300"))
+    now = datetime.now(timezone.utc)
+    cached = _claude_usage_cache.get("data")
+    fetched_at = _claude_usage_cache.get("fetched_at")
+    if cached is not None and fetched_at is not None:
+        age = (now - fetched_at).total_seconds()
+        if age < refresh:
+            return cached
+
+    result = _fetch_claude_usage()
+    _claude_usage_cache["data"] = result
+    _claude_usage_cache["fetched_at"] = now
+    return result
 
 
 app.mount("/", StaticFiles(directory="static", html=True), name="static")

--- a/test_server.py
+++ b/test_server.py
@@ -513,3 +513,62 @@ def test_cycle_times_with_data(isolated_client):
     # issue_lifetime and pr_lifetime are null because columns not set
     assert data["issue_lifetime"] is None
     assert data["pr_lifetime"] is None
+
+
+# ── /api/claude_usage tests ──
+
+def test_claude_usage_disabled_by_default(isolated_client, monkeypatch):
+    monkeypatch.delenv("CLAUDE_USAGE_ENABLED", raising=False)
+    resp = isolated_client.get("/api/claude_usage")
+    assert resp.status_code == 200
+    assert resp.json() == {"enabled": False}
+
+
+def test_claude_usage_enabled_returns_correct_shape(isolated_client, monkeypatch):
+    import server as _srv
+    import json as _json
+
+    monkeypatch.setenv("CLAUDE_USAGE_ENABLED", "true")
+    monkeypatch.setenv("ANTHROPIC_ADMIN_KEY", "test-key")
+
+    fake_body = _json.dumps({
+        "total_tokens_used": 500000,
+        "token_limit": 1000000,
+        "reset_at": "2026-05-01T00:00:00Z",
+        "cache_read_tokens": 100000,
+    }).encode()
+
+    class FakeResponse:
+        def read(self):
+            return fake_body
+        def __enter__(self):
+            return self
+        def __exit__(self, *args):
+            pass
+
+    monkeypatch.setattr(_srv.urllib.request, "urlopen", lambda req, timeout=None: FakeResponse())
+    _srv._claude_usage_cache.clear()
+
+    resp = isolated_client.get("/api/claude_usage")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["enabled"] is True
+    assert data["quota_used"] == 500000
+    assert data["quota_limit"] == 1000000
+    assert data["quota_pct"] == 50.0
+    assert data["reset_at"] == "2026-05-01T00:00:00Z"
+    assert data["cache_hit_pct"] == 20.0
+
+
+def test_claude_usage_error_on_missing_key(isolated_client, monkeypatch):
+    import server as _srv
+
+    monkeypatch.setenv("CLAUDE_USAGE_ENABLED", "true")
+    monkeypatch.delenv("ANTHROPIC_ADMIN_KEY", raising=False)
+    _srv._claude_usage_cache.clear()
+
+    resp = isolated_client.get("/api/claude_usage")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["enabled"] is True
+    assert "error" in data


### PR DESCRIPTION
Closes #55

## Changes
- Added `GET /api/claude_usage` to `server.py`, gated by `CLAUDE_USAGE_ENABLED` env var (default: disabled)
- When disabled, returns `{"enabled": false}` immediately — no upstream call
- When enabled with `ANTHROPIC_ADMIN_KEY`, calls `https://api.anthropic.com/v1/usage` via stdlib `urllib.request` and returns `quota_used`, `quota_limit`, `quota_pct`, `reset_at`, `cache_hit_pct`
- Server-side module-level dict cache with `CLAUDE_USAGE_REFRESH_SECONDS` TTL (default 300s)
- Any upstream error (401, network failure, missing key) returns `{"enabled": true, "error": "..."}` — no 500, no crash
- No new dependencies (uses stdlib `urllib.request`)

## Test Plan
- `test_claude_usage_disabled_by_default`: unset env var → `{"enabled": false}`
- `test_claude_usage_enabled_returns_correct_shape`: monkeypatched `urlopen` → asserts all fields + computed `quota_pct=50.0`, `cache_hit_pct=20.0`
- `test_claude_usage_error_on_missing_key`: missing `ANTHROPIC_ADMIN_KEY` → error response, no crash
- Full suite: 38 tests pass, no regressions

CLAUDE.md absent; conventions derived from existing code.