### PR TITLE
[LM-55] add /api/claude_usage endpoint with env-var config and cached Anthropic source

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -18,6 +18,7 @@ app = FastAPI(title="Loop Monitor", lifespan=lifespan)
 from server.routes import (  # noqa: E402
     action_queue,
     board,
+    claude_usage,
     feed,
     graph,
     health,
@@ -34,6 +35,7 @@ app.include_router(runs.router)
 app.include_router(stats.router)
 app.include_router(graph.router)
 app.include_router(action_queue.router)
+app.include_router(claude_usage.router)
 
 app.mount("/", StaticFiles(directory="static", html=True), name="static")
 

--- a/server/routes/claude_usage.py
+++ b/server/routes/claude_usage.py
@@ -1,0 +1,102 @@
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+ANTHROPIC_USAGE_URL = "https://api.anthropic.com/v1/organizations/usage_report/messages"
+
+_cache: dict = {"data": None, "fetched_at": None}
+
+
+def _refresh_seconds() -> int:
+    try:
+        return max(1, int(os.environ.get("CLAUDE_USAGE_REFRESH_SECONDS", "300")))
+    except ValueError:
+        return 300
+
+
+def _enabled() -> bool:
+    return os.environ.get("CLAUDE_USAGE_ENABLED", "").lower() in ("1", "true", "yes")
+
+
+def _fetch_upstream(api_key: str) -> dict:
+    """Hit the Anthropic admin usage endpoint. Raises on transport / HTTP failure."""
+    req = urllib.request.Request(
+        ANTHROPIC_USAGE_URL,
+        headers={
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+            "accept": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _shape(payload: dict) -> dict:
+    """Normalize Anthropic admin usage payload into the dashboard contract."""
+    quota_used = payload.get("quota_used") or payload.get("input_tokens", 0) or 0
+    quota_limit = payload.get("quota_limit")
+    quota_pct = None
+    if quota_limit:
+        quota_pct = round(100.0 * quota_used / quota_limit, 2)
+    cache_hit_pct = payload.get("cache_hit_pct")
+    if cache_hit_pct is None:
+        cr = payload.get("cache_read_input_tokens")
+        ci = payload.get("input_tokens")
+        if cr is not None and ci:
+            cache_hit_pct = round(100.0 * cr / (cr + ci), 2)
+    return {
+        "enabled": True,
+        "quota_used": quota_used,
+        "quota_limit": quota_limit,
+        "quota_pct": quota_pct,
+        "reset_at": payload.get("reset_at"),
+        "cache_hit_pct": cache_hit_pct,
+    }
+
+
+def _cache_fresh() -> bool:
+    fetched: Optional[datetime] = _cache["fetched_at"]
+    if fetched is None or _cache["data"] is None:
+        return False
+    age = (datetime.now(timezone.utc) - fetched).total_seconds()
+    return age < _refresh_seconds()
+
+
+@router.get("/api/claude_usage")
+def get_claude_usage():
+    if not _enabled():
+        return {"enabled": False}
+
+    if _cache_fresh():
+        return _cache["data"]
+
+    api_key = os.environ.get("ANTHROPIC_ADMIN_KEY")
+    if not api_key:
+        return {"enabled": True, "error": "ANTHROPIC_ADMIN_KEY not set"}
+
+    try:
+        payload = _fetch_upstream(api_key)
+        data = _shape(payload)
+    except urllib.error.HTTPError as e:
+        logger.warning("Anthropic usage HTTP %s", e.code)
+        return {"enabled": True, "error": f"upstream HTTP {e.code}"}
+    except urllib.error.URLError as e:
+        logger.warning("Anthropic usage network error: %s", e.reason)
+        return {"enabled": True, "error": "network error"}
+    except (json.JSONDecodeError, ValueError) as e:
+        logger.warning("Anthropic usage decode error: %s", e)
+        return {"enabled": True, "error": "invalid upstream payload"}
+
+    _cache["data"] = data
+    _cache["fetched_at"] = datetime.now(timezone.utc)
+    return data

--- a/tests/test_claude_usage.py
+++ b/tests/test_claude_usage.py
@@ -1,0 +1,72 @@
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+import server  # noqa: F401
+from server.app import app
+from server.routes import claude_usage
+
+client = TestClient(app)
+
+
+def _reset_cache():
+    claude_usage._cache["data"] = None
+    claude_usage._cache["fetched_at"] = None
+
+
+def test_disabled_returns_enabled_false(monkeypatch):
+    monkeypatch.delenv("CLAUDE_USAGE_ENABLED", raising=False)
+    _reset_cache()
+    resp = client.get("/api/claude_usage")
+    assert resp.status_code == 200
+    assert resp.json() == {"enabled": False}
+
+
+def test_enabled_without_key_returns_error(monkeypatch):
+    monkeypatch.setenv("CLAUDE_USAGE_ENABLED", "true")
+    monkeypatch.delenv("ANTHROPIC_ADMIN_KEY", raising=False)
+    _reset_cache()
+    resp = client.get("/api/claude_usage")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["enabled"] is True
+    assert "error" in body
+
+
+def test_enabled_with_key_returns_shaped_payload(monkeypatch):
+    monkeypatch.setenv("CLAUDE_USAGE_ENABLED", "true")
+    monkeypatch.setenv("ANTHROPIC_ADMIN_KEY", "sk-test")
+    _reset_cache()
+
+    fake_upstream = {
+        "quota_used": 250_000,
+        "quota_limit": 1_000_000,
+        "reset_at": "2026-05-02T00:00:00Z",
+        "cache_read_input_tokens": 30_000,
+        "input_tokens": 70_000,
+    }
+    with patch.object(claude_usage, "_fetch_upstream", return_value=fake_upstream):
+        resp = client.get("/api/claude_usage")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["enabled"] is True
+    assert body["quota_used"] == 250_000
+    assert body["quota_limit"] == 1_000_000
+    assert body["quota_pct"] == 25.0
+    assert body["reset_at"] == "2026-05-02T00:00:00Z"
+    assert body["cache_hit_pct"] == 30.0
+
+
+def test_cache_avoids_second_upstream_call(monkeypatch):
+    monkeypatch.setenv("CLAUDE_USAGE_ENABLED", "true")
+    monkeypatch.setenv("ANTHROPIC_ADMIN_KEY", "sk-test")
+    _reset_cache()
+
+    fake_upstream = {"quota_used": 1, "quota_limit": 10, "reset_at": "2026-05-02T00:00:00Z"}
+    with patch.object(
+        claude_usage, "_fetch_upstream", return_value=fake_upstream
+    ) as mocked:
+        client.get("/api/claude_usage")
+        client.get("/api/claude_usage")
+        assert mocked.call_count == 1


### PR DESCRIPTION
Closes #55. Replaces unrebaseable PR #75 (pre-dated the server/ package split).

## Changes
- `server/routes/claude_usage.py`: new module. Disabled by default (env `CLAUDE_USAGE_ENABLED`). When enabled + `ANTHROPIC_ADMIN_KEY` set, fetches Anthropic admin usage via stdlib urllib (no new deps), normalizes to `{quota_used, quota_limit, quota_pct, reset_at, cache_hit_pct}`. Module-level cache controlled by `CLAUDE_USAGE_REFRESH_SECONDS` (default 300). All upstream errors return `{enabled: true, error: ...}` — no 500.
- `server/app.py`: wires the new router.
- `tests/test_claude_usage.py`: 4 tests — disabled, missing-key, shaped-payload (mocked), cache-suppresses-second-call.

## Test plan
- pytest test_server.py tests/ — 81 passed
- ruff check clean for new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)