### PR TITLE
[LM-102] add git_sha to /api/health

### DIFF
--- a/server/routes/health.py
+++ b/server/routes/health.py
@@ -1,9 +1,31 @@
+import subprocess
+from pathlib import Path
+
 from fastapi import APIRouter
 
 from server.constants import MONITOR_VERSION, SUPPORTED_API_MAJOR
 from server.db import get_db
 
 router = APIRouter()
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _git_sha() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            cwd=_REPO_ROOT,
+        )
+    except Exception:
+        return "unknown"
+    if result.returncode != 0:
+        return "unknown"
+    sha = result.stdout.strip()
+    return sha or "unknown"
 
 
 @router.get("/api/health")
@@ -21,6 +43,7 @@ def health():
     return {
         "status": "ok",
         "monitor_version": MONITOR_VERSION,
+        "git_sha": _git_sha(),
         "supported_bounty_api": f"{SUPPORTED_API_MAJOR}.x",
         "core_version_counts": core_version_counts,
         "loop_ids": loop_ids,

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,3 +1,4 @@
+import re
 import time
 
 
@@ -80,6 +81,15 @@ def test_health_loop_ids_field(isolated_client):
     assert "loop_ids" in data
     assert "(unknown)" in data["loop_ids"]
     assert "loop-a" in data["loop_ids"]
+
+
+def test_health_git_sha_field(isolated_client):
+    resp = isolated_client.get("/api/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "git_sha" in data
+    sha = data["git_sha"]
+    assert sha == "unknown" or re.match(r"^[0-9a-f]{7}$", sha)
 
 
 def test_health_loop_ids_empty_db(isolated_client):


### PR DESCRIPTION
Closes #102

## Changes
- `server/routes/health.py`: add `_git_sha()` helper that runs `git rev-parse --short HEAD` from the repo root with a 2s timeout; falls back to `"unknown"` on any error, non-zero exit, or empty output. Include the result as `git_sha` in the `/api/health` response.
- `tests/test_health.py`: add `test_health_git_sha_field` asserting the field is present and either matches `^[0-9a-f]{7}$` or equals `"unknown"`.

No new dependencies; no caching (per spec).

## Test Plan
- [ ] `pytest tests/` passes (86/86 locally).
- [ ] `GET /api/health` includes `git_sha` matching the 7-char short SHA of HEAD in a git checkout.
- [ ] Outside a git checkout, `git_sha` is `"unknown"` rather than raising.