### PR TITLE
[LM-136] Phase 6.3 · Stuck detector

### DIFF
--- a/server/routes/action_queue.py
+++ b/server/routes/action_queue.py
@@ -11,9 +11,27 @@ from server.helpers.timeline import parse_ts
 router = APIRouter()
 
 STUCK_STAGES = {"blocked", "needs-clarification"}
-TIMEOUT_STAGES = {"in-progress", "in-review", "in-rework"}
+TIMEOUT_STAGES = {"in-progress", "in-review", "in-rework", "needs-qa", "needs-review", "ready-for-qa"}
 QA_FAIL_STAGE = "qa-fail"
 QA_FAIL_RETRY_THRESHOLD = 3
+
+STAGE_THRESHOLD_ENV = {
+    "in-progress":  "HANDLER_TIMEOUT_DEV",
+    "in-rework":    "HANDLER_TIMEOUT_DEV",
+    "in-review":    "HANDLER_TIMEOUT_REVIEW",
+    "needs-review": "HANDLER_TIMEOUT_REVIEW",
+    "needs-qa":     "HANDLER_TIMEOUT_QA",
+    "ready-for-qa": "HANDLER_TIMEOUT_QA",
+}
+
+STAGE_DEFAULTS = {
+    "in-progress":  7200,
+    "in-rework":    7200,
+    "in-review":    1800,
+    "needs-review": 1800,
+    "needs-qa":     3600,
+    "ready-for-qa": 3600,
+}
 
 
 def _handler_timeout_seconds() -> int:
@@ -21,6 +39,17 @@ def _handler_timeout_seconds() -> int:
         return int(os.environ.get("HANDLER_TIMEOUT", "3600"))
     except ValueError:
         return 3600
+
+
+def _threshold_for_stage(stage: str) -> int:
+    env_key = STAGE_THRESHOLD_ENV.get(stage)
+    fallback = STAGE_DEFAULTS.get(stage, _handler_timeout_seconds() * 2)
+    if env_key:
+        try:
+            return int(os.environ.get(env_key, fallback))
+        except ValueError:
+            return fallback
+    return fallback
 
 
 def _action_queue_reason(
@@ -41,7 +70,6 @@ def action_queue():
 
     Derived from the latest event per (project, kind, number). No GitHub API call.
     """
-    threshold = _handler_timeout_seconds() * 2
     conn = get_db()
     rows = conn.execute(
         """
@@ -80,6 +108,7 @@ def action_queue():
         stage = (r["event_type"] or "").lower()
         created = parse_ts(r["created_at"])
         age_seconds = int((now - created).total_seconds()) if created else 0
+        threshold = _threshold_for_stage(stage)
         reason = _action_queue_reason(stage, age_seconds, r["rework_count"] or 0, threshold)
         if reason is None:
             continue
@@ -104,6 +133,7 @@ def action_queue():
             "stage": stage,
             "age_seconds": age_seconds,
             "reason": reason,
+            "threshold_seconds": threshold if reason == "timeout" else None,
             "loop_id": r["loop_id"],
             "github_url": github_url,
         })

--- a/tests/test_action_queue.py
+++ b/tests/test_action_queue.py
@@ -37,7 +37,7 @@ def test_action_queue_needs_clarification(isolated_client):
 
 
 def test_action_queue_timeout_threshold(isolated_client, monkeypatch):
-    monkeypatch.setenv("HANDLER_TIMEOUT", "100")  # threshold = 200
+    monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "200")
     server._insert_event(server.ReportPayload(
         project="loop", role="dev", event_type="in-progress", issue_number=11
     ))
@@ -57,7 +57,7 @@ def test_action_queue_timeout_threshold(isolated_client, monkeypatch):
 
 
 def test_action_queue_in_progress_below_threshold_excluded(isolated_client, monkeypatch):
-    monkeypatch.setenv("HANDLER_TIMEOUT", "3600")
+    monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "3600")
     server._insert_event(server.ReportPayload(
         project="loop", role="dev", event_type="in-progress", issue_number=13
     ))
@@ -67,7 +67,7 @@ def test_action_queue_in_progress_below_threshold_excluded(isolated_client, monk
 
 
 def test_action_queue_sorted_by_age_desc(isolated_client, monkeypatch):
-    monkeypatch.setenv("HANDLER_TIMEOUT", "100")
+    monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "100")
     server._insert_event(server.ReportPayload(
         project="loop", role="dev", event_type="blocked", issue_number=200
     ))
@@ -84,3 +84,76 @@ def test_action_queue_sorted_by_age_desc(isolated_client, monkeypatch):
     data = resp.json()
     nums = [it["number"] for it in data if it["number"] in (200, 201)]
     assert nums == [200, 201]
+
+
+def test_action_queue_per_stage_threshold_dev_override(isolated_client, monkeypatch):
+    monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "500")
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="in-progress", issue_number=300
+    ))
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        "UPDATE events SET created_at = datetime('now', '-600 seconds') WHERE issue_number = 300"
+    )
+    conn.commit()
+    conn.close()
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    timeout_items = [it for it in data if it["reason"] == "timeout" and it["number"] == 300]
+    assert len(timeout_items) == 1
+    assert timeout_items[0]["threshold_seconds"] == 500
+
+
+def test_action_queue_needs_qa_past_threshold(isolated_client, monkeypatch):
+    monkeypatch.setenv("HANDLER_TIMEOUT_QA", "60")
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="needs-qa", issue_number=301
+    ))
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        "UPDATE events SET created_at = datetime('now', '-120 seconds') WHERE issue_number = 301"
+    )
+    conn.commit()
+    conn.close()
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    timeout_items = [it for it in data if it["reason"] == "timeout" and it["number"] == 301]
+    assert len(timeout_items) == 1
+    assert timeout_items[0]["stage"] == "needs-qa"
+    assert timeout_items[0]["threshold_seconds"] == 60
+
+
+def test_action_queue_needs_qa_under_threshold_excluded(isolated_client, monkeypatch):
+    monkeypatch.setenv("HANDLER_TIMEOUT_QA", "3600")
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="needs-qa", issue_number=302
+    ))
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    assert all(it["number"] != 302 for it in data)
+
+
+def test_action_queue_threshold_seconds_field(isolated_client, monkeypatch):
+    monkeypatch.setenv("HANDLER_TIMEOUT_QA", "60")
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="needs-qa", issue_number=303
+    ))
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="blocked", issue_number=304
+    ))
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        "UPDATE events SET created_at = datetime('now', '-120 seconds') WHERE issue_number = 303"
+    )
+    conn.commit()
+    conn.close()
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    timeout_item = next((it for it in data if it["number"] == 303), None)
+    stuck_item = next((it for it in data if it["number"] == 304), None)
+    assert timeout_item is not None
+    assert timeout_item["reason"] == "timeout"
+    assert timeout_item["threshold_seconds"] == 60
+    assert stuck_item is not None
+    assert stuck_item["reason"] == "stuck_label"
+    assert stuck_item["threshold_seconds"] is None

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,0 +1,12 @@
+export interface QueueItem {
+  project: string;
+  kind: 'issue' | 'pr';
+  number: number;
+  title: string;
+  stage: string;
+  age_seconds: number;
+  reason: 'stuck_label' | 'timeout' | 'qa_fail_repeated';
+  threshold_seconds: number | null;
+  loop_id: string | null;
+  github_url: string | null;
+}

--- a/web/src/screens/Queue.tsx
+++ b/web/src/screens/Queue.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useState } from 'react';
+import type { QueueItem } from '../lib/types';
+
+function formatAge(seconds: number): string {
+  if (seconds >= 3600) {
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    return `${h}h ${m}m`;
+  }
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+}
+
+interface DrawerProps {
+  item: QueueItem;
+  onClose: () => void;
+}
+
+function Drawer({ item, onClose }: DrawerProps) {
+  return (
+    <div className="drawer-overlay" onClick={onClose}>
+      <div className="drawer" onClick={e => e.stopPropagation()}>
+        <button className="drawer-close" onClick={onClose}>×</button>
+        <h2>{item.title || `${item.kind} #${item.number}`}</h2>
+        <dl>
+          <dt>Project</dt><dd>{item.project}</dd>
+          <dt>Stage</dt><dd>{item.stage}</dd>
+          <dt>Age</dt><dd>{formatAge(item.age_seconds)}</dd>
+          <dt>Reason</dt><dd>{item.reason}</dd>
+          {item.threshold_seconds !== null && (
+            <><dt>Threshold</dt><dd>{formatAge(item.threshold_seconds)}</dd></>
+          )}
+        </dl>
+        {item.github_url && (
+          <a href={item.github_url} target="_blank" rel="noreferrer">
+            View on GitHub
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface RowProps {
+  item: QueueItem;
+  onClick: (item: QueueItem) => void;
+}
+
+function QueueRow({ item, onClick }: RowProps) {
+  return (
+    <tr className="queue-row" onClick={() => onClick(item)} style={{ cursor: 'pointer' }}>
+      <td>{item.project}</td>
+      <td>{item.kind} #{item.number}</td>
+      <td>{item.stage}</td>
+      <td>{formatAge(item.age_seconds)}</td>
+      <td>{item.stage}</td>
+    </tr>
+  );
+}
+
+export default function Queue() {
+  const [items, setItems] = useState<QueueItem[]>([]);
+  const [selected, setSelected] = useState<QueueItem | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/action_queue')
+      .then(r => r.json())
+      .then((data: QueueItem[]) => {
+        setItems(data);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
+  const stuckItems = items
+    .filter(i => i.reason === 'stuck_label' || i.reason === 'timeout')
+    .sort((a, b) => b.age_seconds - a.age_seconds);
+
+  const otherItems = items
+    .filter(i => i.reason !== 'stuck_label' && i.reason !== 'timeout')
+    .sort((a, b) => b.age_seconds - a.age_seconds);
+
+  if (loading) return <div className="muted">Loading…</div>;
+
+  return (
+    <div className="queue-screen">
+      <section className="queue-section">
+        <h2 className="queue-section-title">Stuck</h2>
+        {stuckItems.length === 0 ? (
+          <div className="muted">No stuck items</div>
+        ) : (
+          <table className="queue-table">
+            <thead>
+              <tr>
+                <th>Project</th>
+                <th>Item</th>
+                <th>Stage</th>
+                <th>Age</th>
+                <th>Last Event</th>
+              </tr>
+            </thead>
+            <tbody>
+              {stuckItems.map(item => (
+                <QueueRow
+                  key={`${item.project}-${item.kind}-${item.number}`}
+                  item={item}
+                  onClick={setSelected}
+                />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      {otherItems.length > 0 && (
+        <section className="queue-section">
+          <h2 className="queue-section-title">Action Queue</h2>
+          <table className="queue-table">
+            <thead>
+              <tr>
+                <th>Project</th>
+                <th>Item</th>
+                <th>Stage</th>
+                <th>Age</th>
+                <th>Last Event</th>
+              </tr>
+            </thead>
+            <tbody>
+              {otherItems.map(item => (
+                <QueueRow
+                  key={`${item.project}-${item.kind}-${item.number}`}
+                  item={item}
+                  onClick={setSelected}
+                />
+              ))}
+            </tbody>
+          </table>
+        </section>
+      )}
+
+      {selected && <Drawer item={selected} onClose={() => setSelected(null)} />}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #136

## Changes

### Backend (`server/routes/action_queue.py`)
- Replaced single `_handler_timeout_seconds()` call with per-stage `_threshold_for_stage(stage)` helper
- Added `STAGE_THRESHOLD_ENV` mapping (stage → env var: `HANDLER_TIMEOUT_DEV`, `HANDLER_TIMEOUT_QA`, `HANDLER_TIMEOUT_REVIEW`)
- Added `STAGE_DEFAULTS` per-stage fallback seconds (dev=7200, qa=3600, review=1800)
- Extended `TIMEOUT_STAGES` to include `needs-qa`, `needs-review`, `ready-for-qa`
- Added `threshold_seconds: int | null` field to each returned item (populated for `timeout` items, `null` for `stuck_label` / `qa_fail_repeated`)
- `HANDLER_TIMEOUT` legacy env var still used as fallback for unmapped stages (backwards-compatible)

### Tests (`tests/test_action_queue.py`)
- Added 4 new test cases: per-stage env override, `needs-qa` past threshold, `needs-qa` under threshold excluded, `threshold_seconds` field correctness
- Updated existing tests to use `HANDLER_TIMEOUT_DEV` for `in-progress` stage (consistent with new per-stage logic)

### Frontend (`web/src/lib/types.ts`)
- New file: `QueueItem` interface with all action queue fields including `threshold_seconds: number | null`

### Frontend (`web/src/screens/Queue.tsx`)
- New file: Queue screen with **Stuck** sub-section (items where `reason ∈ {"stuck_label", "timeout"}`)
- Sorted by `age_seconds` descending; empty state shows "No stuck items"
- Age formatted as `mm:ss` under 1h, `Xh Ym` above 1h
- Click row opens detail drawer showing all fields including threshold when applicable

## Test Plan
- `pytest tests/test_action_queue.py -v` — all 10 tests pass
- `cd web && npm run typecheck` — passes
- Set `HANDLER_TIMEOUT_QA=60` and insert a `needs-qa` event backdated >60s — should appear in Stuck section
- Verify empty Stuck state renders "No stuck items" when no items qualify