### PR TITLE
[LM-50] Per-project PR monitor view

### DIFF
--- a/server/routes/runs.py
+++ b/server/routes/runs.py
@@ -1,8 +1,42 @@
+import json
+from datetime import datetime, timezone
+from typing import Optional
+
 from fastapi import APIRouter
 
+from server.constants import PROJECTS
 from server.db import get_db
+from server.helpers.timeline import parse_ts
 
 router = APIRouter()
+
+
+STAGE_MAP = {
+    "dev_start": "in-development",
+    "dev_done": "dev-complete",
+    "dev_failed": "dev-failed",
+    "review_start": "in-review",
+    "review_done": "review-complete",
+    "review_failed": "review-failed",
+    "rework_start": "needs-rework",
+    "rework_done": "rework-complete",
+    "rework_failed": "rework-failed",
+    "qa_start": "in-qa",
+    "qa_pass": "qa-passed",
+    "qa_done": "qa-complete",
+    "merge_start": "merging",
+    "merge_done": "merged",
+    "po_start": "in-po",
+    "po_done": "po-approved",
+    "po_failed": "po-failed",
+    "finished": "finished",
+}
+
+
+def _derive_stage(event_type: Optional[str]) -> Optional[str]:
+    if not event_type:
+        return None
+    return STAGE_MAP.get(event_type, event_type)
 
 
 @router.get("/api/history/{project}/{issue}")
@@ -53,3 +87,70 @@ def get_runs_by_project(project: str):
     ).fetchall()
     conn.close()
     return [dict(r) for r in rows]
+
+
+@router.get("/api/projects/{slug}/prs")
+def get_project_prs(slug: str, include_finished: bool = False):
+    """PR monitor: every PR seen by the pipeline with current stage and time-in-stage."""
+    conn = get_db()
+    finished_clause = "" if include_finished else " AND outcome IS NULL"
+    runs = conn.execute(
+        f"""SELECT issue_number, pr_number, title, outcome, completed_at, rework_count
+           FROM pipeline_runs
+           WHERE project=? AND pr_number IS NOT NULL{finished_clause}
+           ORDER BY id DESC""",
+        (slug,),
+    ).fetchall()
+
+    repo = PROJECTS.get(slug)
+    now = datetime.now(timezone.utc)
+    result = []
+    for run in runs:
+        last_event = conn.execute(
+            """SELECT event_type, created_at, payload FROM events
+               WHERE project=? AND (issue_number=? OR pr_number=?)
+               ORDER BY id DESC LIMIT 1""",
+            (slug, run["issue_number"], run["pr_number"]),
+        ).fetchone()
+
+        stage = None
+        last_event_type = None
+        last_event_at = None
+        time_in_stage = None
+        branch = None
+        is_draft = None
+        if last_event:
+            last_event_type = last_event["event_type"]
+            last_event_at = last_event["created_at"]
+            stage = _derive_stage(last_event_type)
+            ts = parse_ts(last_event_at)
+            if ts is not None:
+                time_in_stage = int((now - ts).total_seconds())
+            if last_event["payload"]:
+                try:
+                    p = json.loads(last_event["payload"])
+                    if isinstance(p, dict):
+                        branch = p.get("branch")
+                        if "draft" in p:
+                            is_draft = bool(p.get("draft"))
+                except Exception:
+                    pass
+
+        github_url = f"https://github.com/{repo}/pull/{run['pr_number']}" if repo else None
+
+        result.append({
+            "pr_number": run["pr_number"],
+            "title": run["title"],
+            "branch": branch,
+            "stage": stage,
+            "time_in_stage_seconds": time_in_stage,
+            "retry_count": run["rework_count"] or 0,
+            "last_event": last_event_type,
+            "last_event_at": last_event_at,
+            "github_url": github_url,
+            "is_finished": run["outcome"] is not None,
+            "is_draft": is_draft,
+        })
+
+    conn.close()
+    return result

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -848,3 +848,37 @@ a.gh-link:hover { text-decoration: underline; }
   color: var(--red);
   border: 1px solid #4a1a1a;
 }
+
+.stage-badge {
+  display: inline-block;
+  font-size: 0.68rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: var(--surface2);
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+.pr-time-red    { color: var(--red);    font-weight: 600; }
+.pr-time-yellow { color: #d4a017;       font-weight: 600; }
+.pr-time-fresh  { color: var(--muted); }
+.pr-draft-badge {
+  display: inline-block;
+  font-size: 0.6rem;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--surface2);
+  color: var(--muted);
+  border: 1px solid var(--border);
+  margin-left: 4px;
+}
+.pr-finished-badge {
+  display: inline-block;
+  font-size: 0.6rem;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: #0d2c1a;
+  color: var(--green);
+  border: 1px solid #1a4a2a;
+  margin-left: 4px;
+}

--- a/static/index.html
+++ b/static/index.html
@@ -205,6 +205,38 @@
       </tbody>
     </table>
   </div>
+
+  <div class="pr-monitor-wrap" style="margin-top:24px">
+    <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:8px;">
+      <span class="section-title" style="margin-bottom:0;font-size:0.85rem">PR Monitor</span>
+      <div style="display:flex;gap:8px;align-items:center;">
+        <select id="pr-stage-filter" style="background:var(--surface2);border:1px solid var(--border);color:var(--text);font-size:0.7rem;padding:2px 6px;border-radius:4px;cursor:pointer;">
+          <option value="">All stages</option>
+        </select>
+        <select id="pr-sort" style="background:var(--surface2);border:1px solid var(--border);color:var(--text);font-size:0.7rem;padding:2px 6px;border-radius:4px;cursor:pointer;">
+          <option value="age">Sort: oldest first</option>
+          <option value="age-desc">Sort: newest first</option>
+          <option value="stage">Sort: stage</option>
+        </select>
+        <label style="font-size:0.7rem;color:var(--muted);display:flex;gap:4px;align-items:center;cursor:pointer">
+          <input type="checkbox" id="pr-include-finished" /> Include finished
+        </label>
+      </div>
+    </div>
+    <div class="runs-table-wrap">
+      <table class="runs-table">
+        <thead>
+          <tr>
+            <th>PR</th><th>Title</th><th>Stage</th><th>Time in stage</th>
+            <th>Retries</th><th>Last event</th><th></th>
+          </tr>
+        </thead>
+        <tbody id="pr-monitor-body">
+          <tr><td colspan="7" class="empty-state">Loading…</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
 </section>
 
 <div id="graph-tooltip"></div>

--- a/static/js/components/runs.js
+++ b/static/js/components/runs.js
@@ -10,6 +10,9 @@ const mainEl        = document.querySelector('main');
 const chartsEl      = document.getElementById('charts-section');
 const eventsGraphEl = document.getElementById('events-graph-section');
 
+let currentProject = null;
+let prMonitorInterval = null;
+
 export function showProjectPanel(project) {
   document.getElementById('project-panel-title').textContent = project + ' — Run History';
   document.getElementById('runs-table-body').innerHTML =
@@ -22,6 +25,7 @@ export function showProjectPanel(project) {
 
   history.pushState(null, '', '#project/' + encodeURIComponent(project));
 
+  currentProject = project;
   fetch('/api/runs/' + encodeURIComponent(project))
     .then(r => r.ok ? r.json() : Promise.reject(r.status))
     .then(rows => renderRunsTable(project, rows))
@@ -29,6 +33,12 @@ export function showProjectPanel(project) {
       document.getElementById('runs-table-body').innerHTML =
         '<tr><td colspan="6" style="color:var(--red);text-align:center;padding:16px">Failed to load runs</td></tr>';
     });
+
+  loadPrMonitor(project);
+  if (prMonitorInterval) clearInterval(prMonitorInterval);
+  prMonitorInterval = setInterval(() => {
+    if (currentProject) loadPrMonitor(currentProject);
+  }, 60000);
 }
 
 export function showHome() {
@@ -36,6 +46,90 @@ export function showHome() {
   mainEl.style.display        = '';
   chartsEl.style.display      = '';
   eventsGraphEl.style.display = eventsGraphVisible ? '' : 'none';
+  currentProject = null;
+  if (prMonitorInterval) {
+    clearInterval(prMonitorInterval);
+    prMonitorInterval = null;
+  }
+}
+
+let prMonitorRows = [];
+
+function loadPrMonitor(project) {
+  const includeFinished = document.getElementById('pr-include-finished')?.checked ? 'true' : 'false';
+  fetch(`/api/projects/${encodeURIComponent(project)}/prs?include_finished=${includeFinished}`)
+    .then(r => r.ok ? r.json() : Promise.reject(r.status))
+    .then(rows => {
+      prMonitorRows = rows;
+      populateStageFilter(rows);
+      renderPrMonitor();
+    })
+    .catch(() => {
+      const tbody = document.getElementById('pr-monitor-body');
+      if (tbody) tbody.innerHTML =
+        '<tr><td colspan="7" style="color:var(--red);text-align:center;padding:16px">Failed to load PRs</td></tr>';
+    });
+}
+
+function populateStageFilter(rows) {
+  const sel = document.getElementById('pr-stage-filter');
+  if (!sel) return;
+  const current = sel.value;
+  const stages = Array.from(new Set(rows.map(r => r.stage).filter(Boolean))).sort();
+  const opts = ['<option value="">All stages</option>']
+    .concat(stages.map(s => `<option value="${escHtml(s)}">${escHtml(s)}</option>`));
+  sel.innerHTML = opts.join('');
+  if (stages.includes(current)) sel.value = current;
+}
+
+function timeBadgeClass(secs) {
+  if (secs == null) return '';
+  if (secs > 86400) return 'pr-time-red';
+  if (secs > 21600) return 'pr-time-yellow';
+  return 'pr-time-fresh';
+}
+
+function renderPrMonitor() {
+  const tbody = document.getElementById('pr-monitor-body');
+  if (!tbody) return;
+  const stageFilter = document.getElementById('pr-stage-filter')?.value || '';
+  const sortMode    = document.getElementById('pr-sort')?.value || 'age';
+
+  let rows = prMonitorRows.slice();
+  if (stageFilter) rows = rows.filter(r => r.stage === stageFilter);
+
+  rows.sort((a, b) => {
+    if (sortMode === 'stage') return (a.stage || '').localeCompare(b.stage || '');
+    const av = a.time_in_stage_seconds ?? -1;
+    const bv = b.time_in_stage_seconds ?? -1;
+    return sortMode === 'age-desc' ? av - bv : bv - av;
+  });
+
+  if (!rows.length) {
+    tbody.innerHTML = '<tr><td colspan="7" class="empty-state">No PRs tracked yet</td></tr>';
+    return;
+  }
+
+  tbody.innerHTML = rows.map(r => {
+    const cls   = timeBadgeClass(r.time_in_stage_seconds);
+    const time  = r.time_in_stage_seconds != null ? fmtDur(r.time_in_stage_seconds) : '—';
+    const stage = r.stage || '—';
+    const draft = r.is_draft ? ' <span class="pr-draft-badge">draft</span>' : '';
+    const branch = r.branch ? `<div style="color:var(--muted);font-size:0.7rem">${escHtml(r.branch)}</div>` : '';
+    const finishedBadge = r.is_finished ? ' <span class="pr-finished-badge">done</span>' : '';
+    const link  = r.github_url
+      ? `<a href="${escHtml(r.github_url)}" target="_blank" rel="noopener" style="color:var(--muted);font-size:0.75rem">↗</a>`
+      : '';
+    return `<tr>
+      <td>#${r.pr_number}${draft}${finishedBadge}</td>
+      <td>${escHtml(r.title || '')}${branch}</td>
+      <td><span class="stage-badge stage-${escHtml((stage).replace(/[^a-z0-9-]/gi,''))}">${escHtml(stage)}</span></td>
+      <td class="${cls}">${escHtml(time)}</td>
+      <td style="text-align:center">${r.retry_count || 0}</td>
+      <td style="color:var(--muted);font-size:0.75rem">${escHtml(r.last_event || '—')}</td>
+      <td>${link}</td>
+    </tr>`;
+  }).join('');
 }
 
 export function openDrawer(project, issue, pr) {
@@ -280,6 +374,15 @@ export function checkHash() {
 }
 
 export function initRunsPanel() {
+  const stageFilter = document.getElementById('pr-stage-filter');
+  const sortSel     = document.getElementById('pr-sort');
+  const incFinished = document.getElementById('pr-include-finished');
+  if (stageFilter) stageFilter.addEventListener('change', renderPrMonitor);
+  if (sortSel)     sortSel.addEventListener('change', renderPrMonitor);
+  if (incFinished) incFinished.addEventListener('change', () => {
+    if (currentProject) loadPrMonitor(currentProject);
+  });
+
   document.getElementById('project-panel-back').addEventListener('click', () => {
     history.pushState(null, '', window.location.pathname + window.location.search);
     showHome();

--- a/test_server.py
+++ b/test_server.py
@@ -791,6 +791,14 @@ def test_action_queue_empty(isolated_client):
     assert resp.json() == []
 
 
+# ── PR monitor (/api/projects/{slug}/prs) ──
+
+def test_prs_unknown_slug_returns_empty(isolated_client):
+    resp = isolated_client.get("/api/projects/no-such-project/prs")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
 def test_action_queue_blocked_label(isolated_client):
     server._insert_event(server.ReportPayload(
         project="boba-event", role="dev", event_type="blocked", issue_number=42,
@@ -898,3 +906,55 @@ def test_concurrent_reports_both_persisted():
     feed = client.get("/api/feed").json()
     roles = {e["role"] for e in feed if e["project"] == project}
     assert {"builder", "reviewer"}.issubset(roles)
+
+
+def test_prs_lists_open_pipeline_runs(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="ppl", role="dev", event_type="dev_start",
+        issue_number=101, pr_number=201,
+    ))
+    server._insert_event(server.ReportPayload(
+        project="ppl", role="reviewer", event_type="rework_start",
+        issue_number=101, pr_number=201,
+    ))
+    resp = isolated_client.get("/api/projects/ppl/prs")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    pr = data[0]
+    assert pr["pr_number"] == 201
+    assert pr["last_event"] == "rework_start"
+    assert pr["stage"] == "needs-rework"
+    assert pr["is_finished"] is False
+    assert pr["github_url"].endswith("/pull/201")
+    assert pr["time_in_stage_seconds"] is not None
+    assert pr["retry_count"] == 0
+
+
+def test_prs_excludes_finished_by_default(isolated_client):
+    # Open PR
+    server._insert_event(server.ReportPayload(
+        project="ppl", role="dev", event_type="dev_start",
+        issue_number=110, pr_number=210,
+    ))
+    # Closed PR (outcome set via finished event)
+    server._insert_event(server.ReportPayload(
+        project="ppl", role="dev", event_type="dev_start",
+        issue_number=111, pr_number=211,
+    ))
+    server._insert_event(server.ReportPayload(
+        project="ppl", role="merge", event_type="finished",
+        issue_number=111, pr_number=211, detail="merged",
+    ))
+
+    open_only = isolated_client.get("/api/projects/ppl/prs").json()
+    pr_nums = {p["pr_number"] for p in open_only}
+    assert 210 in pr_nums
+    assert 211 not in pr_nums
+
+    all_prs = isolated_client.get("/api/projects/ppl/prs?include_finished=true").json()
+    pr_nums_all = {p["pr_number"] for p in all_prs}
+    assert 210 in pr_nums_all
+    assert 211 in pr_nums_all
+    finished_pr = next(p for p in all_prs if p["pr_number"] == 211)
+    assert finished_pr["is_finished"] is True


### PR DESCRIPTION
Closes #50

## Changes
- New endpoint `GET /api/projects/{slug}/prs` returns a per-project PR monitor list derived from `pipeline_runs` joined with the most recent matching event. No live GitHub API calls.
- Each row exposes `pr_number`, `title`, `branch`, `stage` (mapped from event_type, e.g. `rework_start`→`needs-rework`), `time_in_stage_seconds`, `retry_count`, `last_event`, `last_event_at`, `github_url`, `is_finished`, `is_draft`.
- `branch` and `is_draft` are pulled from event payload when present; otherwise null.
- `is_finished` derives from `pipeline_runs.outcome IS NOT NULL`. Defaults to open PRs only; `?include_finished=true` includes closed/merged.
- Unknown slug returns `[]` (not 500).
- Frontend: PR Monitor table in the per-project drill-down (#22) view, with stage filter, sort by age/stage, and color-coded time-in-stage (>24h red, >6h yellow). Refreshes every 60s while panel is open.
- Tests cover the populated endpoint, unknown slug, and finished filter behavior.

## Test Plan
- [ ] `pytest test_server.py` passes (55 tests, including 3 new PR-monitor cases).
- [ ] Open the dashboard, click into a project. The new "PR Monitor" table renders below the run history.
- [ ] Toggle "Include finished" — closed/merged PRs appear with the `done` badge.
- [ ] Stage filter restricts the visible rows; sort dropdown reorders by age or stage.
- [ ] Time-in-stage cell is red for entries older than 24h, yellow for >6h.
- [ ] GitHub link in the last column opens the PR.