### PR TITLE
[LM-81] Add baseline linting + type-checking (ruff + mypy + pre-commit)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install linting tools
+        run: pip install ruff mypy
+
+      - name: ruff check
+        run: ruff check .
+
+      - name: mypy
+        run: mypy server.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.19.1
+    hooks:
+      - id: mypy
+        files: ^server\.py$
+        additional_dependencies: []

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,33 @@ pip install -r requirements.txt
 uvicorn server:app --host 127.0.0.1 --port 18792 --reload
 ```
 
+## Code quality
+
+This repo uses [ruff](https://docs.astral.sh/ruff/) for linting/formatting and
+[mypy](https://mypy.readthedocs.io/) for type checking.
+
+**One-time setup** — install the pre-commit hooks so checks run automatically before every commit:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+**Run checks manually:**
+
+```bash
+# Lint + format check
+ruff check .
+
+# Type check (server only)
+mypy server.py
+
+# Run all pre-commit hooks against every file
+pre-commit run --all-files
+```
+
+CI runs `ruff check .` and `mypy server.py` on every PR and push to `main`.
+
 Open http://127.0.0.1:18792.
 
 ## Tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.ruff]
+line-length = 120
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+
+[tool.mypy]
+strict_optional = true
+warn_unused_ignores = true
+ignore_missing_imports = true

--- a/server.py
+++ b/server.py
@@ -1,12 +1,12 @@
+import json
 import logging
 import sqlite3
-import json
-from datetime import datetime, timezone
 from contextlib import asynccontextmanager
-from typing import Optional, Any
-
+from datetime import datetime, timezone
 from pathlib import Path
-from fastapi import FastAPI, BackgroundTasks, HTTPException
+from typing import Any, Optional
+
+from fastapi import BackgroundTasks, FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, model_validator
 
@@ -79,8 +79,10 @@ MIGRATIONS = [
         CREATE INDEX IF NOT EXISTS idx_events_project_role ON events (project, role);
         CREATE INDEX IF NOT EXISTS idx_events_event_type ON events (event_type);
         CREATE INDEX IF NOT EXISTS idx_events_created_at ON events (created_at);
-        CREATE INDEX IF NOT EXISTS idx_events_issue_number ON events (project, issue_number) WHERE issue_number IS NOT NULL;
-        CREATE INDEX IF NOT EXISTS idx_events_pr_number ON events (project, pr_number) WHERE pr_number IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_events_issue_number ON events (project, issue_number)
+            WHERE issue_number IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_events_pr_number ON events (project, pr_number)
+            WHERE pr_number IS NOT NULL;
         """,
     ),
     (
@@ -245,7 +247,7 @@ BOUNTY_POINTS = {
 
 def _auto_bounty(conn, data: "ReportPayload", now: str):
     """Auto-insert a verdict when a terminal event is received."""
-    pts = BOUNTY_POINTS.get(data.event_type)
+    pts = BOUNTY_POINTS.get(data.event_type or "")
     if pts is None:
         return
     reason = f"auto: {data.event_type}"
@@ -268,7 +270,8 @@ def _auto_bounty(conn, data: "ReportPayload", now: str):
         )
     else:
         conn.execute(
-            "INSERT INTO scores (project, role, model, total_points, verdict_count, updated_at) VALUES (?, ?, ?, ?, 1, ?)",
+            "INSERT INTO scores (project, role, model, total_points, verdict_count, updated_at)"
+            " VALUES (?, ?, ?, ?, 1, ?)",
             (data.project, data.role, data.model, pts, now),
         )
 
@@ -278,7 +281,8 @@ def _insert_event(data: ReportPayload):
     now = datetime.now(timezone.utc).isoformat()
     conn.execute(
         """INSERT INTO events
-           (project, role, model, event_type, issue_number, pr_number, detail, payload, core_version, loop_id, created_at)
+           (project, role, model, event_type, issue_number, pr_number, detail, payload,
+            core_version, loop_id, created_at)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             data.project,
@@ -355,7 +359,8 @@ def _insert_event(data: ReportPayload):
             except Exception:
                 issue_secs = None
             first_pr = conn.execute(
-                "SELECT created_at FROM issue_history WHERE project=? AND issue_number=? AND pr_number IS NOT NULL ORDER BY id ASC LIMIT 1",
+                "SELECT created_at FROM issue_history"
+                " WHERE project=? AND issue_number=? AND pr_number IS NOT NULL ORDER BY id ASC LIMIT 1",
                 (data.project, data.issue_number),
             ).fetchone()
             pr_secs = None
@@ -400,7 +405,8 @@ def _insert_verdict(data: VerdictPayload):
         )
     else:
         conn.execute(
-            "INSERT INTO scores (project, role, model, total_points, verdict_count, updated_at) VALUES (?, ?, ?, ?, 1, ?)",
+            "INSERT INTO scores (project, role, model, total_points, verdict_count, updated_at)"
+            " VALUES (?, ?, ?, ?, 1, ?)",
             (data.project, data.role, data.model, data.points, now),
         )
     conn.commit()
@@ -408,7 +414,8 @@ def _insert_verdict(data: VerdictPayload):
 
 
 SUPPORTED_API_MAJOR = "1"
-MONITOR_VERSION = (Path(__file__).parent / "VERSION").read_text().strip() if (Path(__file__).parent / "VERSION").exists() else "unknown"
+_version_file = Path(__file__).parent / "VERSION"
+MONITOR_VERSION = _version_file.read_text().strip() if _version_file.exists() else "unknown"
 
 
 @app.get("/api/health")
@@ -520,7 +527,12 @@ def history(limit: int = 50, loop_id: Optional[str] = None):
         LEFT JOIN verdicts v ON v.project = d.project AND v.role = d.role
             AND v.reason LIKE '%auto: ' || d.event_type || '%'
             AND v.created_at >= d.created_at
-            AND v.id = (SELECT MIN(v2.id) FROM verdicts v2 WHERE v2.project=d.project AND v2.role=d.role AND v2.created_at >= d.created_at AND v2.reason LIKE '%auto: ' || d.event_type || '%')
+            AND v.id = (
+                SELECT MIN(v2.id) FROM verdicts v2
+                WHERE v2.project=d.project AND v2.role=d.role
+                  AND v2.created_at >= d.created_at
+                  AND v2.reason LIKE '%auto: ' || d.event_type || '%'
+            )
         WHERE (d.event_type LIKE '%_done' OR d.event_type LIKE '%_pass' OR d.event_type LIKE '%_failed')
         {loop_clause}
         ORDER BY d.id DESC
@@ -939,7 +951,7 @@ def get_projects():
     return [{"project": p, "repo": r} for p, r in PROJECTS.items() if p in active]
 
 
-def _percentile_stats(values: list) -> dict:
+def _percentile_stats(values: list) -> Optional[dict]:
     """Return median, P90, sample_size, most_recent for a sorted list of values."""
     n = len(values)
     if n == 0:

--- a/test_server.py
+++ b/test_server.py
@@ -1,17 +1,19 @@
 import os
 import tempfile
+
 import pytest
 
 # Use a temp file so all get_db() calls share state
 _db_fd, _db_path = tempfile.mkstemp(suffix=".db")
 os.close(_db_fd)
 
-import server
+import server  # noqa: E402
+
 server.DB_PATH = _db_path
 server.apply_pending_migrations()
 
-from fastapi.testclient import TestClient
-from server import app
+from fastapi.testclient import TestClient  # noqa: E402,I001
+from server import app  # noqa: E402,I001
 
 client = TestClient(app)
 
@@ -292,11 +294,12 @@ def test_missing_api_accepted_with_warning(isolated_client, caplog):
 
 def test_loop_id_persisted(isolated_client):
     import sqlite3
+    import time
     isolated_client.post("/api/report", json={
         "project": "proj-li", "role": "dev", "event_type": "dev_start",
         "loop_id": "my-loop",
     })
-    import time; time.sleep(0.05)  # background task
+    time.sleep(0.05)  # background task
     conn = sqlite3.connect(server.DB_PATH)
     row = conn.execute(
         "SELECT loop_id FROM events WHERE project='proj-li' AND loop_id='my-loop'"
@@ -308,10 +311,11 @@ def test_loop_id_persisted(isolated_client):
 
 def test_loop_id_null_when_absent(isolated_client):
     import sqlite3
+    import time
     isolated_client.post("/api/report", json={
         "project": "proj-li2", "role": "dev", "event_type": "dev_start",
     })
-    import time; time.sleep(0.05)  # background task
+    time.sleep(0.05)  # background task
     conn = sqlite3.connect(server.DB_PATH)
     row = conn.execute(
         "SELECT loop_id FROM events WHERE project='proj-li2'"
@@ -350,7 +354,6 @@ def test_loops_empty_db(isolated_client):
 
 
 def test_loops_with_data(isolated_client):
-    import sqlite3
     import time
     isolated_client.post("/api/report", json={
         "api": "1.0", "project": "p", "role": "dev", "event_type": "dev_done",
@@ -412,10 +415,11 @@ def test_health_loop_ids_empty_db(isolated_client):
 
 def test_timeline_cumulative_seconds(isolated_client):
     """cumulative_seconds on each event is elapsed from the first event."""
-    import time as _time
     # Insert start then done events with a known gap via _insert_event
     # Use direct DB insertion with controlled timestamps for determinism
-    import sqlite3, server as _srv
+    import sqlite3
+
+    import server as _srv
     conn = sqlite3.connect(_srv.DB_PATH)
     conn.row_factory = sqlite3.Row
     conn.execute(


### PR DESCRIPTION
Closes #81

## Changes

- **`pyproject.toml`** — Added `[tool.ruff]` config (rules: E, F, W, I; line-length: 120; target-version: py39) and `[tool.mypy]` (strict_optional, warn_unused_ignores, ignore_missing_imports).
- **`.pre-commit-config.yaml`** — Hooks for ruff (lint + format) and mypy on `server.py`.
- **`.github/workflows/lint.yml`** — CI workflow running `ruff check .` and `mypy server.py` on every PR and push to main.
- **`server.py`** — Fixed all ruff violations (import sort, long lines) and 2 mypy errors (Optional[str] dict.get arg, Optional return type on `_percentile_stats`).
- **`test_server.py`** — Fixed ruff violations: import sort, E402 (intentional module-level setup suppressed with noqa), E702 semicolon statements split, unused imports removed.
- **`CONTRIBUTING.md`** — Added "Code quality" section documenting one-time `pre-commit install` and manual check commands.

## Test Plan
- `ruff check .` passes with zero violations
- `mypy server.py` passes with zero errors
- CI workflow will enforce both on every PR