### PR TITLE
[LM-47] Add Action Queue dashboard tab and API

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import sqlite3
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
@@ -1038,6 +1039,105 @@ def get_events_graph(window: int = 24):
     ).fetchall()
     conn.close()
     return {"window_hours": window, "buckets": [dict(r) for r in rows]}
+
+
+STUCK_STAGES = {"blocked", "needs-clarification"}
+TIMEOUT_STAGES = {"in-progress", "in-review", "in-rework"}
+QA_FAIL_STAGE = "qa-fail"
+QA_FAIL_RETRY_THRESHOLD = 3
+
+
+def _handler_timeout_seconds() -> int:
+    try:
+        return int(os.environ.get("HANDLER_TIMEOUT", "3600"))
+    except ValueError:
+        return 3600
+
+
+def _action_queue_reason(stage: str, age_seconds: int, retry_count: int, threshold: int) -> Optional[str]:
+    if stage in STUCK_STAGES:
+        return "stuck_label"
+    if stage in TIMEOUT_STAGES and age_seconds > threshold:
+        return "timeout"
+    if stage == QA_FAIL_STAGE and retry_count >= QA_FAIL_RETRY_THRESHOLD:
+        return "qa_fail_repeated"
+    return None
+
+
+@app.get("/api/action_queue")
+def action_queue():
+    """Items across all projects awaiting human input.
+
+    Derived from the latest event per (project, kind, number). No GitHub API call.
+    """
+    threshold = _handler_timeout_seconds() * 2
+    conn = get_db()
+    rows = conn.execute(
+        """
+        SELECT e.project, e.role, e.event_type, e.issue_number, e.pr_number,
+               e.detail, e.loop_id, e.created_at,
+               COALESCE(h.rework_count, 0) AS rework_count,
+               COALESCE(r.title, '') AS title
+        FROM events e
+        INNER JOIN (
+            SELECT project,
+                   COALESCE(issue_number, -1) AS i,
+                   COALESCE(pr_number, -1) AS p,
+                   MAX(id) AS max_id
+            FROM events
+            WHERE issue_number IS NOT NULL OR pr_number IS NOT NULL
+            GROUP BY project, COALESCE(issue_number, -1), COALESCE(pr_number, -1)
+        ) latest
+            ON e.id = latest.max_id
+        LEFT JOIN issue_history h ON h.id = (
+            SELECT MAX(h2.id) FROM issue_history h2
+            WHERE h2.project = e.project
+              AND (h2.issue_number = e.issue_number OR h2.pr_number = e.pr_number)
+        )
+        LEFT JOIN pipeline_runs r ON r.id = (
+            SELECT MAX(r2.id) FROM pipeline_runs r2
+            WHERE r2.project = e.project
+              AND (r2.issue_number = e.issue_number OR r2.pr_number = e.pr_number)
+        )
+        """
+    ).fetchall()
+    conn.close()
+
+    now = datetime.now(timezone.utc)
+    result = []
+    for r in rows:
+        stage = (r["event_type"] or "").lower()
+        created = _parse_ts(r["created_at"])
+        age_seconds = int((now - created).total_seconds()) if created else 0
+        reason = _action_queue_reason(stage, age_seconds, r["rework_count"] or 0, threshold)
+        if reason is None:
+            continue
+        if r["issue_number"] is not None:
+            kind = "issue"
+            number = r["issue_number"]
+        elif r["pr_number"] is not None:
+            kind = "pr"
+            number = r["pr_number"]
+        else:
+            continue
+        repo = PROJECTS.get(r["project"])
+        github_url = (
+            f"https://github.com/{repo}/{'issues' if kind == 'issue' else 'pull'}/{number}"
+            if repo else None
+        )
+        result.append({
+            "project": r["project"],
+            "kind": kind,
+            "number": number,
+            "title": r["title"] or r["detail"] or "",
+            "stage": stage,
+            "age_seconds": age_seconds,
+            "reason": reason,
+            "loop_id": r["loop_id"],
+            "github_url": github_url,
+        })
+    result.sort(key=lambda x: x["age_seconds"], reverse=True)
+    return result
 
 
 app.mount("/", StaticFiles(directory="static", html=True), name="static")

--- a/static/index.html
+++ b/static/index.html
@@ -11,6 +11,12 @@
 
 <header>
   <h1>Bounty <span>Monitor</span></h1>
+  <nav id="dashboard-tabs" style="display:flex;gap:6px;align-items:center;">
+    <button class="tab-btn active" data-dash-tab="overview">Overview</button>
+    <button class="tab-btn" data-dash-tab="action-queue">
+      Action Queue <span id="action-queue-badge" class="badge" style="display:none;margin-left:4px;background:#c44;color:#fff;border-radius:10px;padding:1px 7px;font-size:0.7rem;">0</span>
+    </button>
+  </nav>
   <div style="display:flex;align-items:center;gap:12px;">
     <span id="version-badge">loop-monitor</span>
     <div id="loop-selector-wrap">
@@ -25,6 +31,43 @@
     </div>
   </div>
 </header>
+
+<section id="action-queue-section" style="display:none;">
+  <div class="section-title">Action Queue</div>
+  <div style="display:flex;gap:8px;margin-bottom:8px;flex-wrap:wrap;">
+    <select id="aq-filter-project" style="background:var(--surface2);border:1px solid var(--border);color:var(--text);font-size:0.75rem;padding:3px 6px;border-radius:4px;">
+      <option value="">All projects</option>
+    </select>
+    <select id="aq-filter-reason" style="background:var(--surface2);border:1px solid var(--border);color:var(--text);font-size:0.75rem;padding:3px 6px;border-radius:4px;">
+      <option value="">All reasons</option>
+      <option value="stuck_label">stuck_label</option>
+      <option value="timeout">timeout</option>
+      <option value="qa_fail_repeated">qa_fail_repeated</option>
+    </select>
+    <select id="aq-filter-loop" style="background:var(--surface2);border:1px solid var(--border);color:var(--text);font-size:0.75rem;padding:3px 6px;border-radius:4px;">
+      <option value="">All loops</option>
+    </select>
+  </div>
+  <div style="background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:4px 0;">
+    <table class="active-table" id="action-queue-table">
+      <thead>
+        <tr>
+          <th data-aq-sort="project">Project</th>
+          <th data-aq-sort="kind">Kind</th>
+          <th data-aq-sort="number">Number</th>
+          <th data-aq-sort="title">Title</th>
+          <th data-aq-sort="age_seconds">Age</th>
+          <th data-aq-sort="reason">Reason</th>
+          <th data-aq-sort="loop_id">Loop</th>
+          <th>Link</th>
+        </tr>
+      </thead>
+      <tbody id="action-queue-body">
+        <tr><td colspan="8" class="no-workers">Loading…</td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
 
 <section id="events-graph-section" style="display:none">
   <div id="events-graph-card">

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -8,6 +8,7 @@ import { initVersionBadge, initLoopSelector } from '/js/components/header.js';
 import { renderActive, renderAgents } from '/js/components/stats.js';
 import { initRunsPanel, checkHash } from '/js/components/runs.js';
 import { fetchClaudeUsage } from '/js/components/claude_usage.js';
+import { fetchActionQueue, initActionQueue, renderActionQueue } from '/js/components/action_queue.js';
 
 async function fetchAll() {
   try {
@@ -33,6 +34,9 @@ async function fetchAll() {
     renderVerdicts(verdicts);
     updateCharts(activity, board, stages, rework);
 
+    const actionItems = await fetchActionQueue();
+    renderActionQueue(actionItems);
+
     document.getElementById('last-update').textContent = 'Updated ' + timeAgo(new Date().toISOString());
   } catch (e) {
     console.error('Fetch error:', e);
@@ -45,6 +49,7 @@ initRunsPanel();
 initGraphTooltip();
 initVersionBadge();
 initLoopSelector(fetchAll);
+initActionQueue();
 
 document.getElementById('feed-role-filter').addEventListener('change', fetchAll);
 document.getElementById('feed-status-filter').addEventListener('change', fetchAll);

--- a/static/js/components/action_queue.js
+++ b/static/js/components/action_queue.js
@@ -1,0 +1,164 @@
+let currentItems = [];
+let sortKey = 'age_seconds';
+let sortDesc = true;
+
+function fmtAge(seconds) {
+  if (seconds == null) return '—';
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`;
+  return `${Math.floor(seconds / 86400)}d`;
+}
+
+function ageColor(seconds) {
+  if (seconds == null) return '';
+  if (seconds > 86400) return 'color:#e44;font-weight:600';
+  if (seconds > 21600) return 'color:#e9a000;font-weight:600';
+  return 'color:#3c8;';
+}
+
+function escapeHtml(s) {
+  return String(s ?? '').replace(/[&<>"']/g, c => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  }[c]));
+}
+
+function applyFilters(items) {
+  const project = document.getElementById('aq-filter-project').value;
+  const reason = document.getElementById('aq-filter-reason').value;
+  const loop = document.getElementById('aq-filter-loop').value;
+  return items.filter(it =>
+    (!project || it.project === project) &&
+    (!reason || it.reason === reason) &&
+    (!loop || it.loop_id === loop)
+  );
+}
+
+function sortItems(items) {
+  const sorted = items.slice();
+  sorted.sort((a, b) => {
+    const av = a[sortKey];
+    const bv = b[sortKey];
+    if (av == null && bv == null) return 0;
+    if (av == null) return 1;
+    if (bv == null) return -1;
+    if (av < bv) return sortDesc ? 1 : -1;
+    if (av > bv) return sortDesc ? -1 : 1;
+    return 0;
+  });
+  return sorted;
+}
+
+function renderRows(items) {
+  const tbody = document.getElementById('action-queue-body');
+  if (!tbody) return;
+  if (!items.length) {
+    tbody.innerHTML = '<tr><td colspan="8" class="no-workers">No items need your attention.</td></tr>';
+    return;
+  }
+  tbody.innerHTML = items.map(it => `
+    <tr>
+      <td>${escapeHtml(it.project)}</td>
+      <td>${escapeHtml(it.kind)}</td>
+      <td>#${escapeHtml(it.number)}</td>
+      <td>${escapeHtml(it.title)}</td>
+      <td style="${ageColor(it.age_seconds)}">${fmtAge(it.age_seconds)}</td>
+      <td>${escapeHtml(it.reason)}</td>
+      <td>${escapeHtml(it.loop_id || '')}</td>
+      <td>
+        ${it.github_url ? `<a href="${escapeHtml(it.github_url)}" target="_blank" rel="noopener">GitHub</a>` : ''}
+        ${it.kind === 'issue' ? ` · <a href="#runs/${encodeURIComponent(it.project)}">project</a>` : ''}
+      </td>
+    </tr>
+  `).join('');
+}
+
+function refreshFilterOptions(items) {
+  const projectSel = document.getElementById('aq-filter-project');
+  const loopSel = document.getElementById('aq-filter-loop');
+  const projects = [...new Set(items.map(i => i.project))].sort();
+  const loops = [...new Set(items.map(i => i.loop_id).filter(Boolean))].sort();
+  const ensureOptions = (sel, values) => {
+    const current = sel.value;
+    const existing = new Set(Array.from(sel.options).map(o => o.value));
+    for (const v of values) {
+      if (!existing.has(v)) {
+        const opt = document.createElement('option');
+        opt.value = v;
+        opt.textContent = v;
+        sel.appendChild(opt);
+      }
+    }
+    sel.value = current;
+  };
+  ensureOptions(projectSel, projects);
+  ensureOptions(loopSel, loops);
+}
+
+export function renderActionQueue(items) {
+  currentItems = items || [];
+  refreshFilterOptions(currentItems);
+  const filtered = applyFilters(currentItems);
+  renderRows(sortItems(filtered));
+  const badge = document.getElementById('action-queue-badge');
+  if (badge) {
+    badge.textContent = String(currentItems.length);
+    badge.style.display = currentItems.length > 0 ? '' : 'none';
+  }
+}
+
+export function initActionQueue() {
+  document.querySelectorAll('#dashboard-tabs [data-dash-tab]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('#dashboard-tabs [data-dash-tab]').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      const tab = btn.dataset.dashTab;
+      const overviewSelectors = [
+        '#events-graph-section', 'main', '#claude-usage-section',
+        '#charts-section', '#project-panel',
+      ];
+      const aq = document.getElementById('action-queue-section');
+      if (tab === 'action-queue') {
+        overviewSelectors.forEach(sel => {
+          document.querySelectorAll(sel).forEach(el => { el.dataset.prevDisplay = el.style.display; el.style.display = 'none'; });
+        });
+        aq.style.display = '';
+      } else {
+        overviewSelectors.forEach(sel => {
+          document.querySelectorAll(sel).forEach(el => { el.style.display = el.dataset.prevDisplay || ''; });
+        });
+        aq.style.display = 'none';
+      }
+    });
+  });
+
+  ['aq-filter-project', 'aq-filter-reason', 'aq-filter-loop'].forEach(id => {
+    document.getElementById(id).addEventListener('change', () => {
+      renderRows(sortItems(applyFilters(currentItems)));
+    });
+  });
+
+  document.querySelectorAll('#action-queue-table th[data-aq-sort]').forEach(th => {
+    th.style.cursor = 'pointer';
+    th.addEventListener('click', () => {
+      const key = th.dataset.aqSort;
+      if (sortKey === key) {
+        sortDesc = !sortDesc;
+      } else {
+        sortKey = key;
+        sortDesc = true;
+      }
+      renderRows(sortItems(applyFilters(currentItems)));
+    });
+  });
+}
+
+export async function fetchActionQueue() {
+  try {
+    const res = await fetch('/api/action_queue');
+    if (!res.ok) return [];
+    return await res.json();
+  } catch {
+    return [];
+  }
+}

--- a/test_server.py
+++ b/test_server.py
@@ -780,3 +780,89 @@ def test_feed_role_filter_preserves_loop_id(isolated_client):
     data = resp.json()
     assert len(data) >= 1
     assert all(item["role"] == "dev" for item in data)
+
+
+# ── Action queue tests ──
+
+def test_action_queue_empty(isolated_client):
+    resp = isolated_client.get("/api/action_queue")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_action_queue_blocked_label(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="boba-event", role="dev", event_type="blocked", issue_number=42,
+        detail="needs human"
+    ))
+    resp = isolated_client.get("/api/action_queue")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["project"] == "boba-event"
+    assert data[0]["kind"] == "issue"
+    assert data[0]["number"] == 42
+    assert data[0]["stage"] == "blocked"
+    assert data[0]["reason"] == "stuck_label"
+    assert data[0]["github_url"].endswith("/issues/42")
+
+
+def test_action_queue_needs_clarification(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="needs-clarification", issue_number=7
+    ))
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    assert any(item["reason"] == "stuck_label" and item["stage"] == "needs-clarification" for item in data)
+
+
+def test_action_queue_timeout_threshold(isolated_client, monkeypatch):
+    monkeypatch.setenv("HANDLER_TIMEOUT", "100")  # threshold = 200
+    import sqlite3
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="in-progress", issue_number=11
+    ))
+    # backdate created_at to 300s ago — exceeds 200s threshold
+    conn = sqlite3.connect(server.DB_PATH)
+    conn.execute(
+        "UPDATE events SET created_at = datetime('now', '-300 seconds') WHERE issue_number = 11"
+    )
+    conn.commit()
+    conn.close()
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    timeout_items = [it for it in data if it["reason"] == "timeout" and it["number"] == 11]
+    assert len(timeout_items) == 1
+    assert timeout_items[0]["stage"] == "in-progress"
+    assert timeout_items[0]["age_seconds"] >= 200
+
+
+def test_action_queue_in_progress_below_threshold_excluded(isolated_client, monkeypatch):
+    monkeypatch.setenv("HANDLER_TIMEOUT", "3600")
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="in-progress", issue_number=13
+    ))
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    assert all(it["number"] != 13 for it in data)
+
+
+def test_action_queue_sorted_by_age_desc(isolated_client, monkeypatch):
+    monkeypatch.setenv("HANDLER_TIMEOUT", "100")
+    import sqlite3
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="blocked", issue_number=200
+    ))
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="blocked", issue_number=201
+    ))
+    conn = sqlite3.connect(server.DB_PATH)
+    conn.execute(
+        "UPDATE events SET created_at = datetime('now', '-9000 seconds') WHERE issue_number = 200"
+    )
+    conn.commit()
+    conn.close()
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    nums = [it["number"] for it in data if it["number"] in (200, 201)]
+    assert nums == [200, 201]


### PR DESCRIPTION
Closes #47

## Changes
- New `GET /api/action_queue` endpoint that derives stuck items from the latest event per (project, kind, number) using the events/issue_history/pipeline_runs tables. No GitHub API calls.
- Surfaces items whose latest event stage is `blocked`/`needs-clarification` (`stuck_label`), items at `in-progress`/`in-review`/`in-rework` past `2 × HANDLER_TIMEOUT` (default 3600 → 7200s, `timeout`), or `qa-fail` with `rework_count ≥ 3` (`qa_fail_repeated`).
- Sorted age desc, returns `[]` on empty DB.
- New "Action Queue" tab in the dashboard header nav with sortable table (project / kind / number / title / age / reason / loop / link), filters by project / reason / loop, age color-coding (>24h red, >6h yellow), and counter badge in the header.
- Refreshes on every dashboard poll cycle.
- Tests cover endpoint with data, empty DB, timeout threshold logic, sub-threshold exclusion, and sort order.

## Test Plan
- [ ] `pytest test_server.py` passes (58 tests).
- [ ] `GET /api/action_queue` on a fresh DB returns `[]` with status 200.
- [ ] Insert a `blocked` event for a project — item appears with `reason: stuck_label`.
- [ ] Insert an old `in-progress` event with `HANDLER_TIMEOUT=100` — item appears with `reason: timeout`.
- [ ] Frontend tab shows the table; badge updates with the count; filters narrow the list; clicking a column header sorts.