### PR TITLE
[LM-115] Phase 2 · API client, transforms, fixture mode

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "loop-monitor-web",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.56.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -16,7 +17,8 @@
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.1",
         "typescript": "^5.6.3",
-        "vite": "^5.4.8"
+        "vite": "^5.4.8",
+        "vitest": "^2.0.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1138,6 +1140,32 @@
         "win32"
       ]
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.9.tgz",
+      "integrity": "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.9.tgz",
+      "integrity": "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.9"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1239,6 +1267,129 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.28",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.28.tgz",
@@ -1286,6 +1437,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001792",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
@@ -1306,6 +1467,33 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -1339,12 +1527,29 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.353",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.353.tgz",
       "integrity": "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1393,6 +1598,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fsevents": {
@@ -1464,6 +1689,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1472,6 +1704,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/ms": {
@@ -1506,6 +1748,23 @@
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1642,6 +1901,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1650,6 +1916,64 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/typescript": {
@@ -1755,6 +2079,112 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/web/package.json
+++ b/web/package.json
@@ -6,9 +6,11 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.56.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
@@ -17,6 +19,7 @@
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.1",
     "typescript": "^5.6.3",
-    "vite": "^5.4.8"
+    "vite": "^5.4.8",
+    "vitest": "^2.0.5"
   }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,15 +1,36 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import Logo from './components/Logo';
 import TopBar from './components/TopBar';
 import NavRail from './components/NavRail';
-import { useState } from 'react';
+import { fetchActive, fetchHealth } from './lib/api';
 
 export default function App() {
   const [screen, setScreen] = useState('overview');
 
+  const activeQuery = useQuery({
+    queryKey: ['active'],
+    queryFn: () => fetchActive(),
+    refetchInterval: 5000,
+    staleTime: 0,
+  });
+
+  const healthQuery = useQuery({
+    queryKey: ['health'],
+    queryFn: () => fetchHealth(),
+    staleTime: 60_000,
+  });
+
+  const events = (activeQuery.data ?? []).map((w) => ({
+    ts: new Date(w.created_at).getTime(),
+  }));
+  const online = !activeQuery.isError;
+  const version = healthQuery.data?.monitor_version ?? '…';
+
   return (
     <div className="app">
       <Logo />
-      <TopBar events={[]} online={false} version="0.0.0" />
+      <TopBar events={events} online={online} version={version} />
       <NavRail screen={screen} setScreen={setScreen} />
       <main className="main"></main>
     </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,0 +1,119 @@
+// Thin fetch client mirroring the endpoints in static/js/api.js.
+// When ?fixtures=1 is in the URL every function returns seeded data
+// and makes zero network calls — verifiable in DevTools Network tab.
+import type {
+  Worker,
+  BoardEntry,
+  Verdict,
+  FeedItem,
+  LoopEvent,
+  StatusEntry,
+  Project,
+  EventsGraph,
+  QueueItem,
+  PipelineRun,
+  PRMonitorEntry,
+  Health,
+  StatsActivity,
+  StatsStage,
+  StatsRework,
+} from './types';
+import * as fx from './fixtures';
+
+function isFixtureMode(): boolean {
+  return new URLSearchParams(window.location.search).has('fixtures');
+}
+
+async function get<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText} — ${url}`);
+  return res.json() as Promise<T>;
+}
+
+export async function fetchActive(loop_id?: string): Promise<Worker[]> {
+  if (isFixtureMode()) return fx.getFixtureActive();
+  const qs = loop_id ? `?loop_id=${encodeURIComponent(loop_id)}` : '';
+  return get<Worker[]>(`/api/active${qs}`);
+}
+
+export async function fetchBoard(): Promise<BoardEntry[]> {
+  if (isFixtureMode()) return fx.getFixtureBoard();
+  return get<BoardEntry[]>('/api/board');
+}
+
+export async function fetchVerdicts(): Promise<Verdict[]> {
+  if (isFixtureMode()) return fx.getFixtureVerdicts();
+  return get<Verdict[]>('/api/verdicts');
+}
+
+export interface FeedParams {
+  loop_id?: string;
+  role?: string;
+  status?: string;
+}
+
+export async function fetchFeed(params: FeedParams = {}): Promise<FeedItem[]> {
+  if (isFixtureMode()) return fx.getFixtureFeed();
+  const p = new URLSearchParams();
+  if (params.loop_id) p.set('loop_id', params.loop_id);
+  if (params.role)    p.set('role', params.role);
+  if (params.status)  p.set('status', params.status);
+  const qs = p.size ? `?${p.toString()}` : '';
+  return get<FeedItem[]>(`/api/feed${qs}`);
+}
+
+export async function fetchHistory(loop_id?: string): Promise<LoopEvent[]> {
+  if (isFixtureMode()) return fx.getFixtureHistory();
+  const qs = loop_id ? `?loop_id=${encodeURIComponent(loop_id)}` : '';
+  return get<LoopEvent[]>(`/api/history${qs}`);
+}
+
+export async function fetchStatus(): Promise<StatusEntry[]> {
+  if (isFixtureMode()) return fx.getFixtureStatus();
+  return get<StatusEntry[]>('/api/status');
+}
+
+export async function fetchProjects(): Promise<Project[]> {
+  if (isFixtureMode()) return fx.getFixtureProjects();
+  return get<Project[]>('/api/projects');
+}
+
+export async function fetchEventsGraph(window_hours = 24): Promise<EventsGraph> {
+  if (isFixtureMode()) return fx.getFixtureEventsGraph();
+  return get<EventsGraph>(`/api/events_graph?window=${window_hours}`);
+}
+
+export async function fetchActionQueue(): Promise<QueueItem[]> {
+  if (isFixtureMode()) return fx.getFixtureActionQueue();
+  return get<QueueItem[]>('/api/action_queue');
+}
+
+export async function fetchRuns(project: string): Promise<PipelineRun[]> {
+  if (isFixtureMode()) return fx.getFixtureRuns(project);
+  return get<PipelineRun[]>(`/api/runs/${encodeURIComponent(project)}`);
+}
+
+export async function fetchPRMonitor(project: string): Promise<PRMonitorEntry[]> {
+  if (isFixtureMode()) return fx.getFixturePRMonitor(project);
+  return get<PRMonitorEntry[]>(`/api/projects/${encodeURIComponent(project)}/prs`);
+}
+
+export async function fetchHealth(): Promise<Health> {
+  if (isFixtureMode()) return fx.getFixtureHealth();
+  return get<Health>('/api/health');
+}
+
+export async function fetchStatsActivity(): Promise<StatsActivity[]> {
+  if (isFixtureMode()) return fx.getFixtureStatsActivity();
+  return get<StatsActivity[]>('/api/stats/activity');
+}
+
+export async function fetchStatsStages(): Promise<StatsStage[]> {
+  if (isFixtureMode()) return fx.getFixtureStatsStages();
+  return get<StatsStage[]>('/api/stats/stages');
+}
+
+export async function fetchStatsRework(): Promise<StatsRework[]> {
+  if (isFixtureMode()) return fx.getFixtureStatsRework();
+  return get<StatsRework[]>('/api/stats/rework');
+}

--- a/web/src/lib/fixtures.ts
+++ b/web/src/lib/fixtures.ts
@@ -1,0 +1,322 @@
+// Deterministic fixture data ported verbatim from design/new-design/data.js.
+// Same LCG seed (0xC0FFEE) and constants ensure byte-identical output across
+// runs — required by the Phase 0 visual-diff harness.
+import type {
+  Worker,
+  BoardEntry,
+  FeedItem,
+  LoopEvent,
+  StatusEntry,
+  Project,
+  EventsGraph,
+  QueueItem,
+  PipelineRun,
+  PRMonitorEntry,
+  Health,
+  StatsActivity,
+  StatsStage,
+  StatsRework,
+  Verdict,
+} from './types';
+
+const PROJECTS = [
+  { id: 'loop',               repo: 'svv2014/loop' },
+  { id: 'loop-monitor',       repo: 'svv2014/loop-monitor' },
+  { id: 'boba-event',         repo: 'svv2014/boba-event' },
+  { id: 'boba-orchestrator',  repo: 'svv2014/boba-orchestrator' },
+  { id: 'ntc',                repo: 'svv2014/NanoTraderCopilot' },
+  { id: 'pa-scanner',         repo: 'svv2014/pa-scanner' },
+  { id: 'ppl',                repo: 'svv2014/ppl-study' },
+  { id: 'suprun',             repo: 'svv2014/suprun' },
+  { id: 'vrefm-classifier',   repo: 'svv2014/vrefm-classifier' },
+] as const;
+
+const ROLES = ['po', 'dev', 'qa', 'reviewer', 'merge', 'judge'] as const;
+
+const AGENTS = [
+  { agent: 'claude', model: 'sonnet-4-6' },
+  { agent: 'claude', model: 'opus-4-1' },
+  { agent: 'claude', model: 'haiku-4-5' },
+  { agent: 'gpt',    model: 'gpt-5' },
+  { agent: 'gpt',    model: 'gpt-5-mini' },
+  { agent: 'gemini', model: 'gemini-2-5' },
+] as const;
+
+const EVENT_TYPES = [
+  'po_start', 'po_done',
+  'dev_start', 'dev_done',
+  'qa_pass', 'qa_fail',
+  'review_done',
+  'merge_done',
+  'judge_done',
+] as const;
+
+const ROLE_BY_EVENT: Record<string, string> = {
+  po_start: 'po', po_done: 'po',
+  dev_start: 'dev', dev_done: 'dev',
+  qa_pass: 'qa', qa_fail: 'qa',
+  review_done: 'reviewer',
+  merge_done: 'merge',
+  judge_done: 'judge',
+};
+
+// Deterministic RNG — same LCG constants as design/new-design/data.js
+let _seed = 0xC0FFEE;
+function resetSeed() { _seed = 0xC0FFEE; }
+function rand(): number {
+  _seed = (_seed * 1664525 + 1013904223) >>> 0;
+  return _seed / 0xFFFFFFFF;
+}
+function pick<T>(arr: readonly T[]): T { return arr[Math.floor(rand() * arr.length)]; }
+function randInt(lo: number, hi: number): number { return lo + Math.floor(rand() * (hi - lo + 1)); }
+
+type RawEvent = LoopEvent & { ts: number; agent: string; points: number; duration_ms: number };
+
+function buildHistory(): RawEvent[] {
+  const now = Date.now();
+  const events: RawEvent[] = [];
+  const DAY = 24 * 60 * 60 * 1000;
+  for (let i = 0; i < 600; i++) {
+    const t = now - rand() * DAY;
+    const event_type = pick(EVENT_TYPES);
+    const role = ROLE_BY_EVENT[event_type];
+    const project = pick(PROJECTS);
+    const ag = pick(AGENTS);
+    const pts = ['merge_done', 'judge_done', 'dev_done', 'po_done', 'review_done'].includes(event_type)
+      ? randInt(1, 5) : 0;
+    events.push({
+      id: i,
+      ts: t,
+      event_type,
+      role,
+      agent: ag.agent,
+      model: ag.model,
+      project: project.id,
+      issue_number: randInt(20, 150),
+      pr_number: randInt(20, 150),
+      points: pts,
+      duration_ms: randInt(800, 240000),
+      detail: null,
+      created_at: new Date(t).toISOString(),
+    });
+  }
+  events.sort((a, b) => b.ts - a.ts);
+  return events;
+}
+
+// Build once at module load with seed reset so output is always identical
+resetSeed();
+const HISTORY = buildHistory();
+
+const WORKERS_INITIAL: Worker[] = [
+  { project: 'loop',             role: 'dev',      model: 'sonnet-4-6', event_type: 'dev_start',    issue_number: 142, pr_number: null, detail: '#142 implement retry backoff', created_at: new Date(Date.now() - 124_000).toISOString() },
+  { project: 'loop-monitor',     role: 'reviewer', model: 'opus-4-1',   event_type: 'review_start',  issue_number: 138, pr_number: 138,  detail: '#138 review PR diff',          created_at: new Date(Date.now() - 47_000).toISOString() },
+  { project: 'ppl',              role: 'po',       model: 'gpt-5',      event_type: 'po_start',      issue_number: 150, pr_number: null, detail: '#150 spec breakdown',          created_at: new Date(Date.now() - 12_000).toISOString() },
+  { project: 'vrefm-classifier', role: 'qa',       model: 'haiku-4-5',  event_type: 'qa_start',      issue_number: 101, pr_number: null, detail: '#101 run regression suite',    created_at: new Date(Date.now() - 8_000).toISOString() },
+  { project: 'boba-event',       role: 'judge',    model: 'gemini-2-5', event_type: 'judge_start',   issue_number: 88,  pr_number: null, detail: '#88 verdict scoring',          created_at: new Date(Date.now() - 2_300).toISOString() },
+];
+
+export function getFixtureActive(): Worker[] {
+  return WORKERS_INITIAL;
+}
+
+export function getFixtureBoard(): BoardEntry[] {
+  resetSeed();
+  return ROLES.map((role) => ({
+    project: pick(PROJECTS).id,
+    role,
+    model: pick(AGENTS).model,
+    total_points: randInt(10, 200),
+    verdict_count: randInt(2, 40),
+  }));
+}
+
+export function getFixtureVerdicts(): Verdict[] {
+  resetSeed();
+  return Array.from({ length: 20 }, (_, i) => ({
+    id: i + 1,
+    project: pick(PROJECTS).id,
+    role: pick(ROLES),
+    model: pick(AGENTS).model,
+    points: randInt(1, 5),
+    reason: pick(['auto: dev_done', 'auto: qa_pass', 'manual review'] as const),
+    created_at: new Date(Date.now() - randInt(60, 86400) * 1000).toISOString(),
+  }));
+}
+
+export function getFixtureFeed(): FeedItem[] {
+  return HISTORY.slice(0, 50).map((e, i) => ({
+    id: i,
+    project: e.project,
+    role: e.role,
+    model: e.model,
+    event_type: e.event_type,
+    issue_number: e.issue_number,
+    pr_number: e.pr_number,
+    detail: null,
+    payload: null,
+    created_at: e.created_at,
+    age_seconds: Math.floor((Date.now() - e.ts) / 1000),
+    status: e.event_type.endsWith('_fail') ? 'fail' : e.event_type.endsWith('_pass') ? 'pass' : 'done',
+  }));
+}
+
+export function getFixtureHistory(): LoopEvent[] {
+  return HISTORY.slice(0, 50).map((e) => ({
+    id: e.id,
+    project: e.project,
+    role: e.role,
+    model: e.model,
+    event_type: e.event_type,
+    issue_number: e.issue_number,
+    pr_number: e.pr_number,
+    detail: e.detail,
+    created_at: e.created_at,
+    points: e.points,
+  }));
+}
+
+export function getFixtureStatus(): StatusEntry[] {
+  return WORKERS_INITIAL.map((w) => ({
+    project: w.project,
+    role: w.role,
+    model: w.model,
+    event_type: w.event_type,
+    issue_number: w.issue_number,
+    pr_number: w.pr_number,
+    detail: w.detail,
+    payload: null,
+    created_at: w.created_at,
+  }));
+}
+
+export function getFixtureProjects(): Project[] {
+  return PROJECTS.map((p) => ({ project: p.id, repo: p.repo }));
+}
+
+export function getFixtureEventsGraph(): EventsGraph {
+  resetSeed();
+  const buckets = Array.from({ length: 24 }, (_, i) => {
+    const hour = new Date(Date.now() - (23 - i) * 3_600_000);
+    return ROLES.map((role) => ({
+      hour: hour.toISOString().slice(0, 13) + ':00:00',
+      role,
+      count: randInt(0, 20),
+    }));
+  }).flat();
+  return { window_hours: 24, buckets };
+}
+
+const QUEUE_REASONS = ['stuck_label', 'timeout', 'qa_fail_repeated'] as const;
+
+export function getFixtureActionQueue(): QueueItem[] {
+  resetSeed();
+  const TITLES = [
+    'rate-limit handler exceeds budget',
+    'flaky test in pipeline_runs',
+    'spec drift on /api/report v1.2',
+    'judge gives low verdict on small diffs',
+    'memory leak in event ingest loop',
+    'queue starvation under burst load',
+    'webhook timeout retries unbounded',
+    'leaderboard ranks tied agents wrong',
+    'duplicate events from boba-orchestrator',
+    'missing duration on judge_done',
+  ] as const;
+  return Array.from({ length: 18 }, (_, i) => {
+    const p = pick(PROJECTS);
+    return {
+      project: p.id,
+      kind: 'issue' as const,
+      number: randInt(20, 200),
+      title: pick(TITLES),
+      stage: pick(['blocked', 'needs-clarification', 'in-progress'] as const),
+      age_seconds: randInt(60, 6 * 60 * 60),
+      reason: pick(QUEUE_REASONS),
+      threshold_seconds: null,
+      loop_id: null,
+      github_url: `https://github.com/${p.repo}/issues/${i + 1}`,
+    };
+  });
+}
+
+export function getFixtureRuns(project: string): PipelineRun[] {
+  resetSeed();
+  return Array.from({ length: 10 }, (_, i) => ({
+    id: i + 1,
+    project,
+    issue_number: randInt(10, 200),
+    pr_number: randInt(10, 200),
+    title: `Issue #${randInt(10, 200)} auto-fix attempt`,
+    outcome: pick(['clean', 'failed', null] as const),
+    started_at: new Date(Date.now() - randInt(1000, 86400) * 1000).toISOString(),
+    completed_at: new Date(Date.now() - randInt(0, 1000) * 1000).toISOString(),
+    total_duration_seconds: randInt(60, 3600),
+    rework_count: randInt(0, 3),
+    total_bounty: randInt(0, 20),
+    created_at: new Date(Date.now() - randInt(1000, 86400) * 1000).toISOString(),
+  }));
+}
+
+export function getFixturePRMonitor(project: string): PRMonitorEntry[] {
+  resetSeed();
+  const STAGES = ['in-development', 'in-review', 'merged', 'qa-passed'] as const;
+  return Array.from({ length: 5 }, (_, i) => ({
+    pr_number: randInt(10, 200),
+    title: `PR for issue #${randInt(10, 200)}`,
+    branch: `feat/issue-${randInt(10, 200)}-fix`,
+    stage: pick(STAGES),
+    time_in_stage_seconds: randInt(60, 3600),
+    retry_count: randInt(0, 2),
+    last_event: pick(EVENT_TYPES),
+    last_event_at: new Date(Date.now() - randInt(60, 3600) * 1000).toISOString(),
+    github_url: `https://github.com/svv2014/${project}/pull/${randInt(10, 200)}`,
+    is_finished: i > 3,
+    is_draft: false,
+  }));
+}
+
+export function getFixtureHealth(): Health {
+  return {
+    status: 'ok',
+    monitor_version: '0.0.0-fixture',
+    git_sha: 'c0ffee0',
+    supported_bounty_api: '1.x',
+    core_version_counts: { '1.0': 300, '1.1': 45 },
+    loop_ids: ['loop-001', 'loop-002'],
+  };
+}
+
+export function getFixtureStatsActivity(): StatsActivity[] {
+  resetSeed();
+  return PROJECTS.slice(0, 5).flatMap((p) =>
+    Array.from({ length: 7 }, (_, i) => ({
+      date: new Date(Date.now() - i * 86400_000).toISOString().slice(0, 10),
+      project: p.id,
+      n: randInt(0, 30),
+    }))
+  );
+}
+
+export function getFixtureStatsStages(): StatsStage[] {
+  return [
+    { stage: 'dev',    avg_seconds: 1800, count: 120 },
+    { stage: 'review', avg_seconds: 900,  count: 95 },
+    { stage: 'qa',     avg_seconds: 600,  count: 88 },
+    { stage: 'merge',  avg_seconds: 120,  count: 75 },
+  ];
+}
+
+export function getFixtureStatsRework(): StatsRework[] {
+  resetSeed();
+  return PROJECTS.map((p) => ({
+    project: p.id,
+    rework_starts: randInt(0, 20),
+    review_dones: randInt(5, 40),
+  }));
+}
+
+// Full history for use by transforms (same data that would come from /api/history)
+export function getFixtureHistoryAll(): RawEvent[] {
+  return HISTORY;
+}

--- a/web/src/lib/transforms.test.ts
+++ b/web/src/lib/transforms.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+import { buildLeaderboard, buildProjectStatus, build24hBuckets } from './transforms';
+import type { LoopEvent, Worker } from './types';
+
+type ExtLoopEvent = LoopEvent & { points?: number; agent?: string; ts?: number };
+
+function makeEvent(overrides: Partial<ExtLoopEvent> = {}): ExtLoopEvent {
+  return {
+    id: 1,
+    project: 'loop',
+    role: 'dev',
+    model: 'sonnet-4-6',
+    event_type: 'dev_done',
+    issue_number: 1,
+    pr_number: null,
+    detail: null,
+    created_at: new Date().toISOString(),
+    points: 0,
+    ...overrides,
+  };
+}
+
+function makeWorker(overrides: Partial<Worker> = {}): Worker {
+  return {
+    project: 'loop',
+    role: 'dev',
+    model: 'sonnet-4-6',
+    event_type: 'dev_start',
+    issue_number: 1,
+    pr_number: null,
+    detail: null,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ── buildLeaderboard ──────────────────────────────────────────────────────────
+
+describe('buildLeaderboard', () => {
+  it('aggregates points and verdicts by role', () => {
+    const events = [
+      makeEvent({ role: 'dev', points: 3 }),
+      makeEvent({ role: 'dev', points: 2 }),
+      makeEvent({ role: 'qa',  points: 5 }),
+      makeEvent({ role: 'dev', points: 0 }),
+    ];
+    const rows = buildLeaderboard(events, 'role');
+    const dev = rows.find((r) => r.key === 'dev')!;
+    const qa  = rows.find((r) => r.key === 'qa')!;
+    expect(dev.points).toBe(5);
+    expect(dev.verdicts).toBe(2);
+    expect(qa.points).toBe(5);
+    expect(qa.verdicts).toBe(1);
+  });
+
+  it('returns rows sorted descending by points', () => {
+    const events = [
+      makeEvent({ role: 'po',  points: 1 }),
+      makeEvent({ role: 'dev', points: 10 }),
+      makeEvent({ role: 'qa',  points: 5 }),
+    ];
+    const rows = buildLeaderboard(events, 'role');
+    expect(rows[0].key).toBe('dev');
+    expect(rows[1].key).toBe('qa');
+    expect(rows[2].key).toBe('po');
+  });
+
+  it('aggregates by agent/model when by=agent', () => {
+    const events = [
+      makeEvent({ agent: 'claude', model: 'sonnet-4-6', points: 3 }),
+      makeEvent({ agent: 'claude', model: 'sonnet-4-6', points: 2 }),
+      makeEvent({ agent: 'gpt',    model: 'gpt-5',      points: 7 }),
+    ];
+    const rows = buildLeaderboard(events, 'agent');
+    expect(rows[0].key).toBe('gpt/gpt-5');
+    expect(rows[0].points).toBe(7);
+    expect(rows[1].points).toBe(5);
+  });
+
+  it('ignores events with zero points in verdict count', () => {
+    const events = [
+      makeEvent({ role: 'merge', points: 0 }),
+      makeEvent({ role: 'merge', points: 0 }),
+    ];
+    const rows = buildLeaderboard(events, 'role');
+    expect(rows[0].verdicts).toBe(0);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(buildLeaderboard([])).toEqual([]);
+  });
+});
+
+// ── buildProjectStatus ────────────────────────────────────────────────────────
+
+describe('buildProjectStatus', () => {
+  it('marks projects with a busy worker as busy', () => {
+    const events = [makeEvent({ project: 'loop', points: 5 })];
+    const workers = [makeWorker({ project: 'loop' })];
+    const rows = buildProjectStatus(events, workers);
+    const loop = rows.find((r) => r.id === 'loop')!;
+    expect(loop.status).toBe('busy');
+    expect(loop.busyWorker).toBeTruthy();
+  });
+
+  it('marks projects with no busy worker as idle', () => {
+    const events = [makeEvent({ project: 'loop', points: 3 })];
+    const rows = buildProjectStatus(events, []);
+    expect(rows[0].status).toBe('idle');
+    expect(rows[0].busyWorker).toBeNull();
+  });
+
+  it('accumulates points across multiple events', () => {
+    const events = [
+      makeEvent({ project: 'loop', points: 2 }),
+      makeEvent({ project: 'loop', points: 3 }),
+      makeEvent({ project: 'loop', points: 0 }),
+    ];
+    const rows = buildProjectStatus(events, []);
+    expect(rows[0].points).toBe(5);
+    expect(rows[0].totalEvents).toBe(3);
+  });
+
+  it('tracks the most recent event_type as lastEvent', () => {
+    const old    = makeEvent({ project: 'loop', event_type: 'dev_start', ts: Date.now() - 10_000 });
+    const recent = makeEvent({ project: 'loop', event_type: 'dev_done',  ts: Date.now() });
+    const rows = buildProjectStatus([old, recent], []);
+    expect(rows[0].lastEvent).toBe('dev_done');
+  });
+
+  it('sorts by points descending', () => {
+    const events = [
+      makeEvent({ project: 'alpha', points: 1 }),
+      makeEvent({ project: 'beta',  points: 10 }),
+    ];
+    const rows = buildProjectStatus(events, []);
+    expect(rows[0].id).toBe('beta');
+  });
+});
+
+// ── build24hBuckets ───────────────────────────────────────────────────────────
+
+describe('build24hBuckets', () => {
+  it('returns exactly 24 buckets', () => {
+    expect(build24hBuckets([])).toHaveLength(24);
+  });
+
+  it('places a recent event in the last bucket (index 23)', () => {
+    const now = Date.now();
+    const events = [makeEvent({ role: 'dev', ts: now - 5 * 60 * 1000 })];
+    const buckets = build24hBuckets(events);
+    expect(buckets[23].counts['dev']).toBe(1);
+    expect(buckets[23].total).toBe(1);
+  });
+
+  it('places an event from ~23h ago in bucket 0', () => {
+    const ts = Date.now() - 23 * 60 * 60 * 1000 - 60_000;
+    const events = [makeEvent({ role: 'qa', ts })];
+    const buckets = build24hBuckets(events);
+    expect(buckets[0].counts['qa']).toBe(1);
+  });
+
+  it('ignores events older than 24h', () => {
+    const old = makeEvent({ ts: Date.now() - 25 * 3_600_000 });
+    const buckets = build24hBuckets([old]);
+    const total = buckets.reduce((s, b) => s + b.total, 0);
+    expect(total).toBe(0);
+  });
+
+  it('accumulates multiple events in the same bucket', () => {
+    const now = Date.now();
+    const events = [
+      makeEvent({ role: 'po',  ts: now - 1000 }),
+      makeEvent({ role: 'dev', ts: now - 2000 }),
+      makeEvent({ role: 'qa',  ts: now - 3000 }),
+    ];
+    const buckets = build24hBuckets(events);
+    expect(buckets[23].total).toBe(3);
+  });
+});

--- a/web/src/lib/transforms.ts
+++ b/web/src/lib/transforms.ts
@@ -1,0 +1,112 @@
+// Pure transform helpers ported from design/new-design/data.js.
+// No side effects, no network calls, no imports from fixtures.
+import type { LoopEvent, Worker } from './types';
+
+export interface LeaderboardRow {
+  key: string;
+  verdicts: number;
+  points: number;
+}
+
+export function buildLeaderboard(
+  events: (LoopEvent & { points?: number; agent?: string })[],
+  by: 'role' | 'agent' = 'role',
+): LeaderboardRow[] {
+  const map = new Map<string, LeaderboardRow>();
+  for (const e of events) {
+    const key = by === 'role' ? e.role : `${e.agent ?? ''}/${e.model ?? ''}`;
+    if (!map.has(key)) map.set(key, { key, verdicts: 0, points: 0 });
+    const row = map.get(key)!;
+    const pts = e.points ?? 0;
+    row.points += pts;
+    if (pts > 0) row.verdicts += 1;
+  }
+  return Array.from(map.values()).sort((a, b) => b.points - a.points);
+}
+
+export interface ProjectStatusRow {
+  id: string;
+  lastEvent: string | null;
+  lastTs: number;
+  status: 'idle' | 'busy';
+  points: number;
+  totalEvents: number;
+  busyWorker: Worker | null;
+}
+
+export function buildProjectStatus(
+  events: (LoopEvent & { points?: number; ts?: number })[],
+  workers: Worker[],
+): ProjectStatusRow[] {
+  const byProject = new Map<string, ProjectStatusRow>();
+
+  for (const e of events) {
+    if (!byProject.has(e.project)) {
+      byProject.set(e.project, {
+        id: e.project,
+        lastEvent: null,
+        lastTs: 0,
+        status: 'idle',
+        points: 0,
+        totalEvents: 0,
+        busyWorker: null,
+      });
+    }
+    const row = byProject.get(e.project)!;
+    row.totalEvents += 1;
+    row.points += e.points ?? 0;
+    const ts = e.ts ?? new Date(e.created_at).getTime();
+    if (ts > row.lastTs) {
+      row.lastTs = ts;
+      row.lastEvent = e.event_type;
+    }
+  }
+
+  for (const w of workers) {
+    if (!byProject.has(w.project)) {
+      byProject.set(w.project, {
+        id: w.project,
+        lastEvent: w.event_type,
+        lastTs: new Date(w.created_at).getTime(),
+        status: 'busy',
+        points: 0,
+        totalEvents: 0,
+        busyWorker: w,
+      });
+    } else {
+      const row = byProject.get(w.project)!;
+      row.status = 'busy';
+      row.busyWorker = w;
+    }
+  }
+
+  return Array.from(byProject.values()).sort((a, b) => b.points - a.points);
+}
+
+const KNOWN_ROLES = ['po', 'dev', 'qa', 'reviewer', 'merge', 'judge'] as const;
+
+export interface HourBucket {
+  hour: number;
+  counts: Record<string, number>;
+  total: number;
+}
+
+export function build24hBuckets(
+  events: (LoopEvent & { ts?: number })[],
+): HourBucket[] {
+  const buckets: HourBucket[] = Array.from({ length: 24 }, (_, i) => ({
+    hour: i,
+    counts: Object.fromEntries(KNOWN_ROLES.map((r) => [r, 0])),
+    total: 0,
+  }));
+  const now = Date.now();
+  for (const e of events) {
+    const ts = e.ts ?? new Date(e.created_at).getTime();
+    const hoursAgo = Math.floor((now - ts) / (60 * 60 * 1000));
+    if (hoursAgo < 0 || hoursAgo >= 24) continue;
+    const idx = 23 - hoursAgo;
+    buckets[idx].counts[e.role] = (buckets[idx].counts[e.role] ?? 0) + 1;
+    buckets[idx].total += 1;
+  }
+  return buckets;
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,3 +1,94 @@
+// TS interfaces mirroring server/routes payload shapes.
+// Read from server/routes/*.py — do not invent fields.
+
+export interface Worker {
+  project: string;
+  role: string;
+  model: string | null;
+  event_type: string;
+  issue_number: number | null;
+  pr_number: number | null;
+  detail: string | null;
+  created_at: string;
+}
+
+export interface BoardEntry {
+  project: string;
+  role: string;
+  model: string | null;
+  total_points: number;
+  verdict_count: number;
+}
+
+export interface Verdict {
+  id: number;
+  project: string;
+  role: string;
+  model: string | null;
+  points: number;
+  reason: string | null;
+  created_at: string;
+}
+
+export interface FeedItem {
+  id: number;
+  project: string;
+  role: string;
+  model: string | null;
+  event_type: string;
+  issue_number: number | null;
+  pr_number: number | null;
+  detail: string | null;
+  payload: Record<string, unknown> | null;
+  created_at: string;
+  age_seconds: number | null;
+  status: string;
+}
+
+export interface LoopEvent {
+  id: number;
+  project: string;
+  role: string;
+  model: string | null;
+  event_type: string;
+  issue_number: number | null;
+  pr_number: number | null;
+  detail: string | null;
+  created_at: string;
+  completed_at?: string;
+  started_at?: string | null;
+  duration_seconds?: number | null;
+  points?: number | null;
+}
+
+export interface StatusEntry {
+  project: string;
+  role: string;
+  model: string | null;
+  event_type: string;
+  issue_number: number | null;
+  pr_number: number | null;
+  detail: string | null;
+  payload: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export interface Project {
+  project: string;
+  repo: string;
+}
+
+export interface EventsGraphBucket {
+  hour: string;
+  role: string;
+  count: number;
+}
+
+export interface EventsGraph {
+  window_hours: number;
+  buckets: EventsGraphBucket[];
+}
+
 export interface QueueItem {
   project: string;
   kind: 'issue' | 'pr';
@@ -9,4 +100,60 @@ export interface QueueItem {
   threshold_seconds: number | null;
   loop_id: string | null;
   github_url: string | null;
+}
+
+export interface PipelineRun {
+  id: number;
+  project: string;
+  issue_number: number | null;
+  pr_number: number | null;
+  title: string | null;
+  outcome: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  total_duration_seconds: number | null;
+  rework_count: number;
+  total_bounty: number | null;
+  created_at: string;
+}
+
+export interface PRMonitorEntry {
+  pr_number: number;
+  title: string | null;
+  branch: string | null;
+  stage: string | null;
+  time_in_stage_seconds: number | null;
+  retry_count: number;
+  last_event: string | null;
+  last_event_at: string | null;
+  github_url: string | null;
+  is_finished: boolean;
+  is_draft: boolean | null;
+}
+
+export interface Health {
+  status: string;
+  monitor_version: string;
+  git_sha: string;
+  supported_bounty_api: string;
+  core_version_counts: Record<string, number>;
+  loop_ids: string[];
+}
+
+export interface StatsActivity {
+  date: string;
+  project: string;
+  n: number;
+}
+
+export interface StatsStage {
+  stage: string;
+  avg_seconds: number;
+  count: number;
+}
+
+export interface StatsRework {
+  project: string;
+  rework_starts: number;
+  review_dones: number;
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,10 +1,22 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import './lib/tokens.css';
 import App from './App';
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchInterval: 5000,
+      staleTime: 0,
+    },
+  },
+});
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
-  </StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </StrictMode>,
 );


### PR DESCRIPTION
Closes #115

> CLAUDE.md absent — conventions inferred from design/MIGRATION.md and static/js/api.js.

## Changes

### `web/src/lib/types.ts` — complete
Full TS interfaces for all `/api/*` payload shapes: `Worker`, `LoopEvent`, `FeedItem`, `BoardEntry`, `QueueItem` (includes `threshold_seconds` from the stuck-detector landed in #145), `Project`, `EventsGraph`, `Health`, `PipelineRun`, `PRMonitorEntry`, `Verdict`, `StatsActivity`, `StatsStage`, `StatsRework`. Derived directly from `server/routes/*.py` — no invented fields.

### `web/src/lib/api.ts` — new
Typed `fetch*` function per endpoint mirroring `static/js/api.js`. Accepts optional `loop_id` where the current JS uses one. Fixture mode: when `?fixtures=1` is in the URL every function short-circuits and returns seeded data — **zero network calls** (verifiable in DevTools Network tab).

### `web/src/lib/fixtures.ts` — new
Deterministic fixture data ported verbatim from `design/new-design/data.js`: same LCG seed (`0xC0FFEE`), same constants, same sort order. Produces byte-identical output across runs as required by the Phase 0 visual-diff harness.

### `web/src/lib/transforms.ts` — new
`buildLeaderboard`, `buildProjectStatus`, `build24hBuckets` ported to TypeScript. Pure functions, no side effects, typed against the interfaces in `types.ts`.

### `web/src/lib/transforms.test.ts` — new
15 Vitest unit tests covering all three transforms with non-trivial inputs (multi-event aggregation, sort order, edge cases, 24h bucket placement).

### `web/src/main.tsx` — updated
Added `QueryClientProvider` wrapping the app with `refetchInterval: 5000`, `staleTime: 0` as query defaults.

### `web/src/App.tsx` — updated
Wires `useQuery` on `/api/active` (5s refetch) and `/api/health`; maps workers to the `{ ts }` shape `TopBar` expects; passes `online={!activeQuery.isError}` and `version` as the connection/count smoke test.

### `web/package.json` — updated
Added `@tanstack/react-query ^5.56.2`, `vitest ^2.0.5`, `"test": "vitest run"` script.

## Test Plan
- `cd web && npm run typecheck` → 0 errors (strict `noUnusedLocals` + `noUnusedParameters`)
- `cd web && npm test` → 15/15 pass
- `http://localhost:5173/v2?fixtures=1` in DevTools Network tab → zero `/api/*` requests
- `http://localhost:5173/v2` against a running server → `/api/active` polls every 5s; TopBar shows worker count and green/red dot