### PR TITLE
[LM-82] Add nightly retention script to prune old bounty.db rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,33 @@ this on every pipeline state change.
 
 `core_version_counts` — map of Loop core version → event count, built from ingested events.
 
+## Data Retention
+
+`bounty.db` grows at ~600 events/day. Run `scripts/prune.py` nightly to keep it bounded.
+
+```bash
+python scripts/prune.py --db bounty.db
+python scripts/prune.py --db bounty.db --dry-run   # preview without deleting
+```
+
+**Default horizons:**
+
+| Table           | Env var                     | Default |
+|-----------------|-----------------------------|---------|
+| `events`        | `RETAIN_EVENTS_DAYS`        | 90 days |
+| `verdicts`      | `RETAIN_VERDICTS_DAYS`      | 365 days |
+| `scores`        | `RETAIN_SCORES_DAYS`        | 365 days |
+| `issue_history` | `RETAIN_ISSUE_HISTORY_DAYS` | 90 days |
+| `pipeline_runs` | `RETAIN_PIPELINE_RUNS_DAYS` | 365 days |
+
+Events tied to an in-progress pipeline run are never pruned, regardless of age.
+
+**Schedule via cron** (daily at 03:00):
+
+```cron
+0 3 * * * python /path/to/loop-monitor/scripts/prune.py --db /path/to/bounty.db
+```
+
 ## Scripts
 
 ### `scripts/release.sh patch|minor|major`

--- a/scripts/prune.py
+++ b/scripts/prune.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Nightly retention script: prune old rows from bounty.db.
+
+Usage:
+    python scripts/prune.py --db bounty.db
+    python scripts/prune.py --db bounty.db --dry-run
+
+Retention horizons (days) are read from env vars with these defaults:
+    RETAIN_EVENTS_DAYS=90
+    RETAIN_VERDICTS_DAYS=365
+    RETAIN_SCORES_DAYS=365
+    RETAIN_ISSUE_HISTORY_DAYS=90
+    RETAIN_PIPELINE_RUNS_DAYS=365
+"""
+
+import argparse
+import os
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+
+def _days(env_var: str, default: int) -> int:
+    return int(os.environ.get(env_var, default))
+
+
+def _cutoff(days: int) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+
+
+def _count_events(conn: sqlite3.Connection, cutoff: str) -> int:
+    """Count events older than cutoff that are safe to prune (not in-flight)."""
+    return conn.execute(
+        """
+        SELECT COUNT(*) FROM events
+        WHERE created_at < ?
+          AND (
+            issue_number IS NULL
+            OR issue_number NOT IN (
+              SELECT issue_number FROM pipeline_runs
+              WHERE project = events.project
+                AND completed_at IS NULL
+            )
+          )
+        """,
+        (cutoff,),
+    ).fetchone()[0]
+
+
+def _delete_events(conn: sqlite3.Connection, cutoff: str) -> int:
+    cur = conn.execute(
+        """
+        DELETE FROM events
+        WHERE created_at < ?
+          AND (
+            issue_number IS NULL
+            OR issue_number NOT IN (
+              SELECT issue_number FROM pipeline_runs
+              WHERE project = events.project
+                AND completed_at IS NULL
+            )
+          )
+        """,
+        (cutoff,),
+    )
+    return cur.rowcount
+
+
+_TS_COLUMN = {
+    "events": "created_at",
+    "verdicts": "created_at",
+    "scores": "updated_at",
+    "issue_history": "created_at",
+    "pipeline_runs": "created_at",
+}
+
+
+def _count_simple(conn: sqlite3.Connection, table: str, cutoff: str) -> int:
+    col = _TS_COLUMN[table]
+    return conn.execute(
+        f"SELECT COUNT(*) FROM {table} WHERE {col} < ?",  # noqa: S608
+        (cutoff,),
+    ).fetchone()[0]
+
+
+def _delete_simple(conn: sqlite3.Connection, table: str, cutoff: str) -> int:
+    col = _TS_COLUMN[table]
+    cur = conn.execute(
+        f"DELETE FROM {table} WHERE {col} < ?",  # noqa: S608
+        (cutoff,),
+    )
+    return cur.rowcount
+
+
+def run(db_path: str, dry_run: bool = False) -> None:
+    horizons = {
+        "events": _days("RETAIN_EVENTS_DAYS", 90),
+        "verdicts": _days("RETAIN_VERDICTS_DAYS", 365),
+        "scores": _days("RETAIN_SCORES_DAYS", 365),
+        "issue_history": _days("RETAIN_ISSUE_HISTORY_DAYS", 90),
+        "pipeline_runs": _days("RETAIN_PIPELINE_RUNS_DAYS", 365),
+    }
+
+    size_before = os.path.getsize(db_path)
+    conn = sqlite3.connect(db_path)
+
+    try:
+        if dry_run:
+            counts = {}
+            counts["events"] = _count_events(conn, _cutoff(horizons["events"]))
+            for table in ("verdicts", "scores", "issue_history", "pipeline_runs"):
+                counts[table] = _count_simple(conn, table, _cutoff(horizons[table]))
+            conn.close()
+            parts = " ".join(f"{t}={n}" for t, n in counts.items())
+            print(f"dry-run {parts}; would free ~{_estimate_free(counts, size_before):.1f}MB")
+        else:
+            deleted = {}
+            deleted["events"] = _delete_events(conn, _cutoff(horizons["events"]))
+            for table in ("verdicts", "scores", "issue_history", "pipeline_runs"):
+                deleted[table] = _delete_simple(conn, table, _cutoff(horizons[table]))
+            conn.commit()
+            conn.execute("VACUUM")
+            conn.close()
+            size_after = os.path.getsize(db_path)
+            freed_mb = (size_before - size_after) / (1024 * 1024)
+            parts = " ".join(f"{t}={n}" for t, n in deleted.items())
+            print(f"pruned {parts}; freed {freed_mb:.1f}MB")
+    except Exception:
+        conn.close()
+        raise
+
+
+def _estimate_free(counts: dict, size_before: int) -> float:
+    """Rough estimate: assume average row ~200 bytes."""
+    total_rows = sum(counts.values())
+    return (total_rows * 200) / (1024 * 1024)
+
+
+def main() -> None:
+    default_db = os.environ.get("DB_PATH", "bounty.db")
+    parser = argparse.ArgumentParser(description="Prune old rows from bounty.db")
+    parser.add_argument("--db", default=default_db, help="Path to bounty.db")
+    parser.add_argument("--dry-run", action="store_true", help="Report counts without deleting")
+    args = parser.parse_args()
+    run(db_path=args.db, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_prune.py
+++ b/tests/test_prune.py
@@ -1,0 +1,218 @@
+import os
+import sqlite3
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import server
+from scripts.prune import run
+
+
+def _ts(days_ago: float) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
+
+
+@pytest.fixture()
+def db_path(tmp_path):
+    path = str(tmp_path / "test.db")
+    old_db = server.DB_PATH
+    server.DB_PATH = path
+    server.apply_pending_migrations()
+    server.DB_PATH = old_db
+    return path
+
+
+def _conn(db_path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _insert_event(conn, project="p", issue_number=None, days_ago=1.0):
+    conn.execute(
+        "INSERT INTO events (project, role, event_type, created_at) VALUES (?, 'builder', 'started', ?)",
+        (project, _ts(days_ago)),
+    )
+    conn.commit()
+
+
+def _insert_verdict(conn, project="p", days_ago=1.0):
+    conn.execute(
+        "INSERT INTO verdicts (project, role, points, created_at) VALUES (?, 'builder', 1, ?)",
+        (project, _ts(days_ago)),
+    )
+    conn.commit()
+
+
+def _insert_pipeline_run(conn, project="p", issue_number=1, completed=True, days_ago=1.0):
+    completed_at = _ts(days_ago) if completed else None
+    conn.execute(
+        "INSERT INTO pipeline_runs (project, issue_number, created_at, completed_at) VALUES (?, ?, ?, ?)",
+        (project, issue_number, _ts(days_ago), completed_at),
+    )
+    conn.commit()
+
+
+def _insert_score(conn, project="p", days_ago=1.0):
+    conn.execute(
+        "INSERT INTO scores (project, role, model, total_points, verdict_count, updated_at) VALUES (?, 'builder', NULL, 0, 0, ?)",
+        (project, _ts(days_ago)),
+    )
+    conn.commit()
+
+
+def _insert_issue_history(conn, project="p", days_ago=1.0):
+    conn.execute(
+        "INSERT INTO issue_history (project, issue_number, role, event_type, created_at) VALUES (?, 1, 'builder', 'started', ?)",
+        (project, _ts(days_ago)),
+    )
+    conn.commit()
+
+
+def test_right_rows_deleted_by_age(db_path, monkeypatch):
+    monkeypatch.setenv("RETAIN_EVENTS_DAYS", "90")
+    monkeypatch.setenv("RETAIN_VERDICTS_DAYS", "365")
+
+    conn = _conn(db_path)
+    # old event (120 days ago) — should be pruned
+    _insert_event(conn, days_ago=120)
+    # recent event (10 days ago) — should be kept
+    _insert_event(conn, days_ago=10)
+    conn.close()
+
+    run(db_path=db_path, dry_run=False)
+
+    conn = _conn(db_path)
+    count = conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+    assert count == 1, f"Expected 1 event to remain, got {count}"
+    remaining_age = conn.execute(
+        "SELECT created_at FROM events"
+    ).fetchone()[0]
+    # The kept row should be more recent than 90 days ago
+    kept_dt = datetime.fromisoformat(remaining_age)
+    assert kept_dt > datetime.now(timezone.utc) - timedelta(days=90)
+    conn.close()
+
+
+def test_inflight_events_not_pruned(db_path, monkeypatch):
+    monkeypatch.setenv("RETAIN_EVENTS_DAYS", "30")
+
+    conn = _conn(db_path)
+    # Old event with issue_number tied to an in-progress pipeline run
+    conn.execute(
+        "INSERT INTO events (project, role, event_type, issue_number, created_at) VALUES ('p', 'builder', 'started', 42, ?)",
+        (_ts(60),),
+    )
+    conn.commit()
+    # Pipeline run for that issue is NOT completed (in-flight)
+    _insert_pipeline_run(conn, project="p", issue_number=42, completed=False, days_ago=5)
+    conn.close()
+
+    run(db_path=db_path, dry_run=False)
+
+    conn = _conn(db_path)
+    count = conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+    assert count == 1, "In-flight event must not be pruned"
+    conn.close()
+
+
+def test_completed_issue_events_pruned(db_path, monkeypatch):
+    monkeypatch.setenv("RETAIN_EVENTS_DAYS", "30")
+
+    conn = _conn(db_path)
+    # Old event with issue_number tied to a completed pipeline run
+    conn.execute(
+        "INSERT INTO events (project, role, event_type, issue_number, created_at) VALUES ('p', 'builder', 'started', 99, ?)",
+        (_ts(60),),
+    )
+    conn.commit()
+    # Pipeline run completed
+    _insert_pipeline_run(conn, project="p", issue_number=99, completed=True, days_ago=55)
+    conn.close()
+
+    run(db_path=db_path, dry_run=False)
+
+    conn = _conn(db_path)
+    count = conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+    assert count == 0, "Old event for completed issue should be pruned"
+    conn.close()
+
+
+def test_all_tables_pruned(db_path, monkeypatch):
+    monkeypatch.setenv("RETAIN_EVENTS_DAYS", "30")
+    monkeypatch.setenv("RETAIN_VERDICTS_DAYS", "30")
+    monkeypatch.setenv("RETAIN_SCORES_DAYS", "30")
+    monkeypatch.setenv("RETAIN_ISSUE_HISTORY_DAYS", "30")
+    monkeypatch.setenv("RETAIN_PIPELINE_RUNS_DAYS", "30")
+
+    conn = _conn(db_path)
+    _insert_event(conn, days_ago=60)
+    _insert_verdict(conn, days_ago=60)
+    _insert_score(conn, days_ago=60)
+    _insert_issue_history(conn, days_ago=60)
+    _insert_pipeline_run(conn, days_ago=60, completed=True)
+    conn.close()
+
+    run(db_path=db_path, dry_run=False)
+
+    conn = _conn(db_path)
+    for table in ("events", "verdicts", "scores", "issue_history", "pipeline_runs"):
+        count = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+        assert count == 0, f"Table {table} should be empty after pruning"
+    conn.close()
+
+
+def test_idempotent(db_path, monkeypatch):
+    monkeypatch.setenv("RETAIN_EVENTS_DAYS", "30")
+
+    conn = _conn(db_path)
+    _insert_event(conn, days_ago=60)
+    conn.close()
+
+    run(db_path=db_path, dry_run=False)
+    run(db_path=db_path, dry_run=False)
+
+    conn = _conn(db_path)
+    count = conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+    assert count == 0
+    conn.close()
+
+
+def test_dry_run_shows_counts_without_mutating(db_path, monkeypatch, capsys):
+    monkeypatch.setenv("RETAIN_EVENTS_DAYS", "30")
+
+    conn = _conn(db_path)
+    _insert_event(conn, days_ago=60)
+    _insert_event(conn, days_ago=60)
+    conn.close()
+
+    run(db_path=db_path, dry_run=True)
+
+    captured = capsys.readouterr()
+    assert "dry-run" in captured.out
+    assert "events=2" in captured.out
+
+    conn = _conn(db_path)
+    count = conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+    assert count == 2, "Dry-run must not delete rows"
+    conn.close()
+
+
+def test_recent_rows_kept(db_path, monkeypatch):
+    monkeypatch.setenv("RETAIN_EVENTS_DAYS", "90")
+    monkeypatch.setenv("RETAIN_VERDICTS_DAYS", "365")
+
+    conn = _conn(db_path)
+    _insert_event(conn, days_ago=10)
+    _insert_verdict(conn, days_ago=10)
+    conn.close()
+
+    run(db_path=db_path, dry_run=False)
+
+    conn = _conn(db_path)
+    assert conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM verdicts").fetchone()[0] == 1
+    conn.close()


### PR DESCRIPTION
Closes #82

## Changes

- **`scripts/prune.py`** — standalone nightly retention script using only stdlib (`sqlite3`, `argparse`, `os`, `datetime`). Deletes rows older than configurable horizons from all five tables (`events`, `verdicts`, `scores`, `issue_history`, `pipeline_runs`), runs `VACUUM` after, and prints a one-line summary (`pruned events=N verdicts=N …; freed X.XMB`).
  - `--dry-run` flag reports counts without touching the DB.
  - Horizons read from env vars with documented defaults: events=90d, verdicts=365d, scores=365d, issue_history=90d, pipeline_runs=365d.
  - In-flight guard: events linked to an issue with an open (incomplete) `pipeline_runs` row are never pruned, regardless of age.
  - `scores` table uses `updated_at` (not `created_at`) — handled via per-table column map.
  - `VACUUM` runs after all deletes; freed bytes reported as `size_before − size_after`.

- **`tests/test_prune.py`** — 7 new tests covering: right rows deleted by age, in-flight events not pruned, completed-issue events pruned, all tables pruned, idempotency, dry-run shows counts without mutating, recent rows kept.

- **`README.md`** — new "Data Retention" section documenting defaults, dry-run usage, and example cron line.

Note: `verdicts` table has no `event_id` FK column (checked schema). In-flight guard is implemented via `pipeline_runs.completed_at IS NULL` for the event's `(project, issue_number)`, which is the correct available join key.

## Test Plan

- `pytest test_server.py` — 44 existing tests, all pass
- `pytest tests/test_prune.py` — 7 new prune tests, all pass
- Manual: `python scripts/prune.py --db bounty.db --dry-run` prints `dry-run events=N …` without modifying the DB