### PR TITLE
[LM-39] enable WAL mode, busy_timeout, and OperationalError logging

### DIFF
--- a/server/db.py
+++ b/server/db.py
@@ -141,4 +141,6 @@ def apply_pending_migrations():
 def get_db():
     conn = sqlite3.connect(DB_PATH)
     conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=10000")
     return conn

--- a/server/routes/ingest.py
+++ b/server/routes/ingest.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import sqlite3
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException
@@ -14,6 +15,16 @@ logger = logging.getLogger(__name__)
 
 
 def _insert_event(data: ReportPayload):
+    try:
+        _do_insert_event(data)
+    except sqlite3.OperationalError as e:
+        logger.error(
+            "Failed to persist event (project=%s role=%s event_type=%s): %s",
+            data.project, data.role, data.event_type, e,
+        )
+
+
+def _do_insert_event(data: ReportPayload):
     conn = get_db()
     now = datetime.now(timezone.utc).isoformat()
     conn.execute(
@@ -120,6 +131,16 @@ def _insert_event(data: ReportPayload):
 
 
 def _insert_verdict(data: VerdictPayload):
+    try:
+        _do_insert_verdict(data)
+    except sqlite3.OperationalError as e:
+        logger.error(
+            "Failed to persist verdict (project=%s role=%s points=%s): %s",
+            data.project, data.role, data.points, e,
+        )
+
+
+def _do_insert_verdict(data: VerdictPayload):
     conn = get_db()
     now = datetime.now(timezone.utc).isoformat()
     conn.execute(

--- a/test_server.py
+++ b/test_server.py
@@ -889,8 +889,10 @@ def test_concurrent_reports_both_persisted():
 
     t1 = threading.Thread(target=fire, args=("builder",))
     t2 = threading.Thread(target=fire, args=("reviewer",))
-    t1.start(); t2.start()
-    t1.join(); t2.join()
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
 
     assert sorted(results) == [202, 202]
     feed = client.get("/api/feed").json()

--- a/test_server.py
+++ b/test_server.py
@@ -867,3 +867,32 @@ def test_action_queue_sorted_by_age_desc(isolated_client, monkeypatch):
     data = resp.json()
     nums = [it["number"] for it in data if it["number"] in (200, 201)]
     assert nums == [200, 201]
+
+
+def test_concurrent_reports_both_persisted():
+    """Concurrent POST /api/report writes must both persist (WAL + busy_timeout)."""
+    import threading
+
+    project = "proj-concurrent"
+    results: list[int] = []
+    lock = threading.Lock()
+
+    def fire(role: str):
+        resp = client.post("/api/report", json={
+            "project": project,
+            "role": role,
+            "model": "claude-3",
+            "event_type": "started",
+        })
+        with lock:
+            results.append(resp.status_code)
+
+    t1 = threading.Thread(target=fire, args=("builder",))
+    t2 = threading.Thread(target=fire, args=("reviewer",))
+    t1.start(); t2.start()
+    t1.join(); t2.join()
+
+    assert sorted(results) == [202, 202]
+    feed = client.get("/api/feed").json()
+    roles = {e["role"] for e in feed if e["project"] == project}
+    assert {"builder", "reviewer"}.issubset(roles)


### PR DESCRIPTION
Closes #39

Re-opens the work from closed PR #45, freshly applied to current `main` after the `server.py` split refactor (#78) landed. PR #45 became unrebaseable because `server.py` was deleted in favor of the `server/` package.

## Changes

### `server/db.py`
- `get_db()` now sets `PRAGMA journal_mode=WAL` and `PRAGMA busy_timeout=10000` on every new connection. WAL lets a writer coexist with concurrent readers; the 10 s busy timeout replaces SQLite's default 5 s wait.

### `server/routes/ingest.py`
- `_insert_event` and `_insert_verdict` are now thin wrappers around the original logic (`_do_insert_event`, `_do_insert_verdict`) wrapped in `try/except sqlite3.OperationalError`. On failure, the error is logged via the module logger instead of being silently swallowed by FastAPI's `BackgroundTasks`.

### `test_server.py`
- Added `test_concurrent_reports_both_persisted`: fires two simultaneous `POST /api/report` requests from separate threads and asserts both return 202 and both events appear in `/api/feed`.

## Test plan

- [x] `pytest test_server.py tests/` — 78 passed
- [x] New concurrent-write test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)