### PR TITLE
[LM-96] Add terminal dashboard script

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,17 @@ Wire it into your Loop core startup or a cron job:
 LOOP_ROOT=/path/to/loop ./scripts/check-version.sh
 ```
 
+### `scripts/dashboard.py` — terminal dashboard
+
+Stdlib-only TUI that polls `/api/active`, `/api/board`, and `/api/feed` and renders Active Workers, Project Status, and the last 5 feed events. Refreshes in place every `--interval` seconds (default 10); `Ctrl+C` exits cleanly. Use `--once` for a single snapshot suitable for piping or screenshots.
+
+```bash
+python3 scripts/dashboard.py                       # live, refresh every 10s
+python3 scripts/dashboard.py --interval 5          # custom refresh
+python3 scripts/dashboard.py --once                # one snapshot, exit 0
+python3 scripts/dashboard.py --url http://host:18792 --once
+```
+
 ## Security
 
 loop-monitor is **designed to bind to `127.0.0.1`**. The bounty event

--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Terminal dashboard for Loop Monitor — stdlib-only TUI over the local REST API."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any
+
+DEFAULT_URL = "http://127.0.0.1:18792"
+DEFAULT_INTERVAL = 10
+HTTP_TIMEOUT = 5
+CLEAR = "\x1b[2J\x1b[H"
+
+
+def fetch_json(base_url: str, path: str) -> Any:
+    url = base_url.rstrip("/") + path
+    with urllib.request.urlopen(url, timeout=HTTP_TIMEOUT) as resp:
+        if resp.status != 200:
+            raise urllib.error.HTTPError(url, resp.status, "non-200", resp.headers, None)
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _truncate(s: str, n: int) -> str:
+    s = s or ""
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def _since(row: dict) -> str:
+    age = row.get("age_seconds")
+    if age is None:
+        created = row.get("created_at")
+        if not created:
+            return "?"
+        try:
+            dt = datetime.fromisoformat(str(created).replace(" ", "T"))
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            age = int((datetime.now(timezone.utc) - dt).total_seconds())
+        except Exception:
+            return "?"
+    age = int(age)
+    if age < 60:
+        return f"{age}s"
+    if age < 3600:
+        return f"{age // 60}m"
+    if age < 86400:
+        return f"{age // 3600}h"
+    return f"{age // 86400}d"
+
+
+def format_active(rows: list[dict]) -> str:
+    header = "ACTIVE WORKERS"
+    if not rows:
+        return f"{header}\n  No active workers."
+    lines = [header]
+    lines.append(f"  {'PROJECT':<18} {'ROLE':<10} {'MODEL':<14} {'EVENT':<18} {'TASK':<10} SINCE")
+    for r in rows:
+        task = ""
+        if r.get("issue_number"):
+            task = f"#{r['issue_number']}"
+        elif r.get("pr_number"):
+            task = f"PR{r['pr_number']}"
+        lines.append(
+            f"  {_truncate(r.get('project',''), 18):<18} "
+            f"{_truncate(r.get('role',''), 10):<10} "
+            f"{_truncate(r.get('model','') or '', 14):<14} "
+            f"{_truncate(r.get('event_type',''), 18):<18} "
+            f"{_truncate(task, 10):<10} "
+            f"{_since(r)}"
+        )
+    return "\n".join(lines)
+
+
+def format_board(rows: list[dict]) -> str:
+    header = "PROJECT STATUS"
+    if not rows:
+        return f"{header}\n  No project scores yet."
+    lines = [header]
+    lines.append(f"  {'PROJECT':<18} {'ROLE':<10} {'MODEL':<14} {'PTS':>6} {'VERDICTS':>9}")
+    for r in rows:
+        lines.append(
+            f"  {_truncate(r.get('project',''), 18):<18} "
+            f"{_truncate(r.get('role',''), 10):<10} "
+            f"{_truncate(r.get('model','') or '', 14):<14} "
+            f"{int(r.get('total_points') or 0):>6} "
+            f"{int(r.get('verdict_count') or 0):>9}"
+        )
+    return "\n".join(lines)
+
+
+def format_feed(rows: list[dict], limit: int = 5) -> str:
+    header = "RECENT FEED"
+    if not rows:
+        return f"{header}\n  No recent events."
+    lines = [header]
+    for r in rows[:limit]:
+        target = ""
+        if r.get("issue_number"):
+            target = f" #{r['issue_number']}"
+        elif r.get("pr_number"):
+            target = f" PR{r['pr_number']}"
+        detail = r.get("detail") or ""
+        status = r.get("status") or ""
+        lines.append(
+            f"  [{_since(r):>4}] "
+            f"{_truncate(r.get('project',''), 14):<14} "
+            f"{_truncate(r.get('role',''), 8):<8} "
+            f"{_truncate(r.get('event_type',''), 18):<18}"
+            f"{target}"
+            f"{(' — ' + _truncate(detail, 50)) if detail else ''}"
+            f"{(' [' + status + ']') if status else ''}"
+        )
+    return "\n".join(lines)
+
+
+def render_snapshot(base_url: str) -> str:
+    active = fetch_json(base_url, "/api/active")
+    board = fetch_json(base_url, "/api/board")
+    feed = fetch_json(base_url, "/api/feed")
+    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    parts = [
+        f"LOOP MONITOR — {base_url}   {now}",
+        "",
+        format_active(active or []),
+        "",
+        format_board(board or []),
+        "",
+        format_feed(feed or [], limit=5),
+    ]
+    return "\n".join(parts)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Terminal dashboard for Loop Monitor.")
+    parser.add_argument("--url", default=DEFAULT_URL, help=f"API base URL (default: {DEFAULT_URL})")
+    parser.add_argument("--interval", type=float, default=DEFAULT_INTERVAL,
+                        help=f"refresh interval in seconds (default: {DEFAULT_INTERVAL})")
+    parser.add_argument("--once", action="store_true",
+                        help="print one snapshot and exit")
+    args = parser.parse_args(argv)
+
+    if args.once:
+        try:
+            print(render_snapshot(args.url))
+            return 0
+        except (urllib.error.URLError, urllib.error.HTTPError, ConnectionError, OSError) as e:
+            print(f"loop-monitor unreachable at {args.url}: {e}", file=sys.stderr)
+            return 1
+
+    try:
+        while True:
+            try:
+                snapshot = render_snapshot(args.url)
+                sys.stdout.write(CLEAR + snapshot + "\n")
+                sys.stdout.flush()
+            except (urllib.error.URLError, urllib.error.HTTPError, ConnectionError, OSError) as e:
+                print(f"loop-monitor unreachable at {args.url}: {e}", file=sys.stderr)
+            time.sleep(args.interval)
+    except KeyboardInterrupt:
+        print("dashboard exited.", file=sys.stderr)
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,100 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scripts.dashboard import format_active, format_board, format_feed, _since
+
+
+def test_format_active_empty():
+    out = format_active([])
+    assert "ACTIVE WORKERS" in out
+    assert "No active workers." in out
+
+
+def test_format_active_rows():
+    rows = [
+        {"project": "loop-monitor", "role": "builder", "model": "sonnet",
+         "event_type": "dev_start", "issue_number": 42, "pr_number": None,
+         "detail": "working", "created_at": "2026-04-30T12:00:00+00:00"},
+    ]
+    out = format_active(rows)
+    assert "loop-monitor" in out
+    assert "builder" in out
+    assert "dev_start" in out
+    assert "#42" in out
+
+
+def test_format_active_handles_missing_fields():
+    rows = [{"project": "p", "role": "r"}]  # no event_type, model, ids, etc.
+    out = format_active(rows)
+    assert "p" in out
+    assert "r" in out
+
+
+def test_format_board_empty():
+    out = format_board([])
+    assert "PROJECT STATUS" in out
+    assert "No project scores yet." in out
+
+
+def test_format_board_rows():
+    rows = [
+        {"project": "loop-monitor", "role": "builder", "model": "sonnet",
+         "total_points": 185, "verdict_count": 7},
+    ]
+    out = format_board(rows)
+    assert "185" in out
+    assert "7" in out
+
+
+def test_format_board_handles_none_points():
+    rows = [{"project": "p", "role": "r", "model": None,
+             "total_points": None, "verdict_count": None}]
+    out = format_board(rows)
+    assert "p" in out
+    assert "0" in out
+
+
+def test_format_feed_empty():
+    out = format_feed([])
+    assert "RECENT FEED" in out
+    assert "No recent events." in out
+
+
+def test_format_feed_rows_truncates_to_limit():
+    rows = [
+        {"project": f"p{i}", "role": "builder", "event_type": "dev_done",
+         "issue_number": i, "detail": "ok", "age_seconds": i, "status": "done"}
+        for i in range(10)
+    ]
+    out = format_feed(rows, limit=5)
+    # 1 header + 5 rows
+    assert len(out.splitlines()) == 6
+    assert "p0" in out
+    assert "p4" in out
+    assert "p5" not in out
+
+
+def test_format_feed_uses_age_seconds():
+    rows = [{"project": "p", "role": "r", "event_type": "x_done",
+             "age_seconds": 90, "status": "done"}]
+    out = format_feed(rows)
+    assert "1m" in out
+
+
+def test_since_seconds_minutes_hours_days():
+    assert _since({"age_seconds": 5}) == "5s"
+    assert _since({"age_seconds": 120}) == "2m"
+    assert _since({"age_seconds": 3700}) == "1h"
+    assert _since({"age_seconds": 90000}) == "1d"
+
+
+def test_since_unknown():
+    assert _since({}) == "?"
+
+
+def test_since_falls_back_to_created_at():
+    # any valid ISO timestamp parses without crashing
+    out = _since({"created_at": "2026-04-30T12:00:00+00:00"})
+    assert out and out != "?"

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,9 +1,4 @@
-import os
-import sys
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-
-from scripts.dashboard import format_active, format_board, format_feed, _since
+from scripts.dashboard import _since, format_active, format_board, format_feed
 
 
 def test_format_active_empty():


### PR DESCRIPTION
Closes #96

## Changes
- New `scripts/dashboard.py`: stdlib-only TUI that polls `/api/active`, `/api/board`, `/api/feed` and renders three sections (Active Workers, Project Status, Recent Feed last 5 events).
- Live mode refreshes in place every `--interval` seconds (default 10) using `\x1b[2J\x1b[H`. `Ctrl+C` prints "dashboard exited." to stderr and exits 0.
- `--once` flag prints one snapshot and exits (0 on success, 1 on HTTP failure).
- HTTP failures in live mode print one line to stderr and retry on the next tick; `--url` overrides the base URL (default `http://127.0.0.1:18792`); `urlopen` uses a 5s timeout.
- Pure renderers `format_active`, `format_board`, `format_feed` for unit-testability; `_since` uses `age_seconds` from `/api/feed`, falling back to parsing `created_at`.
- New `tests/test_dashboard.py` covers empty-state rendering, populated rows, missing-field tolerance, feed limit, and `_since` unit conversions.
- README: added one-paragraph "Terminal Dashboard" section under Scripts with `--once` example.
- No changes to `server.py`, `static/`, `requirements.txt`, or `run.sh`.

## Test Plan
- `python3 -m pytest tests/test_dashboard.py -q` — 12 tests pass.
- `python3 scripts/dashboard.py --once --url http://127.0.0.1:1` — exits 1 with one-line stderr error (verified).
- Run `./run.sh` and `python3 scripts/dashboard.py --once` — confirm three sections render with current data.
- Run `python3 scripts/dashboard.py --interval 2` — confirm in-place redraw, then `Ctrl+C` prints "dashboard exited." and exits 0.
- Stop the server while live mode runs — confirm error line appears each tick and recovers when server is back up.