### PR TITLE
[LM-120] Loop selector + version badge in TopBar

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,9 +1,12 @@
+import { useState } from 'react';
 import { TopBar } from './components/TopBar';
 
 export function App() {
+  const [loopId, setLoopId] = useState('');
+
   return (
     <div>
-      <TopBar />
+      <TopBar loopId={loopId} onLoopChange={setLoopId} />
       <main style={{ padding: '1rem' }}>
         <p>Loop Monitor v2 — Phase 3 screens coming soon.</p>
       </main>

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -1,33 +1,56 @@
 import { useQuery } from '@tanstack/react-query';
-import { fetchActive } from '../lib/api';
+import { fetchHealth } from '../lib/api';
 
-export function TopBar() {
-  const query = useQuery({
-    queryKey: ['active'],
-    queryFn: () => fetchActive(),
-    refetchInterval: 5000,
+interface TopBarProps {
+  loopId: string;
+  onLoopChange: (id: string) => void;
+}
+
+export function TopBar({ loopId, onLoopChange }: TopBarProps) {
+  const health = useQuery({
+    queryKey: ['health'],
+    queryFn: fetchHealth,
+    refetchInterval: 30_000,
     staleTime: 0,
   });
 
-  const workerCount = query.data?.length ?? 0;
-  const connected = !query.isError;
+  const version = health.data?.monitor_version ?? '…';
+  const gitSha = health.data?.git_sha ?? '';
+  const rawLoops = health.data?.loop_ids ?? [];
+  const loops = rawLoops.filter(id => id !== '(unknown)');
+  const connected = !health.isError;
 
   return (
     <header style={{ display: 'flex', alignItems: 'center', gap: '1rem', padding: '0.5rem 1rem', borderBottom: '1px solid #333' }}>
       <span style={{ fontWeight: 600 }}>Loop Monitor</span>
-      <span style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-        <span>{workerCount} active</span>
-        <span
-          title={connected ? 'Connected' : 'Connection error'}
-          style={{
-            width: 10,
-            height: 10,
-            borderRadius: '50%',
-            background: connected ? '#22c55e' : '#ef4444',
-            display: 'inline-block',
-          }}
-        />
+      <span style={{ fontSize: '0.75rem', color: '#888' }}>
+        v{version}
+        {gitSha && <span style={{ marginLeft: 4, fontFamily: 'monospace' }}>({gitSha})</span>}
       </span>
+      {loops.length > 1 && (
+        <select
+          value={loopId}
+          onChange={e => onLoopChange(e.target.value)}
+          style={{ marginLeft: 8, fontSize: '0.85rem', background: '#1a1a1a', color: '#eee', border: '1px solid #444', borderRadius: 4, padding: '2px 6px' }}
+        >
+          <option value="">All loops</option>
+          {loops.map(id => (
+            <option key={id} value={id}>{id}</option>
+          ))}
+        </select>
+      )}
+      <span
+        title={connected ? 'Connected' : 'Connection error'}
+        style={{
+          marginLeft: 'auto',
+          width: 10,
+          height: 10,
+          borderRadius: '50%',
+          background: connected ? '#22c55e' : '#ef4444',
+          display: 'inline-block',
+          flexShrink: 0,
+        }}
+      />
     </header>
   );
 }


### PR DESCRIPTION
Closes #120

## Changes

- **TopBar**: rewired to fetch `/api/health` (30s interval) instead of `/api/active`
  - Displays `v{monitor_version} ({git_sha})` version badge
  - Renders a `<select>` loop filter when `health.loop_ids` contains more than 1 real loop (filters out `(unknown)`)
  - Loop selector hidden when there is only one loop (matches legacy `header.js` behavior)
  - Connection indicator retained (green/red dot based on query error state)
- **App**: holds `loopId` state via `useState`; passes `loopId` and `onLoopChange` to `TopBar`; `loopId` is ready to be threaded into screen query keys as phase 3 screens land

## Notes

Branched from `feat/issue-115-api-client-transforms-fixture` (PR #132) since `web/` doesn't exist in `main` yet. Depends on #114 → #115 merging first; this PR will rebase cleanly onto `main` once those land.

## Test Plan

- [ ] Start dev server (`cd web && npm run dev`), open `/v2`
- [ ] Version badge shows `v<version> (<sha>)` from `/api/health`
- [ ] With one loop in DB: selector is hidden
- [ ] With multiple loops in DB: selector appears, choosing a loop updates `loopId` state (verify in React DevTools)
- [ ] `?fixtures=1` shows `v0.0.0-fixture (c0ffee)` and two loop options (`loop-001`, `loop-002`)
- [ ] `npm run typecheck` clean