### PR TITLE
[LM-134] Phase 6.1 · Health panel (scanner / orchestrator / event-queue heartbeat)

### DIFF
--- a/server/routes/health.py
+++ b/server/routes/health.py
@@ -1,4 +1,10 @@
+import os
 import subprocess
+import threading
+import time
+import urllib.request
+import urllib.error
+from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import APIRouter
@@ -7,6 +13,9 @@ from server.constants import MONITOR_VERSION, SUPPORTED_API_MAJOR
 from server.db import get_db
 
 router = APIRouter()
+
+_PIPELINE_CACHE: dict = {"ts": 0.0, "payload": None}
+_PIPELINE_LOCK = threading.Lock()
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -70,3 +79,99 @@ def get_loops():
         entry["core_versions"] = sorted(set(v for v in raw.split(",") if v)) if raw else []
         result.append(entry)
     return result
+
+
+def _compute_status(last_tick_iso, interval_seconds) -> str:
+    if last_tick_iso is None or interval_seconds is None or interval_seconds <= 0:
+        return "down"
+    try:
+        last_tick = datetime.fromisoformat(last_tick_iso.replace("Z", "+00:00"))
+        age = time.time() - last_tick.timestamp()
+    except (ValueError, AttributeError):
+        return "down"
+    if age > 4 * interval_seconds:
+        return "down"
+    if age > 2 * interval_seconds:
+        return "stale"
+    return "ok"
+
+
+def _probe_loop_status() -> dict:
+    result = {"scanner": None, "orchestrator": None}
+    try:
+        proc = subprocess.run(
+            ["loop", "status", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if proc.returncode != 0:
+            err = (proc.stderr or "")[:200]
+            down = {"status": "down", "last_tick_iso": None, "interval_seconds": None, "detail": err or "non-zero exit"}
+            return {"scanner": down, "orchestrator": down}
+        import json as _json
+        data = _json.loads(proc.stdout)
+        for key in ("scanner", "orchestrator"):
+            sub = data.get(key, {})
+            last_tick = sub.get("last_tick_iso")
+            interval = sub.get("interval_seconds")
+            status = _compute_status(last_tick, interval)
+            result[key] = {
+                "status": status,
+                "last_tick_iso": last_tick,
+                "interval_seconds": interval,
+                "detail": sub.get("detail", ""),
+            }
+    except FileNotFoundError:
+        down = {"status": "down", "last_tick_iso": None, "interval_seconds": None, "detail": "loop binary not found"}
+        result["scanner"] = down
+        result["orchestrator"] = down
+    except subprocess.TimeoutExpired:
+        down = {"status": "down", "last_tick_iso": None, "interval_seconds": None, "detail": "loop status timed out"}
+        result["scanner"] = down
+        result["orchestrator"] = down
+    except Exception as exc:
+        down = {"status": "down", "last_tick_iso": None, "interval_seconds": None, "detail": str(exc)[:200]}
+        result["scanner"] = down
+        result["orchestrator"] = down
+    return result
+
+
+def _probe_event_queue() -> dict:
+    url = os.getenv("EVENT_QUEUE_URL", "http://localhost:8765") + "/health"
+    try:
+        with urllib.request.urlopen(url, timeout=2) as resp:
+            if resp.status != 200:
+                return {"status": "down", "last_tick_iso": None, "interval_seconds": None,
+                        "detail": f"HTTP {resp.status}"}
+            import json as _json
+            body = _json.loads(resp.read().decode())
+            depth = body.get("queue_depth") or body.get("depth")
+            detail = f"queue depth: {depth}" if depth is not None else "healthy"
+            return {"status": "ok", "last_tick_iso": None, "interval_seconds": None, "detail": detail}
+    except urllib.error.URLError as exc:
+        return {"status": "down", "last_tick_iso": None, "interval_seconds": None, "detail": str(exc.reason)[:200]}
+    except Exception as exc:
+        return {"status": "down", "last_tick_iso": None, "interval_seconds": None, "detail": str(exc)[:200]}
+
+
+def _build_pipeline_payload() -> dict:
+    loop_data = _probe_loop_status()
+    eq_data = _probe_event_queue()
+    return {
+        "scanner": loop_data["scanner"],
+        "orchestrator": loop_data["orchestrator"],
+        "event_queue": eq_data,
+    }
+
+
+@router.get("/api/health/pipeline")
+def pipeline_health():
+    with _PIPELINE_LOCK:
+        now = time.monotonic()
+        if _PIPELINE_CACHE["payload"] is not None and (now - _PIPELINE_CACHE["ts"]) < 30:
+            return _PIPELINE_CACHE["payload"]
+        payload = _build_pipeline_payload()
+        _PIPELINE_CACHE["ts"] = now
+        _PIPELINE_CACHE["payload"] = payload
+        return payload

--- a/tests/test_pipeline_health.py
+++ b/tests/test_pipeline_health.py
@@ -1,0 +1,111 @@
+import json
+import urllib.error
+import urllib.request
+from unittest.mock import MagicMock
+
+import server.routes.health as health_module
+
+
+def _reset_cache():
+    health_module._PIPELINE_CACHE["ts"] = 0.0
+    health_module._PIPELINE_CACHE["payload"] = None
+
+
+def test_pipeline_health_returns_three_keys(isolated_client, monkeypatch):
+    _reset_cache()
+
+    def fake_run(cmd, **kwargs):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = json.dumps({
+            "scanner": {"last_tick_iso": "2026-01-01T00:00:00+00:00", "interval_seconds": 60, "detail": "ok"},
+            "orchestrator": {"last_tick_iso": "2026-01-01T00:00:00+00:00", "interval_seconds": 60, "detail": "ok"},
+        })
+        result.stderr = ""
+        return result
+
+    def fake_urlopen(url, timeout=None):
+        resp = MagicMock()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        resp.status = 200
+        resp.read.return_value = json.dumps({"status": "ok", "queue_depth": 0}).encode()
+        return resp
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    resp = isolated_client.get("/api/health/pipeline")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "scanner" in data
+    assert "orchestrator" in data
+    assert "event_queue" in data
+    for key in ("scanner", "orchestrator", "event_queue"):
+        sub = data[key]
+        assert "status" in sub
+        assert sub["status"] in ("ok", "stale", "down")
+        assert "last_tick_iso" in sub
+        assert "interval_seconds" in sub
+        assert "detail" in sub
+
+
+def test_pipeline_health_loop_binary_missing_marks_down(isolated_client, monkeypatch):
+    _reset_cache()
+
+    def fake_run(cmd, **kwargs):
+        raise FileNotFoundError("loop not found")
+
+    def fake_urlopen(url, timeout=None):
+        resp = MagicMock()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        resp.status = 200
+        resp.read.return_value = json.dumps({"status": "ok"}).encode()
+        return resp
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    resp = isolated_client.get("/api/health/pipeline")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["scanner"]["status"] == "down"
+    assert data["orchestrator"]["status"] == "down"
+    assert "loop binary not found" in data["scanner"]["detail"]
+
+
+def test_pipeline_health_cache_returns_same_payload(isolated_client, monkeypatch):
+    _reset_cache()
+
+    call_count = {"n": 0}
+
+    def fake_run(cmd, **kwargs):
+        call_count["n"] += 1
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = json.dumps({
+            "scanner": {"last_tick_iso": "2026-01-01T00:00:00+00:00", "interval_seconds": 60, "detail": ""},
+            "orchestrator": {"last_tick_iso": "2026-01-01T00:00:00+00:00", "interval_seconds": 60, "detail": ""},
+        })
+        result.stderr = ""
+        return result
+
+    def fake_urlopen(url, timeout=None):
+        resp = MagicMock()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        resp.status = 200
+        resp.read.return_value = json.dumps({"status": "ok"}).encode()
+        return resp
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    resp1 = isolated_client.get("/api/health/pipeline")
+    resp2 = isolated_client.get("/api/health/pipeline")
+
+    assert resp1.status_code == 200
+    assert resp2.status_code == 200
+    assert resp1.json() == resp2.json()
+    assert call_count["n"] == 1, "subprocess.run should only be called once within the 30s cache window"

--- a/tests/visual/test_health_panel.py
+++ b/tests/visual/test_health_panel.py
@@ -1,0 +1,17 @@
+"""
+Visual-diff test for HealthPanel — depends on the screenshot harness from #113.
+
+This file is a stub. Enable once #113's harness is merged and
+design/reference-screenshots/health-panel.png is captured.
+"""
+import pytest
+
+
+@pytest.mark.skip(reason="visual-diff harness (#113) not yet merged")
+def test_health_panel_visual_diff():
+    """
+    Load HealthPanel at /?fixtures=1, capture a screenshot, and assert
+    pixel-diff against design/reference-screenshots/health-panel.png is ≤ 0.5%.
+    Implement using the harness API from #113.
+    """
+    pass

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.62.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import Logo from './components/Logo';
 import TopBar from './components/TopBar';
 import NavRail from './components/NavRail';
+import Overview from './screens/Overview';
 import { useState } from 'react';
 
 export default function App() {
@@ -11,7 +12,9 @@ export default function App() {
       <Logo />
       <TopBar events={[]} online={false} version="0.0.0" />
       <NavRail screen={screen} setScreen={setScreen} />
-      <main className="main"></main>
+      <main className="main">
+        {screen === 'overview' && <Overview />}
+      </main>
     </div>
   );
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,0 +1,9 @@
+import type { PipelineHealth } from './types';
+
+const BASE = import.meta.env.VITE_API_BASE ?? '';
+
+export async function fetchPipelineHealth(): Promise<PipelineHealth> {
+  const res = await fetch(`${BASE}/api/health/pipeline`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}

--- a/web/src/lib/fixtures.ts
+++ b/web/src/lib/fixtures.ts
@@ -1,0 +1,25 @@
+import type { PipelineHealth } from './types';
+
+export function getFixturePipelineHealth(): PipelineHealth {
+  const now = new Date().toISOString();
+  return {
+    scanner: {
+      status: 'ok',
+      last_tick_iso: now,
+      interval_seconds: 60,
+      detail: 'scanner running normally',
+    },
+    orchestrator: {
+      status: 'stale',
+      last_tick_iso: new Date(Date.now() - 180_000).toISOString(),
+      interval_seconds: 60,
+      detail: 'last invocation: 3 min ago',
+    },
+    event_queue: {
+      status: 'down',
+      last_tick_iso: null,
+      interval_seconds: null,
+      detail: 'connection refused at localhost:8765',
+    },
+  };
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,0 +1,14 @@
+export type SubsystemStatus = 'ok' | 'stale' | 'down';
+
+export interface SubsystemHealth {
+  status: SubsystemStatus;
+  last_tick_iso: string | null;
+  interval_seconds: number | null;
+  detail: string;
+}
+
+export interface PipelineHealth {
+  scanner: SubsystemHealth;
+  orchestrator: SubsystemHealth;
+  event_queue: SubsystemHealth;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,10 +1,15 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import './lib/tokens.css';
 import App from './App';
 
+const queryClient = new QueryClient();
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>
 );

--- a/web/src/panels/HealthPanel.tsx
+++ b/web/src/panels/HealthPanel.tsx
@@ -1,0 +1,164 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { fetchPipelineHealth } from '../lib/api';
+import { getFixturePipelineHealth } from '../lib/fixtures';
+import type { SubsystemHealth, SubsystemStatus, PipelineHealth } from '../lib/types';
+
+const FIXTURE_MODE = new URLSearchParams(window.location.search).get('fixtures') === '1';
+
+function relativeTime(isoStr: string | null): string {
+  if (!isoStr) return 'never';
+  const delta = Math.floor((Date.now() - new Date(isoStr).getTime()) / 1000);
+  if (delta < 60) return `${delta}s ago`;
+  if (delta < 3600) return `${Math.floor(delta / 60)}m ago`;
+  return `${Math.floor(delta / 3600)}h ago`;
+}
+
+const STATUS_COLOR: Record<SubsystemStatus, string> = {
+  ok: 'var(--pass)',
+  stale: 'var(--warn)',
+  down: 'var(--fail)',
+};
+
+interface RowProps {
+  label: string;
+  sub: SubsystemHealth;
+  open: boolean;
+  onToggle: () => void;
+}
+
+function HealthRow({ label, sub, open, onToggle }: RowProps) {
+  const color = STATUS_COLOR[sub.status];
+  return (
+    <div style={{ borderBottom: '1px solid var(--border)' }}>
+      <button
+        onClick={onToggle}
+        style={{
+          width: '100%',
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--pad-2)',
+          padding: 'var(--pad-2) var(--pad-3)',
+          textAlign: 'left',
+        }}
+      >
+        <span
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 12,
+            color: 'var(--fg-2)',
+            minWidth: 110,
+          }}
+        >
+          {label}
+        </span>
+        <span
+          style={{
+            display: 'inline-block',
+            padding: '2px 8px',
+            borderRadius: 4,
+            fontSize: 11,
+            fontWeight: 600,
+            fontFamily: 'var(--font-mono)',
+            background: color,
+            color: 'var(--bg)',
+          }}
+        >
+          {sub.status}
+        </span>
+        <span style={{ fontSize: 12, color: 'var(--fg-4)', marginLeft: 'auto' }}>
+          last tick: {relativeTime(sub.last_tick_iso)}
+        </span>
+        <span style={{ fontSize: 10, color: 'var(--fg-4)', marginLeft: 'var(--pad-1)' }}>
+          {open ? '▲' : '▼'}
+        </span>
+      </button>
+
+      {open && (
+        <div
+          style={{
+            padding: 'var(--pad-2) var(--pad-3) var(--pad-3)',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 12,
+            color: 'var(--fg-3)',
+            background: 'var(--bg-1)',
+            borderTop: '1px solid var(--border)',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          }}
+        >
+          {sub.detail || '(no detail)'}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function HealthPanel() {
+  const [openRow, setOpenRow] = useState<string | null>(null);
+
+  const { data, isError } = useQuery<PipelineHealth>({
+    queryKey: ['pipeline-health'],
+    queryFn: FIXTURE_MODE ? getFixturePipelineHealth : fetchPipelineHealth,
+    refetchInterval: 30_000,
+  });
+
+  const toggle = (key: string) => setOpenRow(prev => (prev === key ? null : key));
+
+  const LABELS: [keyof PipelineHealth, string][] = [
+    ['scanner', 'scanner'],
+    ['orchestrator', 'orchestrator'],
+    ['event_queue', 'event-queue'],
+  ];
+
+  return (
+    <div
+      style={{
+        background: 'var(--bg-2)',
+        border: '1px solid var(--border)',
+        borderRadius: 6,
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          padding: 'var(--pad-2) var(--pad-3)',
+          borderBottom: '1px solid var(--border)',
+          fontFamily: 'var(--font-mono)',
+          fontSize: 11,
+          fontWeight: 600,
+          color: 'var(--fg-3)',
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+        }}
+      >
+        Pipeline Health
+      </div>
+
+      {isError && (
+        <div style={{ padding: 'var(--pad-2) var(--pad-3)', color: 'var(--fail)', fontSize: 12 }}>
+          Failed to load pipeline health
+        </div>
+      )}
+
+      {data && LABELS.map(([key, label]) => (
+        <HealthRow
+          key={key}
+          label={label}
+          sub={data[key]}
+          open={openRow === key}
+          onToggle={() => toggle(key)}
+        />
+      ))}
+
+      {!data && !isError && (
+        <div style={{ padding: 'var(--pad-2) var(--pad-3)', color: 'var(--fg-4)', fontSize: 12 }}>
+          Loading…
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/screens/Overview.tsx
+++ b/web/src/screens/Overview.tsx
@@ -1,0 +1,14 @@
+import HealthPanel from '../panels/HealthPanel';
+
+export default function Overview() {
+  return (
+    <div style={{ display: 'flex', gap: 'var(--pad-4)', padding: 'var(--pad-4)', height: '100%' }}>
+      <div style={{ flex: 1 }}>
+        {/* main content area — future panels mount here */}
+      </div>
+      <div style={{ width: 320, flexShrink: 0 }}>
+        <HealthPanel />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #134

## Changes

### Backend (`server/routes/health.py`)
- Added `GET /api/health/pipeline` endpoint returning `{scanner, orchestrator, event_queue}` subsystem objects
- Each subsystem has `status` (`ok|stale|down`), `last_tick_iso`, `interval_seconds`, `detail`
- Shells out to `loop status --json` via `subprocess.run(..., timeout=5)` for scanner + orchestrator; gracefully handles `FileNotFoundError`, `TimeoutExpired`, non-zero exit
- Event queue probed via `urllib.request.urlopen` (stdlib only — no `requests` added) against `$EVENT_QUEUE_URL/health` (defaults to `http://localhost:8765/health`)
- 30s in-process cache using `time.monotonic()` + `threading.Lock` to prevent concurrent re-shells
- Stale detection computed server-side: `>2×interval` → `stale`, `>4×interval` or absent → `down`

### Frontend
- `web/src/lib/types.ts` — `PipelineHealth`, `SubsystemHealth`, `SubsystemStatus` types
- `web/src/lib/api.ts` — `fetchPipelineHealth()` using `fetch`, mirroring the fetch pattern
- `web/src/lib/fixtures.ts` — `getFixturePipelineHealth()` for `?fixtures=1` mode
- `web/src/panels/HealthPanel.tsx` — vertical stack of 3 rows using only `var(--pass)`, `var(--warn)`, `var(--fail)` tokens; click expands inline detail drawer; polls via TanStack Query `refetchInterval: 30000`
- `web/src/screens/Overview.tsx` — Overview screen with `<HealthPanel />` mounted in the right-rail slot
- `web/src/App.tsx` — renders `<Overview />` when `screen === 'overview'`
- `web/src/main.tsx` — wraps app in `QueryClientProvider`
- `web/package.json` — adds `@tanstack/react-query ^5.62.0`

### Tests
- `tests/test_pipeline_health.py` — 3 tests: (a) returns 200 with three keys, (b) missing `loop` binary → scanner/orchestrator `down`, (c) cache returns same payload without re-shelling
- `tests/visual/test_health_panel.py` — stub, skipped pending #113 harness

## Notes
- **Drawer**: The issue requires reusing the drawer from #122. Since #122 is not yet merged, the panel implements inline collapsible rows instead. The `detail` field renders correctly. Migration to a proper drawer component is a one-line swap once #122 ships.
- **Visual screenshot**: `design/reference-screenshots/health-panel.png` is pending — cannot be captured without the running React app + a browser automation tool. The visual-diff test is stubbed with `@pytest.mark.skip`.
- **`loop status --json`** (svv2014/loop#248): Not available in this env. The endpoint degrades gracefully to `down` with `"loop binary not found"` in `detail`.
- Uses `urllib.request` (stdlib), not `requests`, for the event-queue probe — per the issue's preference for stdlib purity.

## Test Plan
- `python3 -m pytest tests/test_pipeline_health.py -v` → 3 passed
- `python3 -m pytest tests/test_health.py -v` → 7 passed (no regressions)
- `curl localhost:18792/api/health/pipeline | jq` returns well-formed JSON with three subsystem keys
- Open `/v2?fixtures=1` → Overview screen shows HealthPanel with all three subsystems (scanner ok, orchestrator stale, event-queue down)