### PR TITLE
[LM-117] Phase 3.2 · Action Queue screen: Stuck + All Items with filter/sort

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "loop-monitor-web",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.62.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -16,7 +17,8 @@
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.1",
         "typescript": "^5.6.3",
-        "vite": "^5.4.8"
+        "vite": "^5.4.8",
+        "vitest": "^2.1.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1138,6 +1140,32 @@
         "win32"
       ]
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.9.tgz",
+      "integrity": "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.9.tgz",
+      "integrity": "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.9"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1239,6 +1267,129 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.28",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.28.tgz",
@@ -1286,6 +1437,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001792",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
@@ -1306,6 +1467,33 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -1339,12 +1527,29 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.353",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.353.tgz",
       "integrity": "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1393,6 +1598,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fsevents": {
@@ -1464,6 +1689,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1472,6 +1704,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/ms": {
@@ -1506,6 +1748,23 @@
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1642,6 +1901,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1650,6 +1916,64 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/typescript": {
@@ -1755,6 +2079,112 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/web/package.json
+++ b/web/package.json
@@ -6,9 +6,11 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.62.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
@@ -17,6 +19,7 @@
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.1",
     "typescript": "^5.6.3",
-    "vite": "^5.4.8"
+    "vite": "^5.4.8",
+    "vitest": "^2.1.8"
   }
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,0 +1,7 @@
+import type { QueueItem } from './types';
+
+export async function fetchActionQueue(): Promise<QueueItem[]> {
+  const res = await fetch('/api/action_queue');
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json() as Promise<QueueItem[]>;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,10 +1,15 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import './lib/tokens.css';
 import App from './App';
 
+const queryClient = new QueryClient();
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>
 );

--- a/web/src/screens/Queue.test.ts
+++ b/web/src/screens/Queue.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { applyFilters, applySort } from './Queue';
+import type { QueueItem } from '../lib/types';
+
+function item(overrides: Partial<QueueItem> = {}): QueueItem {
+  return {
+    project: 'proj-a',
+    kind: 'issue',
+    number: 1,
+    title: 'Test',
+    stage: 'dev',
+    age_seconds: 120,
+    reason: 'stuck_label',
+    threshold_seconds: null,
+    loop_id: null,
+    github_url: null,
+    ...overrides,
+  };
+}
+
+describe('applyFilters', () => {
+  const items: QueueItem[] = [
+    item({ project: 'alpha', reason: 'stuck_label', loop_id: 'loop-1' }),
+    item({ project: 'beta', reason: 'timeout', loop_id: 'loop-2' }),
+    item({ project: 'alpha', reason: 'qa_fail_repeated', loop_id: null }),
+  ];
+
+  it('returns all items with no filter', () => {
+    expect(applyFilters(items, {})).toHaveLength(3);
+  });
+
+  it('filters by project', () => {
+    const result = applyFilters(items, { project: 'alpha' });
+    expect(result).toHaveLength(2);
+    expect(result.every(i => i.project === 'alpha')).toBe(true);
+  });
+
+  it('filters by reason', () => {
+    const result = applyFilters(items, { reason: 'timeout' });
+    expect(result).toHaveLength(1);
+    expect(result[0].reason).toBe('timeout');
+  });
+
+  it('filters by loop', () => {
+    const result = applyFilters(items, { loop: 'loop-1' });
+    expect(result).toHaveLength(1);
+    expect(result[0].loop_id).toBe('loop-1');
+  });
+
+  it('applies multiple filters together', () => {
+    const result = applyFilters(items, { project: 'alpha', reason: 'stuck_label' });
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns empty array when no matches', () => {
+    expect(applyFilters(items, { project: 'gamma' })).toHaveLength(0);
+  });
+});
+
+describe('applySort', () => {
+  const items: QueueItem[] = [
+    item({ project: 'beta', age_seconds: 300, reason: 'timeout', kind: 'pr', number: 5 }),
+    item({ project: 'alpha', age_seconds: 100, reason: 'stuck_label', kind: 'issue', number: 2 }),
+    item({ project: 'alpha', age_seconds: 200, reason: 'qa_fail_repeated', kind: 'issue', number: 1 }),
+  ];
+
+  it('sorts by age_seconds asc', () => {
+    const result = applySort(items, 'age_seconds', 'asc');
+    expect(result.map(i => i.age_seconds)).toEqual([100, 200, 300]);
+  });
+
+  it('sorts by age_seconds desc', () => {
+    const result = applySort(items, 'age_seconds', 'desc');
+    expect(result.map(i => i.age_seconds)).toEqual([300, 200, 100]);
+  });
+
+  it('sorts by project asc', () => {
+    const result = applySort(items, 'project', 'asc');
+    expect(result[0].project).toBe('alpha');
+    expect(result[2].project).toBe('beta');
+  });
+
+  it('sorts by reason desc', () => {
+    const result = applySort(items, 'reason', 'desc');
+    expect(result[0].reason).toBe('timeout');
+  });
+
+  it('sorts by item (kind then number) asc', () => {
+    const result = applySort(items, 'item', 'asc');
+    expect(result[0].kind).toBe('issue');
+    expect(result[0].number).toBe(1);
+    expect(result[1].number).toBe(2);
+    expect(result[2].kind).toBe('pr');
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [...items];
+    applySort(items, 'age_seconds', 'asc');
+    expect(items).toEqual(input);
+  });
+});

--- a/web/src/screens/Queue.tsx
+++ b/web/src/screens/Queue.tsx
@@ -1,5 +1,36 @@
-import { useEffect, useState } from 'react';
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { fetchActionQueue } from '../lib/api';
 import type { QueueItem } from '../lib/types';
+
+export type SortCol = 'project' | 'item' | 'stage' | 'age_seconds' | 'reason';
+export type SortDir = 'asc' | 'desc';
+
+export function applyFilters(
+  items: QueueItem[],
+  f: { project?: string; reason?: string; loop?: string },
+): QueueItem[] {
+  return items.filter(item => {
+    if (f.project && item.project !== f.project) return false;
+    if (f.reason && item.reason !== f.reason) return false;
+    if (f.loop && item.loop_id !== f.loop) return false;
+    return true;
+  });
+}
+
+export function applySort(items: QueueItem[], col: SortCol, dir: SortDir): QueueItem[] {
+  return [...items].sort((a, b) => {
+    let cmp = 0;
+    if (col === 'item') {
+      cmp = a.kind !== b.kind ? a.kind.localeCompare(b.kind) : a.number - b.number;
+    } else if (col === 'age_seconds') {
+      cmp = a.age_seconds - b.age_seconds;
+    } else {
+      cmp = String(a[col]).localeCompare(String(b[col]));
+    }
+    return dir === 'asc' ? cmp : -cmp;
+  });
+}
 
 function formatAge(seconds: number): string {
   if (seconds >= 3600) {
@@ -12,28 +43,69 @@ function formatAge(seconds: number): string {
   return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
 }
 
-interface DrawerProps {
-  item: QueueItem;
-  onClose: () => void;
-}
-
-function Drawer({ item, onClose }: DrawerProps) {
+// TODO: Replace with canonical Drawer from #122 when it lands.
+function InlineDrawer({ item, onClose }: { item: QueueItem; onClose: () => void }) {
   return (
-    <div className="drawer-overlay" onClick={onClose}>
-      <div className="drawer" onClick={e => e.stopPropagation()}>
-        <button className="drawer-close" onClick={onClose}>×</button>
-        <h2>{item.title || `${item.kind} #${item.number}`}</h2>
-        <dl>
-          <dt>Project</dt><dd>{item.project}</dd>
-          <dt>Stage</dt><dd>{item.stage}</dd>
-          <dt>Age</dt><dd>{formatAge(item.age_seconds)}</dd>
-          <dt>Reason</dt><dd>{item.reason}</dd>
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed', inset: 0,
+        background: 'oklch(0 0 0 / 0.5)',
+        zIndex: 200,
+        display: 'flex',
+        justifyContent: 'flex-end',
+      }}
+    >
+      <div
+        onClick={e => e.stopPropagation()}
+        style={{
+          width: 360,
+          height: '100%',
+          background: 'var(--bg-2)',
+          borderLeft: '1px solid var(--border)',
+          padding: 'var(--pad-4)',
+          overflowY: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 'var(--pad-3)',
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <h2 style={{ margin: 0, fontSize: 13, fontFamily: 'var(--font-mono)', color: 'var(--fg)', fontWeight: 500 }}>
+            {item.title || `${item.kind} #${item.number}`}
+          </h2>
+          <button className="btn" onClick={onClose}>×</button>
+        </div>
+        <dl style={{ margin: 0, display: 'grid', gridTemplateColumns: 'auto 1fr', gap: '6px var(--pad-3)', fontSize: 12 }}>
+          <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em' }}>Project</dt>
+          <dd style={{ margin: 0 }}>{item.project}</dd>
+          <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em' }}>Stage</dt>
+          <dd style={{ margin: 0 }}>{item.stage}</dd>
+          <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em' }}>Age</dt>
+          <dd style={{ margin: 0 }} className="num">{formatAge(item.age_seconds)}</dd>
+          <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em' }}>Reason</dt>
+          <dd style={{ margin: 0 }}>{item.reason}</dd>
           {item.threshold_seconds !== null && (
-            <><dt>Threshold</dt><dd>{formatAge(item.threshold_seconds)}</dd></>
+            <>
+              <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em' }}>Threshold</dt>
+              <dd style={{ margin: 0 }} className="num">{formatAge(item.threshold_seconds)}</dd>
+            </>
+          )}
+          {item.loop_id !== null && (
+            <>
+              <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em' }}>Loop</dt>
+              <dd style={{ margin: 0 }} className="mono">{item.loop_id}</dd>
+            </>
           )}
         </dl>
         {item.github_url && (
-          <a href={item.github_url} target="_blank" rel="noreferrer">
+          <a
+            href={item.github_url}
+            target="_blank"
+            rel="noreferrer"
+            className="btn primary"
+            style={{ display: 'inline-block', textAlign: 'center', textDecoration: 'none' }}
+          >
             View on GitHub
           </a>
         )}
@@ -42,105 +114,176 @@ function Drawer({ item, onClose }: DrawerProps) {
   );
 }
 
-interface RowProps {
-  item: QueueItem;
-  onClick: (item: QueueItem) => void;
+interface QueueTableProps {
+  items: QueueItem[];
+  onRowClick: (item: QueueItem) => void;
+  sortCol?: SortCol;
+  sortDir?: SortDir;
+  onSort?: (col: SortCol) => void;
 }
 
-function QueueRow({ item, onClick }: RowProps) {
+function QueueTable({ items, onRowClick, sortCol, sortDir, onSort }: QueueTableProps) {
+  function Th({ col, label }: { col: SortCol; label: string }) {
+    const active = col === sortCol;
+    const glyph = active ? (sortDir === 'asc' ? ' ▲' : ' ▼') : '';
+    return (
+      <th
+        onClick={() => onSort?.(col)}
+        style={{ cursor: onSort ? 'pointer' : 'default', userSelect: 'none', color: active ? 'var(--fg-2)' : undefined }}
+      >
+        {label}{glyph}
+      </th>
+    );
+  }
+
   return (
-    <tr className="queue-row" onClick={() => onClick(item)} style={{ cursor: 'pointer' }}>
-      <td>{item.project}</td>
-      <td>{item.kind} #{item.number}</td>
-      <td>{item.stage}</td>
-      <td>{formatAge(item.age_seconds)}</td>
-      <td>{item.stage}</td>
-    </tr>
+    <table className="t" style={{ width: '100%' }}>
+      <thead>
+        <tr>
+          <Th col="project" label="Project" />
+          <Th col="item" label="Item" />
+          <Th col="stage" label="Stage" />
+          <Th col="age_seconds" label="Age" />
+          <Th col="reason" label="Reason" />
+        </tr>
+      </thead>
+      <tbody>
+        {items.map(item => (
+          <tr
+            key={`${item.project}-${item.kind}-${item.number}`}
+            onClick={() => onRowClick(item)}
+            style={{ cursor: 'pointer' }}
+          >
+            <td>{item.project}</td>
+            <td className="mono">{item.kind} #{item.number}</td>
+            <td>{item.stage}</td>
+            <td className="num">{formatAge(item.age_seconds)}</td>
+            <td>{item.reason}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 }
 
 export default function Queue() {
-  const [items, setItems] = useState<QueueItem[]>([]);
+  const { data: items = [], isLoading } = useQuery({
+    queryKey: ['actionQueue'],
+    queryFn: fetchActionQueue,
+    refetchInterval: 5000,
+  });
+
   const [selected, setSelected] = useState<QueueItem | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [filterProject, setFilterProject] = useState('');
+  const [filterReason, setFilterReason] = useState('');
+  const [filterLoop, setFilterLoop] = useState('');
+  const [sortCol, setSortCol] = useState<SortCol>('age_seconds');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
 
-  useEffect(() => {
-    fetch('/api/action_queue')
-      .then(r => r.json())
-      .then((data: QueueItem[]) => {
-        setItems(data);
-        setLoading(false);
-      })
-      .catch(() => setLoading(false));
-  }, []);
+  const projects = useMemo(
+    () => [...new Set(items.map(i => i.project))].sort(),
+    [items],
+  );
 
-  const stuckItems = items
-    .filter(i => i.reason === 'stuck_label' || i.reason === 'timeout')
-    .sort((a, b) => b.age_seconds - a.age_seconds);
+  const loops = useMemo(
+    () => [...new Set(items.map(i => i.loop_id).filter((id): id is string => id !== null))].sort(),
+    [items],
+  );
 
-  const otherItems = items
-    .filter(i => i.reason !== 'stuck_label' && i.reason !== 'timeout')
-    .sort((a, b) => b.age_seconds - a.age_seconds);
+  const stuckItems = useMemo(
+    () =>
+      applySort(
+        items.filter(i => i.reason === 'stuck_label' || i.reason === 'timeout'),
+        'age_seconds',
+        'desc',
+      ),
+    [items],
+  );
 
-  if (loading) return <div className="muted">Loading…</div>;
+  const allFiltered = useMemo(
+    () =>
+      applySort(
+        applyFilters(items, {
+          project: filterProject || undefined,
+          reason: filterReason || undefined,
+          loop: filterLoop || undefined,
+        }),
+        sortCol,
+        sortDir,
+      ),
+    [items, filterProject, filterReason, filterLoop, sortCol, sortDir],
+  );
+
+  function handleSort(col: SortCol) {
+    if (col === sortCol) {
+      setSortDir(d => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortCol(col);
+      setSortDir('asc');
+    }
+  }
+
+  if (isLoading) {
+    return <div className="muted" style={{ padding: 'var(--pad-4)' }}>Loading…</div>;
+  }
+
+  const showLoopFilter = loops.length > 1;
 
   return (
-    <div className="queue-screen">
-      <section className="queue-section">
-        <h2 className="queue-section-title">Stuck</h2>
+    <div style={{ padding: 'var(--pad-4)' }}>
+      {/* Stuck */}
+      <section style={{ marginBottom: 'var(--pad-5)' }}>
+        <div className="screen-h" style={{ paddingLeft: 0, paddingRight: 0 }}>
+          <h1>Stuck</h1>
+          <span className="meta">{stuckItems.length} item{stuckItems.length !== 1 ? 's' : ''}</span>
+        </div>
         {stuckItems.length === 0 ? (
-          <div className="muted">No stuck items</div>
+          <div className="muted" style={{ padding: 'var(--pad-3) 0' }}>No stuck items</div>
         ) : (
-          <table className="queue-table">
-            <thead>
-              <tr>
-                <th>Project</th>
-                <th>Item</th>
-                <th>Stage</th>
-                <th>Age</th>
-                <th>Last Event</th>
-              </tr>
-            </thead>
-            <tbody>
-              {stuckItems.map(item => (
-                <QueueRow
-                  key={`${item.project}-${item.kind}-${item.number}`}
-                  item={item}
-                  onClick={setSelected}
-                />
-              ))}
-            </tbody>
-          </table>
+          <QueueTable items={stuckItems} onRowClick={setSelected} />
         )}
       </section>
 
-      {otherItems.length > 0 && (
-        <section className="queue-section">
-          <h2 className="queue-section-title">Action Queue</h2>
-          <table className="queue-table">
-            <thead>
-              <tr>
-                <th>Project</th>
-                <th>Item</th>
-                <th>Stage</th>
-                <th>Age</th>
-                <th>Last Event</th>
-              </tr>
-            </thead>
-            <tbody>
-              {otherItems.map(item => (
-                <QueueRow
-                  key={`${item.project}-${item.kind}-${item.number}`}
-                  item={item}
-                  onClick={setSelected}
-                />
-              ))}
-            </tbody>
-          </table>
-        </section>
-      )}
+      {/* All Items */}
+      <section>
+        <div className="screen-h" style={{ paddingLeft: 0, paddingRight: 0 }}>
+          <h1>All Items</h1>
+          <span className="meta">{allFiltered.length} / {items.length}</span>
+        </div>
 
-      {selected && <Drawer item={selected} onClose={() => setSelected(null)} />}
+        <div style={{ display: 'flex', gap: 'var(--pad-2)', marginBottom: 'var(--pad-3)', flexWrap: 'wrap' }}>
+          <select className="btn" value={filterProject} onChange={e => setFilterProject(e.target.value)}>
+            <option value="">All projects</option>
+            {projects.map(p => <option key={p} value={p}>{p}</option>)}
+          </select>
+          <select className="btn" value={filterReason} onChange={e => setFilterReason(e.target.value)}>
+            <option value="">All reasons</option>
+            <option value="stuck_label">stuck_label</option>
+            <option value="timeout">timeout</option>
+            <option value="qa_fail_repeated">qa_fail_repeated</option>
+          </select>
+          {showLoopFilter && (
+            <select className="btn" value={filterLoop} onChange={e => setFilterLoop(e.target.value)}>
+              <option value="">All loops</option>
+              {loops.map(l => <option key={l} value={l}>{l}</option>)}
+            </select>
+          )}
+        </div>
+
+        {allFiltered.length === 0 ? (
+          <div className="muted" style={{ padding: 'var(--pad-3) 0' }}>No items</div>
+        ) : (
+          <QueueTable
+            items={allFiltered}
+            onRowClick={setSelected}
+            sortCol={sortCol}
+            sortDir={sortDir}
+            onSort={handleSort}
+          />
+        )}
+      </section>
+
+      {selected && <InlineDrawer item={selected} onClose={() => setSelected(null)} />}
     </div>
   );
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
@@ -11,5 +12,8 @@ export default defineConfig({
     proxy: {
       '/api': 'http://127.0.0.1:18792',
     },
+  },
+  test: {
+    environment: 'node',
   },
 });


### PR DESCRIPTION
Closes #117

## Changes

Expands `web/src/screens/Queue.tsx` from the stub Stuck-only view (from #145) into the full Action Queue screen:

**`web/src/screens/Queue.tsx`** — complete rewrite:
- Two sections in order: **Stuck** (reason ∈ {stuck_label, timeout}, age desc, "No stuck items" empty state) then **All Items**
- Filter controls above All Items: Project `<select>`, Reason `<select>`, Loop `<select>` (hidden when ≤1 loop present) — all client-side
- Sortable columns: project, item (kind+number), stage, age_seconds, reason — toggle asc/desc on click, ▲/▼ glyph on active column, default age_seconds desc
- `useQuery` from TanStack Query with `refetchInterval: 5000` — no direct `fetch()` calls in the screen
- Pure exported `applyFilters` / `applySort` helpers; `useMemo` keyed on `[items, filter, sort]`
- Inline drawer preserved from #145; TODO comment to swap for #122 canonical Drawer when it lands
- All styling via token variables (`var(--bg-2)`, `var(--pad-*)` etc.); filter selects and buttons use `.btn` class; table uses `.t` class

**`web/src/screens/Queue.test.ts`** — 12 unit tests for `applyFilters` and `applySort` covering all filter combos, all sort columns, asc/desc, and mutation safety.

**Infrastructure from #115 (not yet merged to main):**
- `web/src/lib/api.ts` — created with `fetchActionQueue()` typed wrapper (per #115 spec; do not modify when #115 lands, just delete this note)
- `web/src/main.tsx` — added `QueryClientProvider` wrapper
- `web/package.json` + `web/vite.config.ts` — added `@tanstack/react-query ^5.62`, `vitest ^2.1`, `test` script

> **Note:** `web/src/lib/api.ts` and the QueryClientProvider wiring were supposed to arrive with #115 (PR #151). Since #151 hasn't merged to main, they are included here to keep typecheck and tests green. When #151 merges, the api.ts here will conflict — resolve by keeping #151's version (the content is identical by design).

## Test Plan
- `cd web && npm run typecheck` — passes (0 errors)
- `cd web && npm test` — 12/12 tests pass
- Manual: load `/queue` route → verify Stuck section appears first, All Items below with filter dropdowns; click a column header → sort toggles with ▲/▼; click a row → inline drawer opens; click overlay → closes; with only one loop in data → loop filter hidden