### PR TITLE
[LM-138] Phase 6.5 · Retry counter + concurrency-slots widget

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -26,6 +26,7 @@ from server.routes import (  # noqa: E402
     ingest,
     logs,
     runs,
+    scanner_state,
     stats,
 )
 
@@ -39,6 +40,7 @@ app.include_router(graph.router)
 app.include_router(action_queue.router)
 app.include_router(claude_usage.router)
 app.include_router(logs.router)
+app.include_router(scanner_state.router)
 
 if os.path.isdir("static/dist"):
     app.mount("/v2", StaticFiles(directory="static/dist", html=True), name="dist")

--- a/server/routes/scanner_state.py
+++ b/server/routes/scanner_state.py
@@ -1,0 +1,132 @@
+import glob
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+ROLES = ["po", "dev", "qa", "reviewer", "merge"]
+
+# Matches loop's current retry policy; update here if loop ever exposes the limit
+RETRY_MAX = 2
+
+CAP_RE = re.compile(r"max=(\d+) \(per-tick emit cap\)")
+
+MAX_TAIL_LINES = 200
+MAX_TAIL_BYTES = 5 * 1024 * 1024  # mirror logs.py
+
+
+def _scanner_log_path() -> Path:
+    raw = os.environ.get("LOOP_LOG_DIR") or "~/.openclaw/workspace/logs/loop"
+    return Path(os.path.expanduser(raw)) / "loop-scanner.log"
+
+
+def _read_caps(scanner_log_path: Path) -> dict[str, Optional[int]]:
+    result: dict[str, Optional[int]] = {role: None for role in ROLES}
+    if not scanner_log_path.exists():
+        return result
+    try:
+        size = os.stat(str(scanner_log_path)).st_size
+        start = max(0, size - MAX_TAIL_BYTES)
+        with open(scanner_log_path, "rb") as fh:
+            fh.seek(start)
+            data = fh.read(MAX_TAIL_BYTES)
+        text = data.decode("utf-8", errors="replace")
+        if start > 0:
+            nl = text.find("\n")
+            if nl != -1:
+                text = text[nl + 1:]
+        lines = text.splitlines()[-MAX_TAIL_LINES:]
+        # Scan from end; pick most recent cap per role
+        found: dict[str, int] = {}
+        for line in reversed(lines):
+            m = CAP_RE.search(line)
+            if m:
+                cap = int(m.group(1))
+                for role in ROLES:
+                    if role not in found and f"loop-{role}-handler" in line:
+                        found[role] = cap
+            if len(found) == len(ROLES):
+                break
+        for role, cap in found.items():
+            result[role] = cap
+    except OSError:
+        pass
+    return result
+
+
+def _count_inflight(role: str) -> int:
+    try:
+        out = subprocess.run(
+            ["pgrep", "-f", f"loop-{role}-handler"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        # pgrep returns exit 1 when no matches — not an error
+        return sum(1 for line in out.stdout.splitlines() if line.strip())
+    except (subprocess.SubprocessError, OSError):
+        return 0
+
+
+def _read_retries(retries_dir: Path = Path("/tmp")) -> list[dict]:
+    result: list[dict] = []
+    try:
+        files = glob.glob(str(retries_dir / "loop-*-retries-*"))
+    except OSError:
+        return result
+
+    for filepath in files:
+        name = Path(filepath).name
+        try:
+            # split on '-retries-' to isolate role from the project/kind/number tail
+            parts = name.split("-retries-", 1)
+            if len(parts) != 2:
+                continue
+            role_part, suffix = parts
+            if not role_part.startswith("loop-"):
+                continue
+            role = role_part[len("loop-"):]
+            if not role:
+                continue
+            # suffix: '{project}-{kind}-{number}'; project may contain dashes
+            suffix_parts = suffix.rsplit("-", 2)
+            if len(suffix_parts) != 3:
+                continue
+            project, kind, number_str = suffix_parts
+            if not project or not kind:
+                continue
+            number = int(number_str)
+            count = int(Path(filepath).read_text().strip())
+            result.append({
+                "project": project,
+                "kind": kind,
+                "number": number,
+                "stage": role,
+                "count": count,
+                "max": RETRY_MAX,
+            })
+        except (ValueError, OSError):
+            continue
+    return result
+
+
+@router.get("/api/scanner_state")
+def get_scanner_state():
+    caps = _read_caps(_scanner_log_path())
+    stages = {}
+    for role in ROLES:
+        stages[role] = {
+            "in_flight": _count_inflight(role),
+            "cap": caps[role],
+        }
+
+    retries_dir_env = os.environ.get("LOOP_RETRIES_DIR")
+    retries_dir = Path(retries_dir_env) if retries_dir_env else Path("/tmp")
+    retries = _read_retries(retries_dir)
+
+    return {"stages": stages, "retries": retries}

--- a/tests/test_scanner_state.py
+++ b/tests/test_scanner_state.py
@@ -1,0 +1,190 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from server.app import app
+from server.routes import scanner_state as ss_module
+
+client = TestClient(app)
+
+
+def _make_subprocess_mock(stdout="", returncode=0):
+    mock_result = MagicMock()
+    mock_result.stdout = stdout
+    mock_result.returncode = returncode
+    return mock_result
+
+
+class TestEndpointNoFilesNoLog:
+    """Endpoint with no retry files and no scanner log returns empty retries + null caps."""
+
+    def test_empty_retries_and_null_caps(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOOP_LOG_DIR", str(tmp_path))
+        monkeypatch.setenv("LOOP_RETRIES_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            "server.routes.scanner_state.subprocess.run",
+            lambda *a, **kw: _make_subprocess_mock(stdout="", returncode=1),
+        )
+
+        resp = client.get("/api/scanner_state")
+        assert resp.status_code == 200
+        body = resp.json()
+
+        assert body["retries"] == []
+        for role in ss_module.ROLES:
+            assert body["stages"][role]["cap"] is None
+            assert body["stages"][role]["in_flight"] == 0
+
+
+class TestEndpointRetryFiles:
+    """Endpoint with two valid retry files parses both correctly."""
+
+    def test_two_retry_files(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOOP_LOG_DIR", str(tmp_path))
+        monkeypatch.setenv("LOOP_RETRIES_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            "server.routes.scanner_state.subprocess.run",
+            lambda *a, **kw: _make_subprocess_mock(stdout="", returncode=1),
+        )
+
+        (tmp_path / "loop-po-retries-loop-monitor-issue-137").write_text("1")
+        (tmp_path / "loop-dev-retries-my-project-issue-42").write_text("2")
+
+        resp = client.get("/api/scanner_state")
+        assert resp.status_code == 200
+        retries = resp.json()["retries"]
+
+        assert len(retries) == 2
+
+        po_row = next(r for r in retries if r["stage"] == "po")
+        assert po_row["project"] == "loop-monitor"
+        assert po_row["kind"] == "issue"
+        assert po_row["number"] == 137
+        assert po_row["count"] == 1
+        assert po_row["max"] == ss_module.RETRY_MAX
+
+        dev_row = next(r for r in retries if r["stage"] == "dev")
+        assert dev_row["project"] == "my-project"
+        assert dev_row["kind"] == "issue"
+        assert dev_row["number"] == 42
+        assert dev_row["count"] == 2
+
+
+class TestMalformedRetryFilename:
+    """Malformed retry filename is silently skipped."""
+
+    def test_malformed_skipped(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOOP_LOG_DIR", str(tmp_path))
+        monkeypatch.setenv("LOOP_RETRIES_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            "server.routes.scanner_state.subprocess.run",
+            lambda *a, **kw: _make_subprocess_mock(stdout="", returncode=1),
+        )
+
+        # Malformed: missing required parts
+        (tmp_path / "loop-retries-nope").write_text("1")
+        # Missing number
+        (tmp_path / "loop-po-retries-project-onlykind").write_text("1")
+        # Valid one to confirm parsing still works
+        (tmp_path / "loop-qa-retries-some-proj-issue-5").write_text("1")
+
+        resp = client.get("/api/scanner_state")
+        assert resp.status_code == 200
+        retries = resp.json()["retries"]
+
+        assert len(retries) == 1
+        assert retries[0]["stage"] == "qa"
+
+
+class TestScannerLogCapParsing:
+    """Scanner log with max=4 (per-tick emit cap) line yields parsed cap."""
+
+    def test_cap_parsed_from_log(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOOP_LOG_DIR", str(tmp_path))
+        monkeypatch.setenv("LOOP_RETRIES_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            "server.routes.scanner_state.subprocess.run",
+            lambda *a, **kw: _make_subprocess_mock(stdout="", returncode=1),
+        )
+
+        log = tmp_path / "loop-scanner.log"
+        log.write_text(
+            "[2026-05-09 10:00:00] [scanner] loop-po-handler max=4 (per-tick emit cap)\n"
+            "[2026-05-09 10:00:00] [scanner] loop-dev-handler max=4 (per-tick emit cap)\n"
+            "[2026-05-09 10:00:00] [scanner] loop-qa-handler max=4 (per-tick emit cap)\n"
+            "[2026-05-09 10:00:00] [scanner] loop-reviewer-handler max=4 (per-tick emit cap)\n"
+            "[2026-05-09 10:00:00] [scanner] loop-merge-handler max=4 (per-tick emit cap)\n"
+        )
+
+        resp = client.get("/api/scanner_state")
+        assert resp.status_code == 200
+        stages = resp.json()["stages"]
+
+        for role in ss_module.ROLES:
+            assert stages[role]["cap"] == 4
+
+
+class TestHelperReadCaps:
+    """Unit tests for _read_caps helper."""
+
+    def test_missing_log_returns_all_none(self, tmp_path):
+        caps = ss_module._read_caps(tmp_path / "nonexistent.log")
+        assert all(v is None for v in caps.values())
+
+    def test_partial_roles_in_log(self, tmp_path):
+        log = tmp_path / "loop-scanner.log"
+        log.write_text(
+            "[2026-05-09 10:00:00] [scanner] loop-po-handler max=3 (per-tick emit cap)\n"
+        )
+        caps = ss_module._read_caps(log)
+        assert caps["po"] == 3
+        assert caps["dev"] is None
+
+
+class TestHelperReadRetries:
+    """Unit tests for _read_retries helper."""
+
+    def test_unreadable_file_skipped(self, tmp_path):
+        f = tmp_path / "loop-po-retries-proj-issue-1"
+        f.write_text("not-an-int")
+        retries = ss_module._read_retries(tmp_path)
+        assert retries == []
+
+    def test_valid_file_parsed(self, tmp_path):
+        f = tmp_path / "loop-merge-retries-loop-monitor-issue-99"
+        f.write_text("2")
+        retries = ss_module._read_retries(tmp_path)
+        assert len(retries) == 1
+        assert retries[0]["stage"] == "merge"
+        assert retries[0]["project"] == "loop-monitor"
+        assert retries[0]["number"] == 99
+        assert retries[0]["count"] == 2
+
+
+class TestHelperCountInflight:
+    """Unit tests for _count_inflight helper."""
+
+    def test_zero_when_pgrep_exits_1(self, monkeypatch):
+        monkeypatch.setattr(
+            "server.routes.scanner_state.subprocess.run",
+            lambda *a, **kw: _make_subprocess_mock(stdout="", returncode=1),
+        )
+        assert ss_module._count_inflight("po") == 0
+
+    def test_counts_non_empty_lines(self, monkeypatch):
+        monkeypatch.setattr(
+            "server.routes.scanner_state.subprocess.run",
+            lambda *a, **kw: _make_subprocess_mock(stdout="1234\n5678\n", returncode=0),
+        )
+        assert ss_module._count_inflight("po") == 2
+
+    def test_subprocess_error_returns_zero(self, monkeypatch):
+        import subprocess
+
+        def raise_err(*a, **kw):
+            raise subprocess.SubprocessError("boom")
+
+        monkeypatch.setattr("server.routes.scanner_state.subprocess.run", raise_err)
+        assert ss_module._count_inflight("dev") == 0

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,0 +1,9 @@
+import type { ScannerState } from './types';
+
+const BASE = '';
+
+export async function fetchScannerState(): Promise<ScannerState> {
+  const res = await fetch(`${BASE}/api/scanner_state`);
+  if (!res.ok) throw new Error(`scanner_state: ${res.status}`);
+  return res.json() as Promise<ScannerState>;
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,0 +1,18 @@
+export interface StageInfo {
+  in_flight: number;
+  cap: number | null;
+}
+
+export interface RetryRow {
+  project: string;
+  kind: string;
+  number: number;
+  stage: string;
+  count: number;
+  max: number;
+}
+
+export interface ScannerState {
+  stages: Record<string, StageInfo>;
+  retries: RetryRow[];
+}

--- a/web/src/panels/ScannerState.tsx
+++ b/web/src/panels/ScannerState.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useState, useRef } from 'react';
+import { fetchScannerState } from '../lib/api';
+import type { ScannerState as ScannerStateType, RetryRow } from '../lib/types';
+
+const ROLES = ['po', 'dev', 'qa', 'reviewer', 'merge'] as const;
+const POLL_MS = 5000;
+
+interface Props {
+  projectId: string;
+}
+
+export default function ScannerState({ projectId }: Props) {
+  const [data, setData] = useState<ScannerStateType | null>(null);
+  const [error, setError] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const result = await fetchScannerState();
+        if (!cancelled) {
+          setData(result);
+          setError(false);
+        }
+      } catch {
+        if (!cancelled) setError(true);
+      }
+    }
+
+    load();
+    timerRef.current = setInterval(load, POLL_MS);
+
+    return () => {
+      cancelled = true;
+      if (timerRef.current !== null) clearInterval(timerRef.current);
+    };
+  }, []);
+
+  const allCapsNull = data
+    ? ROLES.every((r) => data.stages[r]?.cap == null)
+    : false;
+
+  const projectRetries: RetryRow[] = data
+    ? data.retries.filter((r) => r.project === projectId)
+    : [];
+
+  if (error && !data) {
+    return (
+      <div className="panel">
+        <div className="panel-h">Scanner State</div>
+        <div style={{ padding: 'var(--pad-3)', color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 11 }}>
+          Scanner state unavailable
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="panel">
+      <div className="panel-h">Scanner State</div>
+
+      <div style={{ padding: 'var(--pad-2) var(--pad-3)', borderBottom: 'var(--hairline) solid var(--border)' }}>
+        <div style={{ fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--fg-3)', marginBottom: 'var(--pad-2)' }}>
+          Global concurrency
+        </div>
+        {allCapsNull ? (
+          <div style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 11 }}>
+            Scanner state unavailable
+          </div>
+        ) : (
+          <table className="t">
+            <thead>
+              <tr>
+                <th>Stage</th>
+                <th>Used</th>
+                <th>Cap</th>
+                <th style={{ minWidth: 80 }}>Util</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ROLES.map((role) => {
+                const stage = data?.stages[role];
+                const used = stage?.in_flight ?? 0;
+                const cap = stage?.cap ?? null;
+                const pct = cap != null && cap > 0 ? Math.round((used / cap) * 100) : null;
+                return (
+                  <tr key={role}>
+                    <td>
+                      <span className={`tag role-${role}`}>{role}</span>
+                    </td>
+                    <td className="num">{used}</td>
+                    <td className="num">{cap ?? '—'}</td>
+                    <td>
+                      {pct != null ? (
+                        <UtilBar pct={pct} />
+                      ) : (
+                        <span className="dim">—</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <div style={{ padding: 'var(--pad-2) var(--pad-3)' }}>
+        <div style={{ fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--fg-3)', marginBottom: 'var(--pad-2)' }}>
+          Retries
+        </div>
+        {projectRetries.length === 0 ? (
+          <div style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 11 }}>
+            No retries pending
+          </div>
+        ) : (
+          <table className="t">
+            <thead>
+              <tr>
+                <th>Project</th>
+                <th>Ticket</th>
+                <th>Stage</th>
+                <th>Count</th>
+              </tr>
+            </thead>
+            <tbody>
+              {projectRetries.map((row, i) => (
+                <tr key={i}>
+                  <td className="mono">{row.project}</td>
+                  <td className="mono">{row.kind}#{row.number}</td>
+                  <td>
+                    <span className={`tag role-${row.stage}`}>{row.stage}</span>
+                  </td>
+                  <td className="num">{row.count}/{row.max}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function UtilBar({ pct }: { pct: number }) {
+  const color = pct >= 90
+    ? 'var(--fail)'
+    : pct >= 70
+    ? 'var(--warn)'
+    : 'var(--accent)';
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+      <div style={{ flex: 1, height: 4, background: 'var(--bg-3)', borderRadius: 2, overflow: 'hidden' }}>
+        <div style={{ width: `${pct}%`, height: '100%', background: color, transition: 'width 0.3s' }} />
+      </div>
+      <span className="num" style={{ fontSize: 10, color: 'var(--fg-3)', minWidth: 28, textAlign: 'right' }}>
+        {pct}%
+      </span>
+    </div>
+  );
+}

--- a/web/src/screens/ProjectDetail.tsx
+++ b/web/src/screens/ProjectDetail.tsx
@@ -1,0 +1,16 @@
+import ScannerState from '../panels/ScannerState';
+
+interface Props {
+  projectId: string;
+}
+
+export default function ProjectDetail({ projectId }: Props) {
+  return (
+    <div style={{ padding: 'var(--pad-4)', display: 'grid', gap: 'var(--pad-3)' }}>
+      <div className="screen-h">
+        <h1>{projectId}</h1>
+      </div>
+      <ScannerState projectId={projectId} />
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #138

## Changes

### Backend
- **`server/routes/scanner_state.py`** (new): `GET /api/scanner_state` endpoint with three isolated helpers:
  - `_read_caps()`: parses `max=N (per-tick emit cap)` from the last 200 lines of the scanner log; returns `cap: null` if log absent or pattern not found
  - `_count_inflight()`: counts running handlers per role via `pgrep -f loop-{role}-handler`; exit 1 (no matches) maps to 0, not an error
  - `_read_retries()`: globs `/tmp/loop-*-retries-*`, parses `loop-{role}-retries-{project}-{kind}-{number}` filenames defensively (malformed → skip silently); reads count from file content; hardcodes `max: 2`
  - `LOOP_RETRIES_DIR` env var overrides the default `/tmp` for retry file lookup (used in tests)
- **`server/app.py`**: registers the new `scanner_state` router

### Frontend
- **`web/src/lib/types.ts`** (new): `StageInfo`, `RetryRow`, `ScannerState` interfaces
- **`web/src/lib/api.ts`** (new): `fetchScannerState()` fetch wrapper
- **`web/src/panels/ScannerState.tsx`** (new): two-section panel — Global concurrency table (stage × used/cap/util-bar) and Retries table (project/ticket/stage/count). Polls at 5 s via `useEffect` + `setInterval`. Empty states: "No retries pending" and "Scanner state unavailable". All styling via CSS tokens from `tokens.css`.
- **`web/src/screens/ProjectDetail.tsx`** (new): project detail screen wiring `ScannerState` panel; filters retries by `projectId`

### Tests
- **`tests/test_scanner_state.py`** (new): 11 tests covering:
  - Endpoint with no files/log → empty retries + null caps
  - Two valid retry files → parsed correctly
  - Malformed retry filename → silently skipped
  - Scanner log with `max=4 (per-tick emit cap)` → cap parsed per role
  - Unit tests for all three helper functions

## Test Plan
- `pytest tests/test_scanner_state.py -v` → 11/11 pass ✓
- `cd web && npm run typecheck` → passes ✓
- Manually verify `/api/scanner_state` returns `{"stages": {...}, "retries": [...]}` with correct structure
- With retry files present in `/tmp`, verify they appear in the retries table for the matching project
- With scanner log containing cap lines, verify the util bar fills correctly