### PR TITLE
[LM-98] add Logs tab and /api/logs endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,29 @@ API has **no authentication**. Don't expose port 18792 to the network.
 If you need network exposure, terminate auth at a reverse proxy. See
 [SECURITY.md](SECURITY.md) for the full trust model.
 
+### Logs panel
+
+The dashboard ships a read-only **Logs** tab that tails handler log files
+from `${LOOP_LOG_DIR:-~/.openclaw/workspace/logs/loop}/loop-<handler>.log`
+(via `GET /api/logs`). It also surfaces an orphaned-FD warning when the
+on-disk file size diverges materially from a running handler's open FD
+(see svv2014/loop#194).
+
+By default the endpoint is **loopback-only**: requests from any host
+other than `127.0.0.1`/`::1` receive `403 {"error":"logs disabled"}`. To
+expose the panel (e.g. behind a Tailscale-fronted proxy), set:
+
+```bash
+LOOPMON_EXPOSE_LOGS=1
+```
+
+**Warning:** handler logs may contain `gh` tokens, agent stdout
+(including code snippets), and other potentially sensitive output.
+loop-monitor performs no secret stripping. If you enable
+`LOOPMON_EXPOSE_LOGS`, you are responsible for any exposure that
+results — terminate auth at a reverse proxy, restrict the network, or
+both.
+
 ## Development
 
 ```bash

--- a/server/app.py
+++ b/server/app.py
@@ -23,6 +23,7 @@ from server.routes import (  # noqa: E402
     graph,
     health,
     ingest,
+    logs,
     runs,
     stats,
 )
@@ -36,6 +37,7 @@ app.include_router(stats.router)
 app.include_router(graph.router)
 app.include_router(action_queue.router)
 app.include_router(claude_usage.router)
+app.include_router(logs.router)
 
 app.mount("/", StaticFiles(directory="static", html=True), name="static")
 

--- a/server/routes/logs.py
+++ b/server/routes/logs.py
@@ -1,0 +1,220 @@
+import logging
+import os
+import re
+import subprocess
+import sys
+from collections import deque
+from pathlib import Path
+from typing import Optional, Tuple
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import JSONResponse
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+ALLOWED_HANDLERS = {
+    "scanner",
+    "reconciler",
+    "po-handler",
+    "dev-handler",
+    "dev-rework-handler",
+    "review-handler",
+    "qa-handler",
+    "merge-handler",
+}
+
+MAX_TAIL_BYTES = 5 * 1024 * 1024  # 5 MiB
+ORPHAN_THRESHOLD = 1 * 1024 * 1024  # 1 MiB
+
+LOOPBACK_HOSTS = {"127.0.0.1", "::1", "localhost"}
+
+LINE_RE = re.compile(
+    r"^\[(?P<ts>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\] \[(?P<handler>[^\]]+)\] (?P<msg>.*)$"
+)
+
+
+def _exposed() -> bool:
+    return os.environ.get("LOOPMON_EXPOSE_LOGS", "").lower() in ("1", "true", "yes")
+
+
+def _log_dir() -> Path:
+    raw = os.environ.get("LOOP_LOG_DIR") or "~/.openclaw/workspace/logs/loop"
+    return Path(os.path.expanduser(raw))
+
+
+def _pid_for_handler(handler: str) -> Optional[int]:
+    try:
+        out = subprocess.run(
+            ["pgrep", "-f", handler],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if out.returncode != 0:
+            return None
+        for line in out.stdout.splitlines():
+            line = line.strip()
+            if line.isdigit():
+                return int(line)
+    except (subprocess.SubprocessError, OSError):
+        return None
+    return None
+
+
+def _fd_bytes_for_handler(handler: str, log_path: Path) -> Optional[int]:
+    """Return bytes that the running handler has buffered/written via FD to log_path.
+
+    Linux: scan /proc/<pid>/fd/* symlinks for one matching log_path; read fdinfo for pos.
+    macOS: lsof -p <pid> -F sn to find FD size.
+    Returns None on any failure.
+    """
+    pid = _pid_for_handler(handler)
+    if pid is None:
+        return None
+    try:
+        target = str(log_path.resolve())
+    except OSError:
+        target = str(log_path)
+
+    try:
+        if sys.platform.startswith("linux"):
+            fd_dir = Path(f"/proc/{pid}/fd")
+            if fd_dir.exists():
+                for fd_link in fd_dir.iterdir():
+                    try:
+                        resolved = os.readlink(str(fd_link))
+                    except OSError:
+                        continue
+                    if resolved == target or resolved.endswith(f"/loop-{handler}.log"):
+                        fdinfo = Path(f"/proc/{pid}/fdinfo/{fd_link.name}")
+                        try:
+                            with open(fdinfo, "r") as fh:
+                                for line in fh:
+                                    if line.startswith("pos:"):
+                                        return int(line.split()[1])
+                        except (OSError, ValueError):
+                            pass
+                        try:
+                            return os.stat(str(fd_link)).st_size
+                        except OSError:
+                            pass
+                return None
+        # macOS or fallback
+        out = subprocess.run(
+            ["lsof", "-p", str(pid), "-F", "sn"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if out.returncode != 0:
+            return None
+        cur_size: Optional[int] = None
+        for line in out.stdout.splitlines():
+            if not line:
+                continue
+            tag, val = line[0], line[1:]
+            if tag == "s":
+                try:
+                    cur_size = int(val)
+                except ValueError:
+                    cur_size = None
+            elif tag == "n":
+                if val.endswith(f"loop-{handler}.log"):
+                    if cur_size is not None:
+                        return cur_size
+        return None
+    except (subprocess.SubprocessError, OSError, ValueError):
+        return None
+
+
+def _orphan_status(handler: str, log_path: Path) -> Tuple[int, Optional[int], bool]:
+    try:
+        on_disk = os.stat(str(log_path)).st_size
+    except OSError:
+        on_disk = 0
+    fd_bytes = _fd_bytes_for_handler(handler, log_path)
+    if fd_bytes is None:
+        return on_disk, None, False
+    orphaned = abs(fd_bytes - on_disk) > ORPHAN_THRESHOLD
+    return on_disk, fd_bytes, orphaned
+
+
+def _tail_lines(path: Path, tail: str) -> list[str]:
+    if not path.exists():
+        return []
+    if tail == "all":
+        try:
+            size = os.stat(str(path)).st_size
+        except OSError:
+            return []
+        start = max(0, size - MAX_TAIL_BYTES)
+        with open(path, "rb") as fh:
+            fh.seek(start)
+            data = fh.read(MAX_TAIL_BYTES)
+        text = data.decode("utf-8", errors="replace")
+        if start > 0:
+            nl = text.find("\n")
+            if nl != -1:
+                text = text[nl + 1 :]
+        return text.splitlines()
+    try:
+        n = int(tail)
+    except ValueError:
+        n = 200
+    n = max(1, min(n, 10000))
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            dq = deque(fh, maxlen=n)
+        return [line.rstrip("\n") for line in dq]
+    except OSError:
+        return []
+
+
+def _parse_line(raw: str) -> dict:
+    m = LINE_RE.match(raw)
+    if m:
+        return {
+            "ts": m.group("ts"),
+            "handler": m.group("handler"),
+            "msg": m.group("msg"),
+            "raw": raw,
+        }
+    return {"ts": None, "handler": None, "msg": raw, "raw": raw}
+
+
+@router.get("/api/logs")
+def get_logs(
+    request: Request,
+    handler: str = Query(...),
+    filter: str = Query("", alias="filter"),
+    tail: str = Query("200"),
+):
+    # Loopback gate runs before any file access.
+    if not _exposed():
+        client_host = request.client.host if request.client else None
+        if client_host not in LOOPBACK_HOSTS:
+            return JSONResponse(status_code=403, content={"error": "logs disabled"})
+
+    if handler not in ALLOWED_HANDLERS:
+        raise HTTPException(status_code=400, detail="unknown handler")
+
+    if tail not in ("200", "500", "1000", "all"):
+        tail = "200"
+
+    log_path = _log_dir() / f"loop-{handler}.log"
+
+    on_disk, fd_bytes, orphaned = _orphan_status(handler, log_path)
+
+    raw_lines = _tail_lines(log_path, tail)
+    if filter:
+        raw_lines = [ln for ln in raw_lines if filter in ln]
+    parsed = [_parse_line(ln) for ln in raw_lines]
+
+    return {
+        "path": str(log_path),
+        "on_disk_bytes": on_disk,
+        "fd_bytes": fd_bytes,
+        "orphaned": orphaned,
+        "lines": parsed,
+    }

--- a/static/index.html
+++ b/static/index.html
@@ -16,6 +16,7 @@
     <button class="tab-btn" data-dash-tab="action-queue">
       Action Queue <span id="action-queue-badge" class="badge" style="display:none;margin-left:4px;background:#c44;color:#fff;border-radius:10px;padding:1px 7px;font-size:0.7rem;">0</span>
     </button>
+    <button class="tab-btn" data-dash-tab="logs">Logs</button>
   </nav>
   <div style="display:flex;align-items:center;gap:12px;">
     <span id="version-badge">loop-monitor</span>
@@ -67,6 +68,24 @@
       </tbody>
     </table>
   </div>
+</section>
+
+<section id="logs-section" style="display:none;">
+  <div class="section-title">Logs</div>
+  <div style="display:flex;gap:8px;margin-bottom:8px;flex-wrap:wrap;align-items:center;">
+    <select id="logs-handler" style="background:var(--surface2);border:1px solid var(--border);color:var(--text);font-size:0.75rem;padding:3px 6px;border-radius:4px;"></select>
+    <input id="logs-filter" type="text" placeholder="filter (literal substring)" style="background:var(--surface2);border:1px solid var(--border);color:var(--text);font-size:0.75rem;padding:3px 6px;border-radius:4px;min-width:240px;" />
+    <select id="logs-tail" style="background:var(--surface2);border:1px solid var(--border);color:var(--text);font-size:0.75rem;padding:3px 6px;border-radius:4px;">
+      <option value="200">200</option>
+      <option value="500">500</option>
+      <option value="1000">1000</option>
+      <option value="all">all</option>
+    </select>
+    <button id="logs-refresh" style="background:var(--surface2);border:1px solid var(--border);color:var(--text);font-size:0.75rem;padding:3px 10px;border-radius:4px;cursor:pointer;">Refresh</button>
+    <span id="logs-meta" style="color:var(--muted);font-size:0.7rem;"></span>
+  </div>
+  <div id="logs-orphan-banner" style="display:none;background:#5a1d1d;color:#ffdada;border:1px solid #c44;border-radius:6px;padding:8px 12px;margin-bottom:8px;font-size:0.8rem;"></div>
+  <pre id="logs-output" style="background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:10px;max-height:70vh;overflow:auto;font-size:0.75rem;line-height:1.4;white-space:pre-wrap;word-break:break-all;">Click Refresh to load.</pre>
 </section>
 
 <section id="events-graph-section" style="display:none">

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -9,6 +9,7 @@ import { renderActive, renderAgents } from '/js/components/stats.js';
 import { initRunsPanel, checkHash } from '/js/components/runs.js';
 import { fetchClaudeUsage } from '/js/components/claude_usage.js';
 import { fetchActionQueue, initActionQueue, renderActionQueue } from '/js/components/action_queue.js';
+import { initLogs } from '/js/components/logs.js';
 
 async function fetchAll() {
   try {
@@ -50,6 +51,7 @@ initGraphTooltip();
 initVersionBadge();
 initLoopSelector(fetchAll);
 initActionQueue();
+initLogs();
 
 document.getElementById('feed-role-filter').addEventListener('change', fetchAll);
 document.getElementById('feed-status-filter').addEventListener('change', fetchAll);

--- a/static/js/components/logs.js
+++ b/static/js/components/logs.js
@@ -1,0 +1,92 @@
+import { escHtml } from '/js/utils.js';
+
+const HANDLERS = [
+  'scanner', 'reconciler', 'po-handler', 'dev-handler',
+  'dev-rework-handler', 'review-handler', 'qa-handler', 'merge-handler',
+];
+
+function fmtBytes(n) {
+  if (n == null) return '?';
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function renderLines(lines) {
+  if (!lines.length) return '<div style="color:var(--muted)">No matching lines.</div>';
+  return lines.map(l => {
+    const ts = l.ts ? `<span style="color:var(--muted)">${escHtml(l.ts)}</span> ` : '';
+    const tag = l.handler ? `<span style="color:#7af">[${escHtml(l.handler)}]</span> ` : '';
+    return `<div>${ts}${tag}${escHtml(l.msg ?? l.raw ?? '')}</div>`;
+  }).join('');
+}
+
+async function refresh() {
+  const handler = document.getElementById('logs-handler').value;
+  const filter = document.getElementById('logs-filter').value;
+  const tail = document.getElementById('logs-tail').value;
+  const out = document.getElementById('logs-output');
+  const banner = document.getElementById('logs-orphan-banner');
+  const meta = document.getElementById('logs-meta');
+  out.textContent = 'Loading…';
+  banner.style.display = 'none';
+  try {
+    const params = new URLSearchParams({ handler, tail });
+    if (filter) params.set('filter', filter);
+    const res = await fetch(`/api/logs?${params.toString()}`);
+    if (res.status === 403) {
+      out.innerHTML = '<div style="color:#c44">Logs are disabled. Set LOOPMON_EXPOSE_LOGS=1 or access via loopback.</div>';
+      meta.textContent = '';
+      return;
+    }
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      out.innerHTML = `<div style="color:#c44">Error: ${escHtml(body.detail || res.statusText)}</div>`;
+      meta.textContent = '';
+      return;
+    }
+    const data = await res.json();
+    meta.textContent = `${escHtml(data.path)} · disk=${fmtBytes(data.on_disk_bytes)} · fd=${fmtBytes(data.fd_bytes)}`;
+    if (data.orphaned) {
+      banner.innerHTML = `WARNING: ${escHtml(handler)} log appears orphaned (FD ${fmtBytes(data.fd_bytes)}, file ${fmtBytes(data.on_disk_bytes)}). See svv2014/loop#194.`;
+      banner.style.display = 'block';
+    }
+    out.innerHTML = renderLines(data.lines);
+  } catch (e) {
+    out.innerHTML = `<div style="color:#c44">Fetch error: ${escHtml(String(e))}</div>`;
+  }
+}
+
+export function initLogs() {
+  const sel = document.getElementById('logs-handler');
+  if (sel && !sel.options.length) {
+    for (const h of HANDLERS) {
+      const opt = document.createElement('option');
+      opt.value = h;
+      opt.textContent = h;
+      sel.appendChild(opt);
+    }
+  }
+  document.getElementById('logs-refresh').addEventListener('click', refresh);
+
+  const overviewSelectors = [
+    '#events-graph-section', 'main', '#claude-usage-section',
+    '#charts-section', '#project-panel',
+  ];
+  document.querySelectorAll('#dashboard-tabs [data-dash-tab]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const tab = btn.dataset.dashTab;
+      const logsSection = document.getElementById('logs-section');
+      const aq = document.getElementById('action-queue-section');
+      if (tab === 'logs') {
+        overviewSelectors.forEach(sel => {
+          document.querySelectorAll(sel).forEach(el => { el.style.display = 'none'; });
+        });
+        if (aq) aq.style.display = 'none';
+        logsSection.style.display = '';
+      } else {
+        logsSection.style.display = 'none';
+      }
+    });
+  });
+}

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,0 +1,134 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from server.app import app
+from server.routes import logs as logs_module
+
+client = TestClient(app)
+
+
+def _enable(monkeypatch):
+    monkeypatch.setenv("LOOPMON_EXPOSE_LOGS", "1")
+
+
+def _patch_logdir(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("LOOP_LOG_DIR", str(tmp_path))
+
+
+def test_unknown_handler_rejected(monkeypatch, tmp_path):
+    _enable(monkeypatch)
+    _patch_logdir(monkeypatch, tmp_path)
+    resp = client.get("/api/logs", params={"handler": "../etc/passwd"})
+    assert resp.status_code == 400
+
+
+def test_literal_filter_matches(monkeypatch, tmp_path):
+    _enable(monkeypatch)
+    _patch_logdir(monkeypatch, tmp_path)
+    log = tmp_path / "loop-scanner.log"
+    log.write_text(
+        "[2026-05-02 10:00:00] [scanner] hello pa-scanner\n"
+        "[2026-05-02 10:00:01] [scanner] unrelated event\n"
+        "[2026-05-02 10:00:02] [scanner] another pa-scanner line\n"
+    )
+    with patch.object(logs_module, "_fd_bytes_for_handler", return_value=None):
+        resp = client.get(
+            "/api/logs", params={"handler": "scanner", "filter": "pa-scanner", "tail": "200"}
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["lines"]) == 2
+    assert all("pa-scanner" in line["raw"] for line in body["lines"])
+    assert body["lines"][0]["ts"] == "2026-05-02 10:00:00"
+    assert body["lines"][0]["handler"] == "scanner"
+
+
+def test_unmatched_lines_get_null_metadata(monkeypatch, tmp_path):
+    _enable(monkeypatch)
+    _patch_logdir(monkeypatch, tmp_path)
+    log = tmp_path / "loop-scanner.log"
+    log.write_text("not a structured line\n")
+    with patch.object(logs_module, "_fd_bytes_for_handler", return_value=None):
+        resp = client.get("/api/logs", params={"handler": "scanner"})
+    body = resp.json()
+    assert body["lines"][0]["ts"] is None
+    assert body["lines"][0]["handler"] is None
+    assert body["lines"][0]["raw"] == "not a structured line"
+
+
+def test_tail_all_capped_at_5mib(monkeypatch, tmp_path):
+    _enable(monkeypatch)
+    _patch_logdir(monkeypatch, tmp_path)
+    log = tmp_path / "loop-scanner.log"
+    chunk = ("[2026-05-02 10:00:00] [scanner] " + "x" * 64 + "\n").encode()
+    # Write ~6 MiB worth.
+    with open(log, "wb") as fh:
+        for _ in range(6 * 1024 * 1024 // len(chunk) + 100):
+            fh.write(chunk)
+    assert log.stat().st_size > logs_module.MAX_TAIL_BYTES
+    with patch.object(logs_module, "_fd_bytes_for_handler", return_value=None):
+        resp = client.get("/api/logs", params={"handler": "scanner", "tail": "all"})
+    body = resp.json()
+    total_bytes = sum(len(line["raw"]) + 1 for line in body["lines"])
+    assert total_bytes <= logs_module.MAX_TAIL_BYTES
+
+
+def test_loopback_gate_blocks_non_loopback(monkeypatch, tmp_path):
+    """TestClient default client host is 'testclient' — non-loopback."""
+    monkeypatch.delenv("LOOPMON_EXPOSE_LOGS", raising=False)
+    _patch_logdir(monkeypatch, tmp_path)
+    resp = client.get("/api/logs", params={"handler": "scanner"})
+    assert resp.status_code == 403
+    assert resp.json() == {"error": "logs disabled"}
+
+
+def test_loopback_gate_allows_loopback(monkeypatch, tmp_path):
+    """Simulate loopback by extending the allow-list to include the TestClient host."""
+    monkeypatch.delenv("LOOPMON_EXPOSE_LOGS", raising=False)
+    _patch_logdir(monkeypatch, tmp_path)
+    (tmp_path / "loop-scanner.log").write_text("hi\n")
+    with patch.object(
+        logs_module, "LOOPBACK_HOSTS", logs_module.LOOPBACK_HOSTS | {"testclient"}
+    ):
+        with patch.object(logs_module, "_fd_bytes_for_handler", return_value=None):
+            resp = client.get("/api/logs", params={"handler": "scanner"})
+    assert resp.status_code == 200
+
+
+def test_loopback_gate_bypassed_when_exposed(monkeypatch, tmp_path):
+    """When LOOPMON_EXPOSE_LOGS is set, non-loopback hosts are allowed."""
+    monkeypatch.setenv("LOOPMON_EXPOSE_LOGS", "1")
+    _patch_logdir(monkeypatch, tmp_path)
+    (tmp_path / "loop-scanner.log").write_text("hi\n")
+    with patch.object(logs_module, "_fd_bytes_for_handler", return_value=None):
+        resp = client.get("/api/logs", params={"handler": "scanner"})
+    assert resp.status_code == 200
+
+
+def test_orphan_helper_detects_divergence(monkeypatch, tmp_path):
+    log = tmp_path / "loop-scanner.log"
+    log.write_text("small\n")
+    with patch.object(logs_module, "_fd_bytes_for_handler", return_value=8 * 1024 * 1024):
+        on_disk, fd_bytes, orphaned = logs_module._orphan_status("scanner", log)
+    assert on_disk == log.stat().st_size
+    assert fd_bytes == 8 * 1024 * 1024
+    assert orphaned is True
+
+
+def test_orphan_helper_below_threshold(monkeypatch, tmp_path):
+    log = tmp_path / "loop-scanner.log"
+    log.write_text("x" * 1000)
+    with patch.object(logs_module, "_fd_bytes_for_handler", return_value=1000 + 1024):
+        on_disk, fd_bytes, orphaned = logs_module._orphan_status("scanner", log)
+    assert orphaned is False
+
+
+def test_orphan_helper_no_fd_info(monkeypatch, tmp_path):
+    log = tmp_path / "loop-scanner.log"
+    log.write_text("x")
+    with patch.object(logs_module, "_fd_bytes_for_handler", return_value=None):
+        on_disk, fd_bytes, orphaned = logs_module._orphan_status("scanner", log)
+    assert fd_bytes is None
+    assert orphaned is False


### PR DESCRIPTION
Closes #98

## Changes

- New `GET /api/logs?handler=&filter=&tail=` endpoint (`server/routes/logs.py`):
  - Allow-list of 8 handler names; unknown values → 400.
  - Tail sizes 200/500/1000/all; `tail=all` capped server-side at 5 MiB; bounded sizes use `collections.deque`.
  - Literal substring `filter` (no shell-out, no regex).
  - Per-line parse `[ts] [handler] msg`; non-matching lines preserved as raw with null metadata.
  - Orphan detection: `os.stat` for on-disk; Linux `/proc/<pid>/fd` + fdinfo `pos:`, fallback to `lsof -F sn` on macOS. `orphaned = abs(fd-disk) > 1 MiB`. Subprocess errors → `fd_bytes=null, orphaned=false`, never 500.
  - Loopback gate via `LOOPMON_EXPOSE_LOGS`. Default-deny: non-`127.0.0.1`/`::1` clients get `403 {"error":"logs disabled"}` before any file access. Reads `request.client.host` only — no `X-Forwarded-For` trust.
- Frontend Logs tab (`static/index.html`, `static/js/components/logs.js`, `static/js/app.js`): handler `<select>`, free-text filter, tail-size selector, Refresh button, scrollable `<pre>` with parsed ts/handler/msg, and an orphan warning banner. No auto-poll.
- `tests/test_logs.py`: allow-list rejection, literal filter, `tail=all` cap, loopback gate (block + allow + bypass-when-exposed), orphan helper across 3 cases.
- `README.md`: "Logs panel" subsection — how to enable, loopback default, explicit warning that logs may contain `gh` tokens / agent stdout.

No new dependencies. No write paths. `pytest tests/` is green (95 passed).

## Test Plan

- [ ] `pytest tests/` passes.
- [ ] With `LOOPMON_EXPOSE_LOGS` unset, hitting `/api/logs` from a non-loopback client returns `403 {"error":"logs disabled"}`.
- [ ] With it set to `1`, `GET /api/logs?handler=scanner&tail=200` returns the last 200 lines of the scanner log.
- [ ] Unknown `handler` returns 400.
- [ ] `filter=foo` only returns lines containing the literal `foo`.
- [ ] `tail=all` against a >5 MiB log truncates to ≤5 MiB.
- [ ] Logs tab in the UI: dropdown lists all 8 handlers, Refresh fetches + renders, orphan banner appears when `orphaned=true`.