### PR TITLE
[LM-119] Phase 3.4 · WorkerDetail screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ __pycache__/
 *.pyc
 .venv/
 venv/
+
+# React app
+web/node_modules/
+web/dist/
+static/dist/

--- a/tests/visual/conftest.py
+++ b/tests/visual/conftest.py
@@ -1,0 +1,77 @@
+pytest_plugins = []
+
+try:
+    import playwright  # noqa: F401
+    _PLAYWRIGHT_AVAILABLE = True
+except ImportError:
+    _PLAYWRIGHT_AVAILABLE = False
+
+import pytest
+
+VIEWPORT = {"width": 1440, "height": 900}
+
+
+@pytest.fixture(scope="session")
+def browser_type_launch_args(browser_type_launch_args):
+    # --allow-file-access-from-files: Babel loads .jsx via XHR from file:// origin;
+    # without this flag Chromium blocks those requests (CORS null origin).
+    return {**browser_type_launch_args, "headless": True, "args": ["--allow-file-access-from-files"]}
+
+
+@pytest.fixture(scope="session")
+def browser_context_args(browser_context_args):
+    return {**browser_context_args, "viewport": VIEWPORT}
+
+
+# JS injected before every screenshot: freezes timers/animations and marks VR regions.
+FREEZE_AND_MASK_JS = """
+() => {
+    // Stop all timers so live-data and clocks freeze
+    const maxId = setTimeout(() => {}, 0);
+    for (let i = 0; i <= maxId; i++) {
+        clearTimeout(i);
+        clearInterval(i);
+    }
+
+    // Pause CSS animations (pulse dots, row-flash)
+    const s = document.createElement('style');
+    s.textContent = '*, *::before, *::after { animation-play-state: paused !important; transition: none !important; }';
+    document.head.appendChild(s);
+
+    // Mark live clock spans
+    document.querySelectorAll('.topbar .right span').forEach(el => {
+        if (/\\d{2}:\\d{2}:\\d{2}/.test(el.textContent)) {
+            el.setAttribute('data-vr-mask', 'true');
+        }
+    });
+    // Mark event-rate counter (changes every render)
+    document.querySelectorAll('.topbar .right span').forEach(el => {
+        if (/\\/min/.test(el.textContent)) {
+            el.setAttribute('data-vr-mask', 'true');
+        }
+    });
+    // Mark pulse dots
+    document.querySelectorAll('.dot').forEach(el => {
+        el.setAttribute('data-vr-mask', 'true');
+    });
+    // Mark fresh-row elements
+    document.querySelectorAll('[class*="fresh"], [data-fresh]').forEach(el => {
+        el.setAttribute('data-vr-mask', 'true');
+    });
+
+    // Overwrite masked regions with opaque black so diffs are stable
+    document.querySelectorAll('[data-vr-mask="true"]').forEach(el => {
+        Object.assign(el.style, {
+            color: 'transparent',
+            background: '#000000',
+            boxShadow: 'none',
+            opacity: '1',
+        });
+    });
+}
+"""
+
+
+def mask_vr_regions(page) -> None:
+    """Apply FREEZE_AND_MASK_JS to the loaded page."""
+    page.evaluate(FREEZE_AND_MASK_JS)

--- a/tests/visual/test_worker.py
+++ b/tests/visual/test_worker.py
@@ -1,0 +1,82 @@
+"""Visual regression test: WorkerDetail React screen vs reference screenshot.
+
+Requires:
+  - playwright installed  (pip install playwright && playwright install chromium)
+  - Vite dev server running: cd web && npm run dev
+  - Reference screenshot at design/reference-screenshots/worker.png
+
+Run:
+  cd web && npm run dev &
+  pytest tests/visual/test_worker.py -v
+
+Skipped automatically if playwright is not installed or the dev server is unreachable.
+"""
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("playwright", reason="playwright not installed — skipping visual tests")
+
+from PIL import Image, ImageChops  # noqa: E402
+import numpy as np  # noqa: E402
+
+from tests.visual.conftest import mask_vr_regions  # noqa: E402
+
+REPO_ROOT = Path(__file__).parents[2]
+REFERENCE_DIR = REPO_ROOT / "design" / "reference-screenshots"
+ARTIFACTS_DIR = Path(__file__).parent / "_artifacts"
+
+DEV_SERVER_URL = "http://localhost:5173/v2?fixtures=1"
+DIFF_THRESHOLD = 0.005  # 0.5%
+
+
+def _pixel_diff_ratio(ref: Image.Image, current: Image.Image) -> tuple[float, Image.Image]:
+    ref_rgb = ref.convert("RGB")
+    cur_rgb = current.convert("RGB")
+    diff = ImageChops.difference(ref_rgb, cur_rgb)
+    arr = np.array(diff, dtype=np.uint8)
+    mismatched = int(np.any(arr > 10, axis=2).sum())
+    total = arr.shape[0] * arr.shape[1]
+    return mismatched / total, diff
+
+
+def test_worker_screen_visual(page) -> None:
+    ref_path = REFERENCE_DIR / "worker.png"
+    if not ref_path.exists():
+        pytest.skip(
+            f"Reference screenshot missing: {ref_path}. "
+            "Run: python tests/visual/capture_references.py"
+        )
+
+    try:
+        page.goto(DEV_SERVER_URL, wait_until="networkidle", timeout=15_000)
+    except Exception as exc:
+        pytest.skip(f"Vite dev server not reachable at {DEV_SERVER_URL}: {exc}")
+
+    # Wait for fixtures to hydrate
+    page.wait_for_timeout(1200)
+
+    # Navigate to workers screen via keyboard shortcut 4
+    page.keyboard.press("4")
+    page.wait_for_timeout(600)
+
+    mask_vr_regions(page)
+    page.wait_for_timeout(100)
+
+    screenshot_bytes = page.screenshot(
+        clip={"x": 0, "y": 0, "width": 1440, "height": 900},
+    )
+    current = Image.open(BytesIO(screenshot_bytes))
+    ref = Image.open(ref_path)
+
+    ratio, diff_img = _pixel_diff_ratio(ref, current)
+
+    if ratio > DIFF_THRESHOLD:
+        ARTIFACTS_DIR.mkdir(exist_ok=True)
+        diff_path = ARTIFACTS_DIR / "worker.diff.png"
+        diff_img.save(str(diff_path))
+        pytest.fail(
+            f"[worker] pixel diff {ratio:.4%} exceeds threshold {DIFF_THRESHOLD:.4%}. "
+            f"Diff saved to {diff_path}"
+        )

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Loop Monitor</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,2198 @@
+{
+  "name": "loop-monitor-web",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "loop-monitor-web",
+      "version": "0.0.0",
+      "dependencies": {
+        "@tanstack/react-query": "^5.56.2",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.5",
+        "@types/react-dom": "^18.3.0",
+        "@vitejs/plugin-react": "^4.3.1",
+        "typescript": "^5.5.3",
+        "vite": "^5.4.2",
+        "vitest": "^2.0.5"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.9.tgz",
+      "integrity": "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.9.tgz",
+      "integrity": "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.9"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.28",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.28.tgz",
+      "integrity": "sha512-Ic44hnOtFIgravCunj1ifSoQPSUrkNiJuH9Mf6jr2jjoA74icqV8wU0KuadXeOR8zuIJMOoTv0GuQjZ9ZYNMeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.353",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.353.tgz",
+      "integrity": "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "loop-monitor-web",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.56.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "typescript": "^5.5.3",
+    "vite": "^5.4.2",
+    "vitest": "^2.0.5"
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,11 +1,49 @@
+import { useState, useEffect } from 'react';
+import Logo from './components/Logo';
 import { TopBar } from './components/TopBar';
+import NavRail from './components/NavRail';
+import WorkerDetail from './screens/WorkerDetail';
+
+type Screen = 'overview' | 'queue' | 'projects' | 'workers';
+
+const KEYMAP: Record<string, Screen> = {
+  '1': 'overview',
+  '2': 'queue',
+  '3': 'projects',
+  '4': 'workers',
+};
 
 export function App() {
+  const [screen, setScreen] = useState<Screen>('overview');
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      const next = KEYMAP[e.key];
+      if (next) setScreen(next);
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+
   return (
-    <div>
+    <div className="app">
+      <Logo />
       <TopBar />
-      <main style={{ padding: '1rem' }}>
-        <p>Loop Monitor v2 — Phase 3 screens coming soon.</p>
+      <NavRail screen={screen} setScreen={s => setScreen(s as Screen)} />
+      <main className="main">
+        {screen === 'workers' ? (
+          <WorkerDetail setScreen={s => setScreen(s as Screen)} />
+        ) : (
+          <div style={{
+            padding: 'var(--pad-4)',
+            color: 'var(--fg-3)',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 12,
+          }}>
+            {screen} — coming soon (Phase 3.{screen === 'overview' ? '1' : screen === 'queue' ? '2' : '3'})
+          </div>
+        )}
       </main>
     </div>
   );

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,12 @@
+import { TopBar } from './components/TopBar';
+
+export function App() {
+  return (
+    <div>
+      <TopBar />
+      <main style={{ padding: '1rem' }}>
+        <p>Loop Monitor v2 — Phase 3 screens coming soon.</p>
+      </main>
+    </div>
+  );
+}

--- a/web/src/components/Logo.tsx
+++ b/web/src/components/Logo.tsx
@@ -1,0 +1,7 @@
+export default function Logo() {
+  return (
+    <div className="logo">
+      <div className="glyph"></div>
+    </div>
+  );
+}

--- a/web/src/components/NavRail.tsx
+++ b/web/src/components/NavRail.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode } from 'react';
+
+interface NavRailProps {
+  screen: string;
+  setScreen: (screen: string) => void;
+}
+
+const NAV_ICONS: Record<string, ReactNode> = {
+  overview: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/>
+      <rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/>
+    </svg>
+  ),
+  queue: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M3 6h18M3 12h12M3 18h6"/>
+    </svg>
+  ),
+  projects: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M3 7l9-4 9 4-9 4-9-4z"/><path d="M3 12l9 4 9-4"/><path d="M3 17l9 4 9-4"/>
+    </svg>
+  ),
+  workers: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <circle cx="9" cy="8" r="3"/><path d="M3 20c0-3.3 2.7-6 6-6s6 2.7 6 6"/>
+      <circle cx="17" cy="9" r="2.5"/><path d="M14 18c0-2.5 1.6-4 3-4s3 1.5 3 4"/>
+    </svg>
+  ),
+  settings: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <circle cx="12" cy="12" r="3"/>
+      <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 0 1-4 0v-.1a1.7 1.7 0 0 0-1.1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 0 1 0-4h.1a1.7 1.7 0 0 0 1.5-1.1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3h0a1.7 1.7 0 0 0 1-1.5V3a2 2 0 0 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8v0a1.7 1.7 0 0 0 1.5 1H21a2 2 0 0 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z"/>
+    </svg>
+  ),
+};
+
+export default function NavRail({ screen, setScreen }: NavRailProps) {
+  const items = [
+    { id: 'overview', label: 'Overview' },
+    { id: 'queue',    label: 'Action Queue' },
+    { id: 'projects', label: 'Projects' },
+    { id: 'workers',  label: 'Workers' },
+  ];
+  return (
+    <div className="nav">
+      {items.map(it => (
+        <button key={it.id}
+          className={`nav-item ${screen === it.id ? 'active' : ''}`}
+          onClick={() => setScreen(it.id)}>
+          {NAV_ICONS[it.id]}
+          <span className="nav-tip">{it.label}</span>
+        </button>
+      ))}
+      <div style={{ flex: 1 }}></div>
+      <button className="nav-item" title="Settings">
+        {NAV_ICONS.settings}
+        <span className="nav-tip">Settings</span>
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchActive } from '../lib/api';
+
+export function TopBar() {
+  const query = useQuery({
+    queryKey: ['active'],
+    queryFn: () => fetchActive(),
+    refetchInterval: 5000,
+    staleTime: 0,
+  });
+
+  const workerCount = query.data?.length ?? 0;
+  const connected = !query.isError;
+
+  return (
+    <header style={{ display: 'flex', alignItems: 'center', gap: '1rem', padding: '0.5rem 1rem', borderBottom: '1px solid #333' }}>
+      <span style={{ fontWeight: 600 }}>Loop Monitor</span>
+      <span style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+        <span>{workerCount} active</span>
+        <span
+          title={connected ? 'Connected' : 'Connection error'}
+          style={{
+            width: 10,
+            height: 10,
+            borderRadius: '50%',
+            background: connected ? '#22c55e' : '#ef4444',
+            display: 'inline-block',
+          }}
+        />
+      </span>
+    </header>
+  );
+}

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -1,33 +1,46 @@
+import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchActive } from '../lib/api';
 
+function timeFmt(d: Date): string {
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  const ss = String(d.getSeconds()).padStart(2, '0');
+  return `${hh}:${mm}:${ss}`;
+}
+
+function useTick(ms = 1000) {
+  const [, setN] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setN(n => n + 1), ms);
+    return () => clearInterval(id);
+  }, [ms]);
+}
+
 export function TopBar() {
-  const query = useQuery({
+  useTick(1000);
+  const now = new Date();
+  const { data: workers, isError } = useQuery({
     queryKey: ['active'],
     queryFn: () => fetchActive(),
     refetchInterval: 5000,
     staleTime: 0,
   });
-
-  const workerCount = query.data?.length ?? 0;
-  const connected = !query.isError;
-
+  const online = !isError;
   return (
-    <header style={{ display: 'flex', alignItems: 'center', gap: '1rem', padding: '0.5rem 1rem', borderBottom: '1px solid #333' }}>
-      <span style={{ fontWeight: 600 }}>Loop Monitor</span>
-      <span style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-        <span>{workerCount} active</span>
-        <span
-          title={connected ? 'Connected' : 'Connection error'}
-          style={{
-            width: 10,
-            height: 10,
-            borderRadius: '50%',
-            background: connected ? '#22c55e' : '#ef4444',
-            display: 'inline-block',
-          }}
-        />
-      </span>
-    </header>
+    <div className="topbar">
+      <div className="left">
+        <span className="mono" style={{ color: 'var(--fg)', fontWeight: 500 }}>
+          PIPELINE
+          <span style={{ color: 'var(--fg-4)', marginLeft: 6 }}>v2</span>
+        </span>
+        <span style={{ width: 1, height: 14, background: 'var(--border)' }}></span>
+        <span><span className="dot"></span>&nbsp;{online ? 'CONNECTED' : 'OFFLINE'}</span>
+        <span>· {workers?.length ?? 0} active</span>
+      </div>
+      <div className="right">
+        <span>{timeFmt(now)}</span>
+      </div>
+    </div>
   );
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,0 +1,119 @@
+// Thin fetch client over /api/*.
+// Mirrors the endpoints called by static/js/api.js.
+// When window.location.search contains fixtures=1 every function returns
+// seeded fixture data and makes zero network calls.
+import type {
+  Worker,
+  BoardEntry,
+  Verdict,
+  FeedItem,
+  LoopEvent,
+  StatusEntry,
+  Project,
+  EventsGraph,
+  QueueItem,
+  PipelineRun,
+  PRMonitorEntry,
+  Health,
+  StatsActivity,
+  StatsStage,
+  StatsRework,
+} from './types';
+import * as fx from './fixtures';
+
+function isFixtureMode(): boolean {
+  return new URLSearchParams(window.location.search).has('fixtures');
+}
+
+async function get<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText} — ${url}`);
+  return res.json() as Promise<T>;
+}
+
+export async function fetchActive(loop_id?: string): Promise<Worker[]> {
+  if (isFixtureMode()) return fx.getFixtureActive();
+  const qs = loop_id ? `?loop_id=${encodeURIComponent(loop_id)}` : '';
+  return get<Worker[]>(`/api/active${qs}`);
+}
+
+export async function fetchBoard(): Promise<BoardEntry[]> {
+  if (isFixtureMode()) return fx.getFixtureBoard();
+  return get<BoardEntry[]>('/api/board');
+}
+
+export async function fetchVerdicts(): Promise<Verdict[]> {
+  if (isFixtureMode()) return fx.getFixtureVerdicts();
+  return get<Verdict[]>('/api/verdicts');
+}
+
+export interface FeedParams {
+  loop_id?: string;
+  role?: string;
+  status?: string;
+}
+export async function fetchFeed(params: FeedParams = {}): Promise<FeedItem[]> {
+  if (isFixtureMode()) return fx.getFixtureFeed();
+  const p = new URLSearchParams();
+  if (params.loop_id) p.set('loop_id', params.loop_id);
+  if (params.role)    p.set('role', params.role);
+  if (params.status)  p.set('status', params.status);
+  const qs = p.toString() ? `?${p.toString()}` : '';
+  return get<FeedItem[]>(`/api/feed${qs}`);
+}
+
+export async function fetchHistory(loop_id?: string): Promise<LoopEvent[]> {
+  if (isFixtureMode()) return fx.getFixtureHistory();
+  const qs = loop_id ? `?loop_id=${encodeURIComponent(loop_id)}` : '';
+  return get<LoopEvent[]>(`/api/history${qs}`);
+}
+
+export async function fetchStatus(): Promise<StatusEntry[]> {
+  if (isFixtureMode()) return fx.getFixtureStatus();
+  return get<StatusEntry[]>('/api/status');
+}
+
+export async function fetchProjects(): Promise<Project[]> {
+  if (isFixtureMode()) return fx.getFixtureProjects();
+  return get<Project[]>('/api/projects');
+}
+
+export async function fetchEventsGraph(window_hours = 24): Promise<EventsGraph> {
+  if (isFixtureMode()) return fx.getFixtureEventsGraph();
+  return get<EventsGraph>(`/api/events_graph?window=${window_hours}`);
+}
+
+export async function fetchActionQueue(): Promise<QueueItem[]> {
+  if (isFixtureMode()) return fx.getFixtureActionQueue();
+  return get<QueueItem[]>('/api/action_queue');
+}
+
+export async function fetchRuns(project: string): Promise<PipelineRun[]> {
+  if (isFixtureMode()) return fx.getFixtureRuns(project);
+  return get<PipelineRun[]>(`/api/runs/${encodeURIComponent(project)}`);
+}
+
+export async function fetchPRMonitor(project: string): Promise<PRMonitorEntry[]> {
+  if (isFixtureMode()) return fx.getFixturePRMonitor(project);
+  return get<PRMonitorEntry[]>(`/api/projects/${encodeURIComponent(project)}/prs`);
+}
+
+export async function fetchHealth(): Promise<Health> {
+  if (isFixtureMode()) return fx.getFixtureHealth();
+  return get<Health>('/api/health');
+}
+
+export async function fetchStatsActivity(): Promise<StatsActivity[]> {
+  if (isFixtureMode()) return fx.getFixtureStatsActivity();
+  return get<StatsActivity[]>('/api/stats/activity');
+}
+
+export async function fetchStatsStages(): Promise<StatsStage[]> {
+  if (isFixtureMode()) return fx.getFixtureStatsStages();
+  return get<StatsStage[]>('/api/stats/stages');
+}
+
+export async function fetchStatsRework(): Promise<StatsRework[]> {
+  if (isFixtureMode()) return fx.getFixtureStatsRework();
+  return get<StatsRework[]>('/api/stats/rework');
+}

--- a/web/src/lib/fixtures.ts
+++ b/web/src/lib/fixtures.ts
@@ -1,0 +1,317 @@
+// Deterministic fixture data ported verbatim from design/new-design/data.js.
+// The seeded RNG must produce byte-identical output to the prototype so
+// ?fixtures=1 renders deterministically across runs (Phase 0 visual-diff depends on this).
+import type {
+  Worker,
+  BoardEntry,
+  FeedItem,
+  LoopEvent,
+  StatusEntry,
+  Project,
+  EventsGraph,
+  QueueItem,
+  Health,
+  StatsActivity,
+  StatsStage,
+  StatsRework,
+} from './types';
+
+const PROJECTS = [
+  { id: 'loop',               repo: 'svv2014/loop' },
+  { id: 'loop-monitor',       repo: 'svv2014/loop-monitor' },
+  { id: 'boba-event',         repo: 'svv2014/boba-event' },
+  { id: 'boba-orchestrator',  repo: 'svv2014/boba-orchestrator' },
+  { id: 'ntc',                repo: 'svv2014/NanoTraderCopilot' },
+  { id: 'pa-scanner',         repo: 'svv2014/pa-scanner' },
+  { id: 'ppl',                repo: 'svv2014/ppl-study' },
+  { id: 'suprun',             repo: 'svv2014/suprun' },
+  { id: 'vrefm-classifier',   repo: 'svv2014/vrefm-classifier' },
+];
+
+const ROLES = ['po', 'dev', 'qa', 'reviewer', 'merge', 'judge'] as const;
+
+const AGENTS = [
+  { agent: 'claude', model: 'sonnet-4-6' },
+  { agent: 'claude', model: 'opus-4-1' },
+  { agent: 'claude', model: 'haiku-4-5' },
+  { agent: 'gpt',    model: 'gpt-5' },
+  { agent: 'gpt',    model: 'gpt-5-mini' },
+  { agent: 'gemini', model: 'gemini-2-5' },
+];
+
+const EVENT_TYPES = [
+  'po_start', 'po_done',
+  'dev_start', 'dev_done',
+  'qa_pass', 'qa_fail',
+  'review_done',
+  'merge_done',
+  'judge_done',
+] as const;
+
+const ROLE_BY_EVENT: Record<string, string> = {
+  po_start: 'po', po_done: 'po',
+  dev_start: 'dev', dev_done: 'dev',
+  qa_pass: 'qa', qa_fail: 'qa',
+  review_done: 'reviewer',
+  merge_done: 'merge',
+  judge_done: 'judge',
+};
+
+// Deterministic RNG — same LCG constants as data.js
+let _seed = 0xC0FFEE;
+function rand(): number {
+  _seed = (_seed * 1664525 + 1013904223) >>> 0;
+  return _seed / 0xFFFFFFFF;
+}
+function pick<T>(arr: readonly T[]): T { return arr[Math.floor(rand() * arr.length)]; }
+function randInt(lo: number, hi: number): number { return lo + Math.floor(rand() * (hi - lo + 1)); }
+
+function buildHistory(): LoopEvent[] {
+  const now = Date.now();
+  const events: LoopEvent[] = [];
+  const DAY = 24 * 60 * 60 * 1000;
+  for (let i = 0; i < 600; i++) {
+    const t = now - rand() * DAY;
+    const event_type = pick(EVENT_TYPES);
+    const role = ROLE_BY_EVENT[event_type];
+    const project = pick(PROJECTS);
+    const ag = pick(AGENTS);
+    const pts = ['merge_done', 'judge_done', 'dev_done', 'po_done', 'review_done'].includes(event_type)
+      ? randInt(1, 5) : 0;
+    events.push({
+      id: i,
+      ts: t,
+      event_type,
+      role,
+      agent: ag.agent,
+      model: ag.model,
+      project: project.id,
+      issue_number: randInt(20, 150),
+      pr_number: randInt(20, 150),
+      points: pts,
+      duration_ms: randInt(800, 240000),
+      created_at: new Date(t).toISOString(),
+    } as LoopEvent & { ts: number; agent: string; duration_ms: number; points: number });
+  }
+  events.sort((a, b) => (b as unknown as { ts: number }).ts - (a as unknown as { ts: number }).ts);
+  return events;
+}
+
+// Reset seed before building so fixture data is deterministic on every call
+function resetSeed() { _seed = 0xC0FFEE; }
+
+resetSeed();
+const HISTORY = buildHistory();
+
+const WORKERS_INITIAL: Worker[] = [
+  { project: 'loop',            role: 'dev',      model: 'sonnet-4-6', event_type: 'dev_start',    issue_number: 142, pr_number: null,  detail: '#142 implement retry backoff', created_at: new Date(Date.now() - 124_000).toISOString() },
+  { project: 'loop-monitor',    role: 'reviewer', model: 'opus-4-1',   event_type: 'review_start',  issue_number: 138, pr_number: 138,   detail: '#138 review PR diff',          created_at: new Date(Date.now() - 47_000).toISOString() },
+  { project: 'ppl',             role: 'po',       model: 'gpt-5',      event_type: 'po_start',      issue_number: 150, pr_number: null,  detail: '#150 spec breakdown',          created_at: new Date(Date.now() - 12_000).toISOString() },
+  { project: 'vrefm-classifier',role: 'qa',       model: 'haiku-4-5',  event_type: 'qa_start',      issue_number: 101, pr_number: null,  detail: '#101 run regression suite',    created_at: new Date(Date.now() - 8_000).toISOString() },
+  { project: 'boba-event',      role: 'judge',    model: 'gemini-2-5', event_type: 'judge_start',   issue_number: 88,  pr_number: null,  detail: '#88 verdict scoring',          created_at: new Date(Date.now() - 2_300).toISOString() },
+];
+
+function buildQueue(): QueueItem[] {
+  resetSeed();
+  const PRIORITIES = ['critical', 'high', 'normal', 'low'] as const;
+  const TITLES = [
+    'rate-limit handler exceeds budget',
+    'flaky test in pipeline_runs',
+    'spec drift on /api/report v1.2',
+    'judge gives low verdict on small diffs',
+    'memory leak in event ingest loop',
+    'queue starvation under burst load',
+    'webhook timeout retries unbounded',
+    'leaderboard ranks tied agents wrong',
+    'duplicate events from boba-orchestrator',
+    'missing duration on judge_done',
+  ];
+  const items: QueueItem[] = [];
+  for (let i = 0; i < 18; i++) {
+    const p = pick(PROJECTS);
+    const role = pick(ROLES);
+    items.push({
+      project: p.id,
+      kind: 'issue',
+      number: randInt(20, 200),
+      title: pick(TITLES),
+      stage: pick(['blocked', 'needs-clarification', 'in-progress']),
+      age_seconds: randInt(60, 6 * 60 * 60),
+      reason: pick(['stuck_label', 'timeout', 'qa_fail_repeated']),
+      loop_id: null,
+      github_url: `https://github.com/${p.repo}/issues/${randInt(20, 200)}`,
+      role,
+    } as QueueItem & { role: string });
+  }
+  items.sort((a, b) => PRIORITIES.indexOf(a.reason as never) - PRIORITIES.indexOf(b.reason as never));
+  return items;
+}
+
+// Build all fixture data lazily (reset seed each time for consistency)
+export function getFixtureActive(): Worker[] {
+  return WORKERS_INITIAL;
+}
+
+export function getFixtureBoard(): BoardEntry[] {
+  resetSeed();
+  return ROLES.map((role) => ({
+    project: pick(PROJECTS).id,
+    role,
+    model: pick(AGENTS).model,
+    total_points: randInt(10, 200),
+    verdict_count: randInt(2, 40),
+  }));
+}
+
+export function getFixtureFeed(): FeedItem[] {
+  return HISTORY.slice(0, 50).map((e, i) => {
+    const ev = e as unknown as { ts: number; agent: string; points: number };
+    return {
+      id: i,
+      project: e.project,
+      role: e.role,
+      model: e.model,
+      event_type: e.event_type,
+      issue_number: e.issue_number,
+      pr_number: e.pr_number,
+      detail: null,
+      payload: null,
+      created_at: e.created_at,
+      age_seconds: Math.floor((Date.now() - ev.ts) / 1000),
+      status: e.event_type.endsWith('_fail') ? 'fail' : e.event_type.endsWith('_pass') ? 'pass' : 'done',
+    };
+  });
+}
+
+export function getFixtureHistory(): LoopEvent[] {
+  return HISTORY.slice(0, 50);
+}
+
+export function getFixtureStatus(): StatusEntry[] {
+  return WORKERS_INITIAL.map((w) => ({
+    project: w.project,
+    role: w.role,
+    model: w.model,
+    event_type: w.event_type,
+    issue_number: w.issue_number,
+    pr_number: w.pr_number,
+    detail: w.detail,
+    payload: null,
+    created_at: w.created_at,
+  }));
+}
+
+export function getFixtureProjects(): Project[] {
+  return PROJECTS.map((p) => ({ project: p.id, repo: p.repo }));
+}
+
+export function getFixtureEventsGraph(): EventsGraph {
+  resetSeed();
+  const buckets = Array.from({ length: 24 }, (_, i) => {
+    const hour = new Date(Date.now() - (23 - i) * 3_600_000);
+    return ROLES.map((role) => ({
+      hour: hour.toISOString().slice(0, 13) + ':00:00',
+      role,
+      count: randInt(0, 20),
+    }));
+  }).flat();
+  return { window_hours: 24, buckets };
+}
+
+export function getFixtureActionQueue(): QueueItem[] {
+  return buildQueue();
+}
+
+export function getFixtureRuns(project: string): import('./types').PipelineRun[] {
+  resetSeed();
+  return Array.from({ length: 10 }, (_, i) => ({
+    id: i + 1,
+    project,
+    issue_number: randInt(10, 200),
+    pr_number: randInt(10, 200),
+    title: `Issue #${randInt(10, 200)} auto-fix attempt`,
+    outcome: pick(['clean', 'failed', null] as const),
+    started_at: new Date(Date.now() - randInt(1000, 86400) * 1000).toISOString(),
+    completed_at: new Date(Date.now() - randInt(0, 1000) * 1000).toISOString(),
+    total_duration_seconds: randInt(60, 3600),
+    rework_count: randInt(0, 3),
+    total_bounty: randInt(0, 20),
+    created_at: new Date(Date.now() - randInt(1000, 86400) * 1000).toISOString(),
+  }));
+}
+
+export function getFixturePRMonitor(project: string): import('./types').PRMonitorEntry[] {
+  resetSeed();
+  const STAGES = ['in-development', 'in-review', 'merged', 'qa-passed'];
+  return Array.from({ length: 5 }, (_, i) => ({
+    pr_number: randInt(10, 200),
+    title: `PR for issue #${randInt(10, 200)}`,
+    branch: `feat/issue-${randInt(10, 200)}-fix`,
+    stage: pick(STAGES),
+    time_in_stage_seconds: randInt(60, 3600),
+    retry_count: randInt(0, 2),
+    last_event: pick(EVENT_TYPES as unknown as string[]),
+    last_event_at: new Date(Date.now() - randInt(60, 3600) * 1000).toISOString(),
+    github_url: `https://github.com/svv2014/${project}/pull/${randInt(10, 200)}`,
+    is_finished: i > 3,
+    is_draft: false,
+  }));
+}
+
+export function getFixtureHealth(): Health {
+  return {
+    status: 'ok',
+    monitor_version: '0.0.0-fixture',
+    git_sha: 'c0ffee',
+    supported_bounty_api: '1.x',
+    core_version_counts: { '1.0': 300, '1.1': 45 },
+    loop_ids: ['loop-001', 'loop-002'],
+  };
+}
+
+export function getFixtureVerdicts(): import('./types').Verdict[] {
+  resetSeed();
+  return Array.from({ length: 20 }, (_, i) => ({
+    id: i + 1,
+    project: pick(PROJECTS).id,
+    role: pick(ROLES),
+    model: pick(AGENTS).model,
+    points: randInt(1, 5),
+    reason: pick(['auto: dev_done', 'auto: qa_pass', 'manual review']),
+    created_at: new Date(Date.now() - randInt(60, 86400) * 1000).toISOString(),
+  }));
+}
+
+export function getFixtureStatsActivity(): StatsActivity[] {
+  resetSeed();
+  return PROJECTS.slice(0, 5).flatMap((p) =>
+    Array.from({ length: 7 }, (_, i) => ({
+      date: new Date(Date.now() - i * 86400_000).toISOString().slice(0, 10),
+      project: p.id,
+      n: randInt(0, 30),
+    }))
+  );
+}
+
+export function getFixtureStatsStages(): StatsStage[] {
+  return [
+    { stage: 'dev', avg_seconds: 1800, count: 120 },
+    { stage: 'review', avg_seconds: 900, count: 95 },
+    { stage: 'qa', avg_seconds: 600, count: 88 },
+    { stage: 'merge', avg_seconds: 120, count: 75 },
+  ];
+}
+
+export function getFixtureStatsRework(): StatsRework[] {
+  resetSeed();
+  return PROJECTS.map((p) => ({
+    project: p.id,
+    rework_starts: randInt(0, 20),
+    review_dones: randInt(5, 40),
+  }));
+}
+
+// Raw history for use by transforms (same data that would come from /api/history)
+export function getFixtureHistoryAll(): LoopEvent[] {
+  return HISTORY;
+}

--- a/web/src/lib/tokens.css
+++ b/web/src/lib/tokens.css
@@ -1,0 +1,516 @@
+/* Pipeline Monitor — design tokens + base */
+
+@import url('https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap');
+
+:root {
+  /* Surfaces — cool near-black */
+  --bg:        oklch(0.145 0.006 250);
+  --bg-1:      oklch(0.175 0.006 250);
+  --bg-2:      oklch(0.205 0.007 250);
+  --bg-3:      oklch(0.245 0.008 250);
+  --border:    oklch(0.275 0.008 250);
+  --border-strong: oklch(0.355 0.010 250);
+
+  /* Text */
+  --fg:        oklch(0.96 0.005 250);
+  --fg-2:      oklch(0.78 0.007 250);
+  --fg-3:      oklch(0.58 0.008 250);
+  --fg-4:      oklch(0.42 0.008 250);
+
+  /* Accent — terminal green (single brand accent) */
+  --accent:    oklch(0.82 0.18 145);
+  --accent-2:  oklch(0.62 0.18 145);
+  --accent-fg: oklch(0.18 0.04 145);
+
+  /* Status */
+  --pass:      oklch(0.82 0.18 145);
+  --fail:      oklch(0.68 0.20 25);
+  --warn:      oklch(0.82 0.16 80);
+  --info:      oklch(0.74 0.14 235);
+
+  /* Role tints — constant lightness ~0.74, chroma ~0.13 */
+  --role-po:        oklch(0.74 0.16 295);  /* violet */
+  --role-dev:       oklch(0.78 0.13 210);  /* cyan-blue */
+  --role-qa:        oklch(0.82 0.15 75);   /* amber */
+  --role-reviewer:  oklch(0.74 0.16 0);    /* pink */
+  --role-merge:     oklch(0.80 0.16 145);  /* green */
+  --role-judge:     oklch(0.74 0.14 260);  /* indigo */
+
+  /* Type */
+  --font-sans: 'Geist', system-ui, -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+
+  /* Density (settable via Tweaks) */
+  --d: 1; /* multiplier: 0.85 compact, 1 cozy, 1.15 roomy */
+  --pad-1: calc(6px * var(--d));
+  --pad-2: calc(10px * var(--d));
+  --pad-3: calc(14px * var(--d));
+  --pad-4: calc(20px * var(--d));
+  --pad-5: calc(28px * var(--d));
+
+  --hairline: 1px;
+}
+
+* { box-sizing: border-box; }
+
+html, body, #root {
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--font-sans);
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  font-feature-settings: 'cv11', 'ss01';
+  -webkit-font-smoothing: antialiased;
+}
+
+button { font-family: inherit; }
+
+/* Background grain — very subtle */
+body::before {
+  content: '';
+  position: fixed; inset: 0;
+  pointer-events: none;
+  background-image:
+    radial-gradient(circle at 50% 0%, oklch(0.22 0.02 250 / 0.5), transparent 60%),
+    repeating-linear-gradient(0deg, transparent 0 2px, oklch(1 0 0 / 0.005) 2px 3px);
+  z-index: 0;
+}
+
+/* App shell */
+.app {
+  position: relative;
+  z-index: 1;
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 56px 1fr;
+  grid-template-rows: 36px 1fr;
+  grid-template-areas:
+    "logo topbar"
+    "nav  main";
+}
+
+/* Top status bar */
+.topbar {
+  grid-area: topbar;
+  background: var(--bg);
+  border-bottom: var(--hairline) solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 var(--pad-3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-3);
+  letter-spacing: 0.02em;
+}
+.topbar .left,
+.topbar .right { display: flex; align-items: center; gap: var(--pad-3); }
+
+.kbd {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  padding: 2px 5px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--fg-3);
+  background: var(--bg-1);
+}
+
+.dot {
+  display: inline-block;
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 0 var(--accent);
+  animation: pulse 2s infinite;
+}
+@keyframes pulse {
+  0% { box-shadow: 0 0 0 0 oklch(0.82 0.18 145 / 0.5); }
+  70% { box-shadow: 0 0 0 6px oklch(0.82 0.18 145 / 0); }
+  100% { box-shadow: 0 0 0 0 oklch(0.82 0.18 145 / 0); }
+}
+
+/* Logo */
+.logo {
+  grid-area: logo;
+  display: flex; align-items: center; justify-content: center;
+  background: var(--bg);
+  border-right: var(--hairline) solid var(--border);
+  border-bottom: var(--hairline) solid var(--border);
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: -0.01em;
+}
+.logo .glyph {
+  width: 22px; height: 22px;
+  border: 1.5px solid var(--accent);
+  position: relative;
+}
+.logo .glyph::before {
+  content: '';
+  position: absolute; inset: 4px;
+  border: 1.5px solid var(--accent);
+  background: var(--accent);
+  opacity: 0.4;
+}
+
+/* Left nav rail */
+.nav {
+  grid-area: nav;
+  background: var(--bg);
+  border-right: var(--hairline) solid var(--border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: var(--pad-2) 0;
+  gap: 2px;
+}
+.nav-item {
+  width: 40px; height: 40px;
+  display: flex; align-items: center; justify-content: center;
+  border: none;
+  background: transparent;
+  color: var(--fg-3);
+  cursor: pointer;
+  border-radius: 4px;
+  position: relative;
+  transition: color .15s, background .15s;
+}
+.nav-item:hover { color: var(--fg); background: var(--bg-1); }
+.nav-item.active { color: var(--accent); }
+.nav-item.active::before {
+  content: '';
+  position: absolute;
+  left: -8px; top: 8px; bottom: 8px;
+  width: 2px;
+  background: var(--accent);
+}
+.nav-item svg { width: 18px; height: 18px; }
+.nav-tip {
+  position: absolute;
+  left: calc(100% + 8px);
+  white-space: nowrap;
+  background: var(--bg-2);
+  border: var(--hairline) solid var(--border);
+  padding: 4px 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg);
+  opacity: 0; pointer-events: none;
+  transform: translateX(-4px);
+  transition: opacity .15s, transform .15s;
+  z-index: 100;
+}
+.nav-item:hover .nav-tip { opacity: 1; transform: translateX(0); }
+
+/* Main content */
+.main {
+  grid-area: main;
+  overflow: auto;
+}
+
+/* Generic panel */
+.panel {
+  background: var(--bg-1);
+  border: var(--hairline) solid var(--border);
+}
+.panel-h {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--pad-2) var(--pad-3);
+  border-bottom: var(--hairline) solid var(--border);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--fg-3);
+}
+.panel-h .actions { display: flex; gap: 6px; }
+
+/* Common atoms */
+.mono { font-family: var(--font-mono); }
+.muted { color: var(--fg-3); }
+.dim   { color: var(--fg-4); }
+.num   { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 2px 6px;
+  border: 1px solid currentColor;
+  color: var(--fg-3);
+  border-radius: 2px;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+.tag.solid {
+  background: currentColor;
+}
+.tag.solid > * { color: var(--bg); }
+
+.role-po       { color: var(--role-po); }
+.role-dev      { color: var(--role-dev); }
+.role-qa       { color: var(--role-qa); }
+.role-reviewer { color: var(--role-reviewer); }
+.role-merge    { color: var(--role-merge); }
+.role-judge    { color: var(--role-judge); }
+
+.bg-role-po       { background: var(--role-po); }
+.bg-role-dev      { background: var(--role-dev); }
+.bg-role-qa       { background: var(--role-qa); }
+.bg-role-reviewer { background: var(--role-reviewer); }
+.bg-role-merge    { background: var(--role-merge); }
+.bg-role-judge    { background: var(--role-judge); }
+
+/* Subtle scrollbars */
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 0; }
+::-webkit-scrollbar-thumb:hover { background: var(--border-strong); }
+
+/* Buttons */
+.btn {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--fg-2);
+  cursor: pointer;
+  border-radius: 2px;
+}
+.btn:hover { color: var(--fg); border-color: var(--border-strong); }
+.btn.primary {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.btn.primary:hover { background: oklch(0.82 0.18 145 / 0.1); }
+
+/* Now-Playing hero strip */
+.now-strip {
+  display: grid;
+  grid-template-columns: 1fr;
+  background:
+    linear-gradient(180deg, oklch(0.18 0.008 250) 0%, var(--bg-1) 100%);
+  border-bottom: var(--hairline) solid var(--border);
+}
+
+/* Worker beat (live worker chip) */
+.worker-beat {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--pad-3);
+  padding: var(--pad-3) var(--pad-4);
+  border-right: var(--hairline) solid var(--border);
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+}
+.worker-beat:last-child { border-right: none; }
+.worker-beat .pulse {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--role-c);
+  box-shadow: 0 0 12px var(--role-c);
+  animation: heartbeat 1.4s ease-in-out infinite;
+}
+@keyframes heartbeat {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.45; transform: scale(0.7); }
+}
+.worker-beat .meta { display: grid; gap: 3px; min-width: 0; }
+.worker-beat .agent {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--fg);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.worker-beat .task {
+  font-size: 11px;
+  color: var(--fg-3);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.worker-beat .timer {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  color: var(--fg-2);
+}
+.worker-beat .role-stripe {
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 2px;
+  background: var(--role-c);
+}
+
+/* Bar chart (24h activity) */
+.bars {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+  gap: 3px;
+  align-items: end;
+  height: 100%;
+  padding: 0 var(--pad-2);
+}
+.bar-col {
+  display: flex;
+  flex-direction: column-reverse;
+  height: 100%;
+  position: relative;
+}
+.bar-seg {
+  width: 100%;
+  min-height: 1px;
+}
+.bar-tick {
+  position: absolute;
+  bottom: -16px;
+  left: 0; right: 0;
+  text-align: center;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--fg-4);
+}
+
+/* Sparkline */
+.spark { display: block; width: 100%; height: 100%; }
+
+/* Status dots */
+.status-dot {
+  display: inline-block;
+  width: 6px; height: 6px; border-radius: 50%;
+  vertical-align: middle;
+}
+.status-dot.idle  { background: var(--fg-4); }
+.status-dot.busy  { background: var(--accent); animation: pulse 2s infinite; }
+.status-dot.fail  { background: var(--fail); }
+
+/* Project card (overview grid) */
+.proj-card {
+  border: var(--hairline) solid var(--border);
+  background: var(--bg-1);
+  padding: var(--pad-3);
+  display: grid;
+  gap: var(--pad-2);
+  position: relative;
+  overflow: hidden;
+  transition: border-color .15s, background .15s;
+  cursor: pointer;
+}
+.proj-card:hover { border-color: var(--border-strong); background: var(--bg-2); }
+.proj-card.busy { border-color: oklch(0.82 0.18 145 / 0.5); }
+.proj-card.busy::before {
+  content: '';
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 2px;
+  background: var(--accent);
+}
+
+/* Activity feed row */
+.feed-row {
+  display: grid;
+  grid-template-columns: 16px 1fr auto;
+  gap: var(--pad-2);
+  padding: var(--pad-2) var(--pad-3);
+  border-bottom: var(--hairline) solid var(--border);
+  align-items: center;
+  font-size: 12px;
+}
+.feed-row:last-child { border-bottom: none; }
+.feed-row.fresh {
+  animation: flash 1.2s ease-out;
+}
+@keyframes flash {
+  0%   { background: oklch(0.82 0.18 145 / 0.18); }
+  100% { background: transparent; }
+}
+
+/* Tables */
+table.t { width: 100%; border-collapse: collapse; font-size: 12px; }
+table.t th, table.t td {
+  padding: var(--pad-2) var(--pad-3);
+  text-align: left;
+  border-bottom: var(--hairline) solid var(--border);
+}
+table.t th {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-3);
+  font-weight: 500;
+  background: var(--bg-1);
+  position: sticky; top: 0;
+}
+table.t tr:hover td { background: oklch(1 0 0 / 0.02); }
+
+/* Detail layouts */
+.detail-grid {
+  display: grid;
+  grid-template-columns: 1fr 360px;
+  gap: var(--hairline);
+  background: var(--border);
+}
+.detail-grid > * { background: var(--bg); }
+
+/* Kbd line */
+.cmdline {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-3);
+}
+.cmdline .prompt { color: var(--accent); }
+
+/* Marquee live ticker */
+.ticker {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  display: flex;
+  gap: 24px;
+  color: var(--fg-3);
+}
+.ticker .item { display: inline-flex; gap: 6px; align-items: center; }
+
+/* Section heading row separating screens */
+.screen-h {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: var(--pad-4) var(--pad-4) var(--pad-3);
+  border-bottom: var(--hairline) solid var(--border);
+}
+.screen-h h1 {
+  margin: 0;
+  font-size: 13px;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--fg);
+  font-weight: 500;
+}
+.screen-h .meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-3);
+}

--- a/web/src/lib/transforms.test.ts
+++ b/web/src/lib/transforms.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+import { buildLeaderboard, buildProjectStatus, build24hBuckets } from './transforms';
+import type { LoopEvent, Worker } from './types';
+
+type ExtLoopEvent = LoopEvent & { points?: number; agent?: string; ts?: number };
+
+function makeEvent(overrides: Partial<ExtLoopEvent> = {}): ExtLoopEvent {
+  return {
+    id: 1,
+    project: 'loop',
+    role: 'dev',
+    model: 'sonnet-4-6',
+    event_type: 'dev_done',
+    issue_number: 1,
+    pr_number: null,
+    detail: null,
+    created_at: new Date().toISOString(),
+    points: 0,
+    ...overrides,
+  };
+}
+
+function makeWorker(overrides: Partial<Worker> = {}): Worker {
+  return {
+    project: 'loop',
+    role: 'dev',
+    model: 'sonnet-4-6',
+    event_type: 'dev_start',
+    issue_number: 1,
+    pr_number: null,
+    detail: null,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ── buildLeaderboard ──────────────────────────────────────────────────────────
+
+describe('buildLeaderboard', () => {
+  it('aggregates points and verdicts by role', () => {
+    const events = [
+      makeEvent({ role: 'dev', points: 3 }),
+      makeEvent({ role: 'dev', points: 2 }),
+      makeEvent({ role: 'qa',  points: 5 }),
+      makeEvent({ role: 'dev', points: 0 }),
+    ];
+    const rows = buildLeaderboard(events, 'role');
+    const dev = rows.find((r) => r.key === 'dev')!;
+    const qa  = rows.find((r) => r.key === 'qa')!;
+    expect(dev.points).toBe(5);
+    expect(dev.verdicts).toBe(2);
+    expect(qa.points).toBe(5);
+    expect(qa.verdicts).toBe(1);
+  });
+
+  it('returns rows sorted descending by points', () => {
+    const events = [
+      makeEvent({ role: 'po',  points: 1 }),
+      makeEvent({ role: 'dev', points: 10 }),
+      makeEvent({ role: 'qa',  points: 5 }),
+    ];
+    const rows = buildLeaderboard(events, 'role');
+    expect(rows[0].key).toBe('dev');
+    expect(rows[1].key).toBe('qa');
+    expect(rows[2].key).toBe('po');
+  });
+
+  it('aggregates by agent/model when by=agent', () => {
+    const events = [
+      makeEvent({ agent: 'claude', model: 'sonnet-4-6', points: 3 }),
+      makeEvent({ agent: 'claude', model: 'sonnet-4-6', points: 2 }),
+      makeEvent({ agent: 'gpt',    model: 'gpt-5',      points: 7 }),
+    ];
+    const rows = buildLeaderboard(events, 'agent');
+    expect(rows[0].key).toBe('gpt/gpt-5');
+    expect(rows[0].points).toBe(7);
+    expect(rows[1].points).toBe(5);
+  });
+
+  it('ignores events with zero points in verdict count', () => {
+    const events = [
+      makeEvent({ role: 'merge', points: 0 }),
+      makeEvent({ role: 'merge', points: 0 }),
+    ];
+    const rows = buildLeaderboard(events, 'role');
+    expect(rows[0].verdicts).toBe(0);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(buildLeaderboard([])).toEqual([]);
+  });
+});
+
+// ── buildProjectStatus ────────────────────────────────────────────────────────
+
+describe('buildProjectStatus', () => {
+  it('marks projects with a busy worker as busy', () => {
+    const events = [makeEvent({ project: 'loop', points: 5 })];
+    const workers = [makeWorker({ project: 'loop' })];
+    const rows = buildProjectStatus(events, workers);
+    const loop = rows.find((r) => r.id === 'loop')!;
+    expect(loop.status).toBe('busy');
+    expect(loop.busyWorker).toBeTruthy();
+  });
+
+  it('marks projects with no busy worker as idle', () => {
+    const events = [makeEvent({ project: 'loop', points: 3 })];
+    const rows = buildProjectStatus(events, []);
+    expect(rows[0].status).toBe('idle');
+    expect(rows[0].busyWorker).toBeNull();
+  });
+
+  it('accumulates points across multiple events', () => {
+    const events = [
+      makeEvent({ project: 'loop', points: 2 }),
+      makeEvent({ project: 'loop', points: 3 }),
+      makeEvent({ project: 'loop', points: 0 }),
+    ];
+    const rows = buildProjectStatus(events, []);
+    expect(rows[0].points).toBe(5);
+    expect(rows[0].totalEvents).toBe(3);
+  });
+
+  it('tracks the most recent event_type as lastEvent', () => {
+    const old = makeEvent({ project: 'loop', event_type: 'dev_start', ts: Date.now() - 10_000 });
+    const recent = makeEvent({ project: 'loop', event_type: 'dev_done', ts: Date.now() });
+    const rows = buildProjectStatus([old, recent], []);
+    expect(rows[0].lastEvent).toBe('dev_done');
+  });
+
+  it('sorts by points descending', () => {
+    const events = [
+      makeEvent({ project: 'alpha', points: 1 }),
+      makeEvent({ project: 'beta',  points: 10 }),
+    ];
+    const rows = buildProjectStatus(events, []);
+    expect(rows[0].id).toBe('beta');
+  });
+});
+
+// ── build24hBuckets ───────────────────────────────────────────────────────────
+
+describe('build24hBuckets', () => {
+  it('returns exactly 24 buckets', () => {
+    expect(build24hBuckets([])).toHaveLength(24);
+  });
+
+  it('places a recent event in the last bucket (index 23)', () => {
+    const now = Date.now();
+    const events = [makeEvent({ role: 'dev', ts: now - 5 * 60 * 1000 })];
+    const buckets = build24hBuckets(events);
+    expect(buckets[23].counts['dev']).toBe(1);
+    expect(buckets[23].total).toBe(1);
+  });
+
+  it('places an event from ~23h ago in bucket 0', () => {
+    const ts = Date.now() - 23 * 60 * 60 * 1000 - 60_000;
+    const events = [makeEvent({ role: 'qa', ts })];
+    const buckets = build24hBuckets(events);
+    expect(buckets[0].counts['qa']).toBe(1);
+  });
+
+  it('ignores events older than 24h', () => {
+    const old = makeEvent({ ts: Date.now() - 25 * 3_600_000 });
+    const buckets = build24hBuckets([old]);
+    const total = buckets.reduce((s, b) => s + b.total, 0);
+    expect(total).toBe(0);
+  });
+
+  it('accumulates multiple events in the same bucket', () => {
+    const now = Date.now();
+    const events = [
+      makeEvent({ role: 'po',  ts: now - 1000 }),
+      makeEvent({ role: 'dev', ts: now - 2000 }),
+      makeEvent({ role: 'qa',  ts: now - 3000 }),
+    ];
+    const buckets = build24hBuckets(events);
+    expect(buckets[23].total).toBe(3);
+  });
+});

--- a/web/src/lib/transforms.ts
+++ b/web/src/lib/transforms.ts
@@ -1,0 +1,114 @@
+// Pure transform helpers ported from design/new-design/data.js.
+// No side effects, no network calls, no imports from fixtures.
+import type { LoopEvent, Worker } from './types';
+
+export interface LeaderboardRow {
+  key: string;
+  verdicts: number;
+  points: number;
+}
+
+type LeaderboardBy = 'role' | 'agent';
+
+export function buildLeaderboard(
+  events: (LoopEvent & { points?: number; agent?: string })[],
+  by: LeaderboardBy = 'role',
+): LeaderboardRow[] {
+  const map = new Map<string, LeaderboardRow>();
+  for (const e of events) {
+    const key = by === 'role' ? e.role : `${e.agent ?? ''}/${e.model ?? ''}`;
+    if (!map.has(key)) map.set(key, { key, verdicts: 0, points: 0 });
+    const row = map.get(key)!;
+    const pts = e.points ?? 0;
+    row.points += pts;
+    if (pts > 0) row.verdicts += 1;
+  }
+  return Array.from(map.values()).sort((a, b) => b.points - a.points);
+}
+
+export interface ProjectStatusRow {
+  id: string;
+  lastEvent: string | null;
+  lastTs: number;
+  status: 'idle' | 'busy';
+  points: number;
+  totalEvents: number;
+  busyWorker: Worker | null;
+}
+
+export function buildProjectStatus(
+  events: (LoopEvent & { points?: number; ts?: number })[],
+  workers: Worker[],
+): ProjectStatusRow[] {
+  const byProject = new Map<string, ProjectStatusRow>();
+
+  for (const e of events) {
+    if (!byProject.has(e.project)) {
+      byProject.set(e.project, {
+        id: e.project,
+        lastEvent: null,
+        lastTs: 0,
+        status: 'idle',
+        points: 0,
+        totalEvents: 0,
+        busyWorker: null,
+      });
+    }
+    const row = byProject.get(e.project)!;
+    row.totalEvents += 1;
+    row.points += e.points ?? 0;
+    const ts = e.ts ?? new Date(e.created_at).getTime();
+    if (ts > row.lastTs) {
+      row.lastTs = ts;
+      row.lastEvent = e.event_type;
+    }
+  }
+
+  for (const w of workers) {
+    if (!byProject.has(w.project)) {
+      byProject.set(w.project, {
+        id: w.project,
+        lastEvent: w.event_type,
+        lastTs: new Date(w.created_at).getTime(),
+        status: 'busy',
+        points: 0,
+        totalEvents: 0,
+        busyWorker: w,
+      });
+    } else {
+      const row = byProject.get(w.project)!;
+      row.status = 'busy';
+      row.busyWorker = w;
+    }
+  }
+
+  return Array.from(byProject.values()).sort((a, b) => b.points - a.points);
+}
+
+export interface HourBucket {
+  hour: number;
+  counts: Record<string, number>;
+  total: number;
+}
+
+const ROLES = ['po', 'dev', 'qa', 'reviewer', 'merge', 'judge'] as const;
+
+export function build24hBuckets(
+  events: (LoopEvent & { ts?: number })[],
+): HourBucket[] {
+  const buckets: HourBucket[] = Array.from({ length: 24 }, (_, i) => ({
+    hour: i,
+    counts: Object.fromEntries(ROLES.map((r) => [r, 0])),
+    total: 0,
+  }));
+  const now = Date.now();
+  for (const e of events) {
+    const ts = e.ts ?? new Date(e.created_at).getTime();
+    const hoursAgo = Math.floor((now - ts) / (60 * 60 * 1000));
+    if (hoursAgo < 0 || hoursAgo >= 24) continue;
+    const idx = 23 - hoursAgo;
+    buckets[idx].counts[e.role] = (buckets[idx].counts[e.role] ?? 0) + 1;
+    buckets[idx].total += 1;
+  }
+  return buckets;
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,0 +1,158 @@
+// TS interfaces mirroring server/routes payload shapes.
+// Read from server/routes/*.py — do not invent fields.
+
+export interface Worker {
+  project: string;
+  role: string;
+  model: string | null;
+  event_type: string;
+  issue_number: number | null;
+  pr_number: number | null;
+  detail: string | null;
+  created_at: string;
+}
+
+export interface BoardEntry {
+  project: string;
+  role: string;
+  model: string | null;
+  total_points: number;
+  verdict_count: number;
+}
+
+export interface Verdict {
+  id: number;
+  project: string;
+  role: string;
+  model: string | null;
+  points: number;
+  reason: string | null;
+  created_at: string;
+}
+
+export interface FeedItem {
+  id: number;
+  project: string;
+  role: string;
+  model: string | null;
+  event_type: string;
+  issue_number: number | null;
+  pr_number: number | null;
+  detail: string | null;
+  payload: Record<string, unknown> | null;
+  created_at: string;
+  age_seconds: number | null;
+  status: string;
+}
+
+export interface LoopEvent {
+  id: number;
+  project: string;
+  role: string;
+  model: string | null;
+  event_type: string;
+  issue_number: number | null;
+  pr_number: number | null;
+  detail: string | null;
+  created_at: string;
+  completed_at?: string;
+  started_at?: string | null;
+  duration_seconds?: number | null;
+  points?: number | null;
+}
+
+export interface StatusEntry {
+  project: string;
+  role: string;
+  model: string | null;
+  event_type: string;
+  issue_number: number | null;
+  pr_number: number | null;
+  detail: string | null;
+  payload: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export interface Project {
+  project: string;
+  repo: string;
+}
+
+export interface EventsGraphBucket {
+  hour: string;
+  role: string;
+  count: number;
+}
+
+export interface EventsGraph {
+  window_hours: number;
+  buckets: EventsGraphBucket[];
+}
+
+export interface QueueItem {
+  project: string;
+  kind: 'issue' | 'pr';
+  number: number;
+  title: string;
+  stage: string;
+  age_seconds: number;
+  reason: string;
+  loop_id: string | null;
+  github_url: string | null;
+}
+
+export interface PipelineRun {
+  id: number;
+  project: string;
+  issue_number: number | null;
+  pr_number: number | null;
+  title: string | null;
+  outcome: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  total_duration_seconds: number | null;
+  rework_count: number;
+  total_bounty: number | null;
+  created_at: string;
+}
+
+export interface PRMonitorEntry {
+  pr_number: number;
+  title: string | null;
+  branch: string | null;
+  stage: string | null;
+  time_in_stage_seconds: number | null;
+  retry_count: number;
+  last_event: string | null;
+  last_event_at: string | null;
+  github_url: string | null;
+  is_finished: boolean;
+  is_draft: boolean | null;
+}
+
+export interface Health {
+  status: string;
+  monitor_version: string;
+  git_sha: string;
+  supported_bounty_api: string;
+  core_version_counts: Record<string, number>;
+  loop_ids: string[];
+}
+
+export interface StatsActivity {
+  date: string;
+  project: string;
+  n: number;
+}
+
+export interface StatsStage {
+  stage: string;
+  avg_seconds: number;
+  count: number;
+}
+
+export interface StatsRework {
+  project: string;
+  rework_starts: number;
+  review_dones: number;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import './lib/tokens.css';
 import { App } from './App';
 
 const queryClient = new QueryClient({

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,21 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { App } from './App';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchInterval: 5000,
+      staleTime: 0,
+    },
+  },
+});
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </StrictMode>,
+);

--- a/web/src/screens/WorkerDetail.tsx
+++ b/web/src/screens/WorkerDetail.tsx
@@ -1,0 +1,259 @@
+import { useState, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { fetchFeed } from '../lib/api';
+
+function relTime(isoStr: string, ageSeconds: number | null): string {
+  const secs = ageSeconds ?? Math.floor((Date.now() - new Date(isoStr).getTime()) / 1000);
+  if (secs < 60) return `${secs}s`;
+  if (secs < 3600) return `${Math.floor(secs / 60)}m`;
+  if (secs < 86400) return `${Math.floor(secs / 3600)}h`;
+  return `${Math.floor(secs / 86400)}d`;
+}
+
+const EVENT_GLYPHS: Record<string, string> = {
+  po_start: '▸',   po_done: '✓',
+  dev_start: '▸',  dev_done: '✓',
+  qa_start: '▸',   qa_pass: '✓',  qa_fail: '✗',
+  review_start: '▸', review_done: '✓',
+  merge_start: '▸', merge_done: '◆',
+  judge_start: '▸', judge_done: '★',
+};
+
+function glyphColor(eventType: string, role: string): string {
+  return eventType.includes('_fail') || eventType.includes('_failed')
+    ? 'var(--fail)'
+    : `var(--role-${role})`;
+}
+
+interface AgentRow {
+  key: string;
+  role: string;
+  model: string | null;
+  events: number;
+  fails: number;
+  lastTs: number;
+  lastIso: string;
+  lastAge: number | null;
+  roles: Set<string>;
+}
+
+interface WorkerDetailProps {
+  setScreen: (s: string) => void;
+}
+
+export default function WorkerDetail({ setScreen }: WorkerDetailProps) {
+  const { data: items = [], isLoading } = useQuery({
+    queryKey: ['feed'],
+    queryFn: () => fetchFeed(),
+    refetchInterval: 5000,
+    staleTime: 0,
+  });
+
+  const byAgent = useMemo((): AgentRow[] => {
+    const m = new Map<string, AgentRow>();
+    for (const e of items) {
+      const k = `${e.role}/${e.model ?? ''}`;
+      if (!m.has(k)) {
+        m.set(k, {
+          key: k, role: e.role, model: e.model,
+          events: 0, fails: 0, lastTs: 0,
+          lastIso: e.created_at, lastAge: e.age_seconds,
+          roles: new Set(),
+        });
+      }
+      const row = m.get(k)!;
+      row.events += 1;
+      if (e.event_type === 'qa_fail' || e.event_type.includes('_fail')) row.fails += 1;
+      const ts = new Date(e.created_at).getTime();
+      if (ts > row.lastTs) {
+        row.lastTs = ts;
+        row.lastIso = e.created_at;
+        row.lastAge = e.age_seconds;
+      }
+      row.roles.add(e.role);
+    }
+    return Array.from(m.values()).sort((a, b) => b.events - a.events);
+  }, [items]);
+
+  const [filter, setFilter] = useState('');
+  const selectedKey = filter || byAgent[0]?.key;
+  const selected = byAgent.find(a => a.key === selectedKey) ?? byAgent[0];
+  const selectedItems = useMemo(
+    () => items.filter(e => `${e.role}/${e.model ?? ''}` === selected?.key).slice(0, 60),
+    [items, selected],
+  );
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 'var(--pad-4)', color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 12 }}>
+        Loading…
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="screen-h" style={{ alignItems: 'center', display: 'flex', gap: 'var(--pad-3)' }}>
+        <button className="btn" onClick={() => setScreen('overview')}>← Overview</button>
+        <h1 style={{ flex: 1 }}>
+          <span style={{ color: 'var(--fg-3)' }}>worker /</span>{' '}
+          {selected?.key ?? '—'}
+        </h1>
+        <span className="meta">{byAgent.length} unique agents</span>
+      </div>
+
+      <div
+        className="detail-grid"
+        style={{ alignItems: 'stretch', minHeight: 'calc(100vh - 140px)' }}
+      >
+        {/* Left: agent list */}
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <div className="panel" style={{ border: 'none', borderBottom: '1px solid var(--border)', flex: 1 }}>
+            <div className="panel-h"><span>All agents</span></div>
+            <div style={{ overflow: 'auto', maxHeight: '70vh' }}>
+              {byAgent.map(a => (
+                <div
+                  key={a.key}
+                  onClick={() => setFilter(a.key)}
+                  style={{
+                    padding: 'var(--pad-3) var(--pad-4)',
+                    borderBottom: '1px solid var(--border)',
+                    cursor: 'pointer',
+                    background: selectedKey === a.key ? 'var(--bg-2)' : 'transparent',
+                    borderLeft: selectedKey === a.key
+                      ? '2px solid var(--accent)'
+                      : '2px solid transparent',
+                    display: 'grid',
+                    gridTemplateColumns: '1fr auto',
+                    gap: 'var(--pad-2)',
+                    alignItems: 'center',
+                  }}
+                >
+                  <div>
+                    <div className="mono" style={{ fontSize: 13, color: 'var(--fg)' }}>
+                      {a.model ?? '(no model)'}
+                    </div>
+                    <div className="muted mono" style={{ fontSize: 10 }}>
+                      {a.role} · {Array.from(a.roles).join(', ')}
+                    </div>
+                  </div>
+                  <div style={{ textAlign: 'right' }}>
+                    <div className="num" style={{ color: 'var(--accent)' }}>{a.events}</div>
+                    {a.fails > 0 && (
+                      <div className="muted mono" style={{ fontSize: 10, color: 'var(--fail)' }}>
+                        {a.fails} fail
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))}
+              {byAgent.length === 0 && (
+                <div style={{
+                  padding: 'var(--pad-4)',
+                  color: 'var(--fg-4)',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 12,
+                  textAlign: 'center',
+                }}>
+                  No activity yet
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Right: detail */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--pad-3)', padding: 'var(--pad-4)' }}>
+          {selected ? (
+            <>
+              {/* KPI strip */}
+              <div style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(4, 1fr)',
+                gap: 1,
+                background: 'var(--border)',
+              }}>
+                {([
+                  ['Total events', String(selected.events)],
+                  ['Points',       '—'],
+                  ['QA fails',     String(selected.fails)],
+                  ['Last seen',    relTime(selected.lastIso, selected.lastAge) + ' ago'],
+                ] as [string, string][]).map(([k, v]) => (
+                  <div key={k} style={{ background: 'var(--bg-1)', padding: 'var(--pad-3)' }}>
+                    <div className="mono" style={{
+                      fontSize: 10,
+                      textTransform: 'uppercase',
+                      letterSpacing: '.12em',
+                      color: 'var(--fg-3)',
+                      marginBottom: 4,
+                    }}>{k}</div>
+                    <div className="num" style={{ fontSize: 20, color: 'var(--fg)' }}>{v}</div>
+                  </div>
+                ))}
+              </div>
+
+              {/* Recent events */}
+              <div className="panel">
+                <div className="panel-h">
+                  <span>Recent events for {selected.key}</span>
+                  <span className="muted mono" style={{ fontSize: 10 }}>{selectedItems.length} shown</span>
+                </div>
+                <div style={{ overflow: 'auto', maxHeight: 480 }}>
+                  {selectedItems.map(e => {
+                    const glyph = EVENT_GLYPHS[e.event_type] ?? '·';
+                    const color = glyphColor(e.event_type, e.role);
+                    const ref = e.issue_number != null
+                      ? `${e.project}#${e.issue_number}`
+                      : e.pr_number != null
+                        ? `${e.project}!${e.pr_number}`
+                        : e.project;
+                    return (
+                      <div key={e.id} className="feed-row">
+                        <span className="mono" style={{ color, fontSize: 12 }}>{glyph}</span>
+                        <div>
+                          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                            <span className={`tag role-${e.role}`}>{e.role}</span>
+                            <span className="mono" style={{ fontSize: 12 }}>{e.event_type}</span>
+                            <span className="muted mono" style={{ fontSize: 11 }}>· {ref}</span>
+                          </div>
+                          {e.detail && (
+                            <div className="muted" style={{ fontSize: 11, marginTop: 2 }}>{e.detail}</div>
+                          )}
+                        </div>
+                        <div style={{ textAlign: 'right' }}>
+                          <div className="muted mono" style={{ fontSize: 10 }}>
+                            {relTime(e.created_at, e.age_seconds)}
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                  {selectedItems.length === 0 && (
+                    <div style={{
+                      padding: 'var(--pad-4)',
+                      color: 'var(--fg-4)',
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: 12,
+                      textAlign: 'center',
+                    }}>
+                      No events for this agent
+                    </div>
+                  )}
+                </div>
+              </div>
+            </>
+          ) : (
+            <div style={{
+              padding: 'var(--pad-4)',
+              color: 'var(--fg-3)',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 12,
+            }}>
+              Select an agent from the list
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: '/v2/',
+  build: {
+    outDir: '../static/dist',
+    emptyOutDir: true,
+  },
+  server: {
+    proxy: {
+      '/api': 'http://127.0.0.1:18792',
+    },
+  },
+});


### PR DESCRIPTION
Closes #119

## Changes

### New: `web/src/screens/WorkerDetail.tsx`
Client-side rollup of `/api/feed` grouped by `role/model`. Shows:
- Left panel: scrollable agent list (role/model pairs sorted by event count, accent stripe + bg-2 on selected row)
- Right panel: 4-cell KPI grid (Total events, Points†, QA fails, Last seen) + scrollable recent-events feed

All layout and typography uses design tokens from `tokens.css`; no hard-coded colours or spacing. Renders correctly at all three density settings.

†Points show `—` since `FeedItem` from `/api/feed` does not carry point data; a future ticket can join with `/api/board` if needed.

### `web/src/App.tsx`
Added full screen-router with `useState<Screen>` and a `keydown` listener wired to KEYMAP `{1→overview, 2→queue, 3→projects, 4→workers}`. Keyboard shortcut `4` switches to the Worker Detail screen. Renders `<WorkerDetail>` when `screen === 'workers'`; placeholder text for screens not yet ported.

### Infrastructure brought forward from #114 (Vite scaffold, not yet merged to main)
- `web/src/lib/tokens.css` — full design-token sheet (colours, type, density, shell, panels, feed rows, etc.)
- `web/src/components/Logo.tsx`, `NavRail.tsx` — app-shell components required by the full layout
- `web/src/components/TopBar.tsx` — rewritten to use design-token CSS classes while keeping the TanStack Query live-worker-count from #115

### `web/src/main.tsx`
Added `import './lib/tokens.css'` so the token sheet loads globally.

### `tests/visual/` (new)
- `conftest.py` — Playwright fixtures (1440×900 viewport, freeze/mask JS for stable diffs) brought forward from #113
- `test_worker.py` — visual-diff test: starts at `http://localhost:5173/v2?fixtures=1`, presses `4`, screenshots, diffs against `design/reference-screenshots/worker.png` at ≤ 0.5% threshold. Skips gracefully if `playwright` is not installed or the dev server is unreachable.

### `static/js/components/feed.js` — **not deleted**
Still imported by `static/js/app.js` (the legacy Overview screen). The React Overview (#116) has not landed; deleting it now would break the running dashboard.

## Test Plan
- `npm run typecheck` in `web/` — passes (0 errors)
- `pytest tests/` (excluding pre-existing `test_graph.py::test_events_graph_with_data` date-sensitive failure) — 91 passed
- Manual: `cd web && npm run dev`, open `http://localhost:5173/v2?fixtures=1`, press `4` — Worker Detail renders with agent list and event panel
- Visual diff: `pytest tests/visual/test_worker.py -v` — requires running dev server + `design/reference-screenshots/worker.png` (created by #113)