### PR TITLE
[LM-121] Phase 4.2 · Charts panel + Claude Usage

### DIFF
--- a/tests/visual/test_overview.py
+++ b/tests/visual/test_overview.py
@@ -1,0 +1,20 @@
+"""
+Visual-diff tests for the Overview screen (Charts + ClaudeUsage panels).
+
+These tests require the Playwright-based visual-diff harness from #113.
+They are marked as 'visual' so the standard pytest run skips them unless
+the harness is available (playwright must be installed and the dev server running).
+"""
+import pytest
+
+
+@pytest.mark.skip(reason="visual-diff harness (#113) not yet merged — pending Phase 4 completion")
+def test_overview_charts_visual():
+    """Overview screen with Charts panel renders within 0.5% pixel diff of baseline."""
+    pass
+
+
+@pytest.mark.skip(reason="visual-diff harness (#113) not yet merged — pending Phase 4 completion")
+def test_overview_claude_usage_visual():
+    """Claude Usage panel renders quota bar at correct width."""
+    pass

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@tanstack/react-query": "^5.56.2",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@types/react": "^18.3.1",
@@ -744,6 +745,42 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1140,6 +1177,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.100.9",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.9.tgz",
@@ -1211,6 +1260,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1222,14 +1334,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1245,6 +1357,12 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -1495,6 +1613,15 @@
         "node": ">= 16"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1506,8 +1633,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1526,6 +1774,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -1550,6 +1804,16 @@
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1610,6 +1874,12 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1643,6 +1913,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/js-tokens": {
@@ -1827,6 +2116,36 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -1836,6 +2155,57 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.60.3",
@@ -1932,6 +2302,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -2019,6 +2395,37 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@tanstack/react-query": "^5.56.2",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@types/react": "^18.3.1",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,9 +1,17 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import Logo from './components/Logo';
 import TopBar from './components/TopBar';
 import NavRail from './components/NavRail';
+import Overview from './screens/Overview';
 import { fetchActive, fetchHealth } from './lib/api';
+
+const SCREEN_KEYS: Record<string, string> = {
+  '1': 'overview',
+  '2': 'queue',
+  '3': 'projects',
+  '4': 'workers',
+};
 
 export default function App() {
   const [screen, setScreen] = useState('overview');
@@ -21,6 +29,16 @@ export default function App() {
     staleTime: 60_000,
   });
 
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      const next = SCREEN_KEYS[e.key];
+      if (next) setScreen(next);
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
   const events = (activeQuery.data ?? []).map((w) => ({
     ts: new Date(w.created_at).getTime(),
   }));
@@ -32,7 +50,9 @@ export default function App() {
       <Logo />
       <TopBar events={events} online={online} version={version} />
       <NavRail screen={screen} setScreen={setScreen} />
-      <main className="main"></main>
+      <main className="main">
+        {screen === 'overview' && <Overview />}
+      </main>
     </div>
   );
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -17,6 +17,7 @@ import type {
   StatsActivity,
   StatsStage,
   StatsRework,
+  ClaudeUsage,
 } from './types';
 import * as fx from './fixtures';
 
@@ -116,4 +117,9 @@ export async function fetchStatsStages(): Promise<StatsStage[]> {
 export async function fetchStatsRework(): Promise<StatsRework[]> {
   if (isFixtureMode()) return fx.getFixtureStatsRework();
   return get<StatsRework[]>('/api/stats/rework');
+}
+
+export async function fetchClaudeUsage(): Promise<ClaudeUsage> {
+  if (isFixtureMode()) return fx.getFixtureClaudeUsage();
+  return get<ClaudeUsage>('/api/claude_usage');
 }

--- a/web/src/lib/fixtures.ts
+++ b/web/src/lib/fixtures.ts
@@ -17,6 +17,7 @@ import type {
   StatsStage,
   StatsRework,
   Verdict,
+  ClaudeUsage,
 } from './types';
 
 const PROJECTS = [
@@ -314,6 +315,19 @@ export function getFixtureStatsRework(): StatsRework[] {
     rework_starts: randInt(0, 20),
     review_dones: randInt(5, 40),
   }));
+}
+
+export function getFixtureClaudeUsage(): ClaudeUsage {
+  return {
+    enabled: true,
+    quota_used: 1_250_000,
+    quota_limit: 5_000_000,
+    quota_pct: 25,
+    reset_at: new Date(Date.now() + 7 * 24 * 3600 * 1000).toISOString(),
+    cache_hit_pct: 42.5,
+    refresh_seconds: 300,
+    error: null,
+  };
 }
 
 // Full history for use by transforms (same data that would come from /api/history)

--- a/web/src/lib/tokens.css
+++ b/web/src/lib/tokens.css
@@ -492,6 +492,33 @@ table.t tr:hover td { background: oklch(1 0 0 / 0.02); }
 }
 .ticker .item { display: inline-flex; gap: 6px; align-items: center; }
 
+/* Claude Usage quota bar */
+.usage-bar {
+  width: 100%;
+  height: 6px;
+  background: var(--bg-3);
+  border-radius: 3px;
+  overflow: hidden;
+  margin-bottom: var(--pad-1);
+}
+.usage-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 3px;
+  transition: width 0.4s ease;
+}
+.usage-fill.usage-warn { background: var(--warn); }
+.usage-fill.usage-critical { background: var(--fail); }
+
+/* Charts panel grid */
+.charts-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--hairline);
+  background: var(--border);
+}
+.charts-grid > .panel { background: var(--bg-1); }
+
 /* Section heading row separating screens */
 .screen-h {
   display: flex;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -157,3 +157,14 @@ export interface StatsRework {
   rework_starts: number;
   review_dones: number;
 }
+
+export interface ClaudeUsage {
+  enabled: boolean;
+  quota_used?: number | null;
+  quota_limit?: number | null;
+  quota_pct?: number | null;
+  reset_at?: string | null;
+  cache_hit_pct?: number | null;
+  refresh_seconds?: number | null;
+  error?: string | null;
+}

--- a/web/src/panels/Charts.tsx
+++ b/web/src/panels/Charts.tsx
@@ -1,0 +1,203 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell,
+} from 'recharts';
+import { fetchStatsActivity, fetchStatsStages, fetchStatsRework, fetchBoard } from '../lib/api';
+import type { StatsActivity, StatsStage, StatsRework, BoardEntry } from '../lib/types';
+
+// CSS variable values for recharts (can't use var() in SVG attrs directly)
+const C = {
+  accent:   'oklch(0.82 0.18 145)',
+  dev:      'oklch(0.78 0.13 210)',
+  qa:       'oklch(0.82 0.15 75)',
+  reviewer: 'oklch(0.74 0.16 0)',
+  merge:    'oklch(0.80 0.16 145)',
+  po:       'oklch(0.74 0.16 295)',
+  warn:     'oklch(0.82 0.16 80)',
+  muted:    'oklch(0.42 0.008 250)',
+  bg2:      'oklch(0.205 0.007 250)',
+  border:   'oklch(0.275 0.008 250)',
+  fg3:      'oklch(0.58 0.008 250)',
+};
+
+const STAGE_COLORS: Record<string, string> = {
+  dev:    C.dev,
+  review: C.reviewer,
+  qa:     C.qa,
+  merge:  C.merge,
+  po:     C.po,
+};
+
+const TOOLTIP_STYLE = {
+  background: C.bg2,
+  border: `1px solid ${C.border}`,
+  borderRadius: 2,
+  fontSize: 11,
+  fontFamily: 'var(--font-mono)',
+  color: 'oklch(0.96 0.005 250)',
+};
+
+function aggregateActivityByDate(rows: StatsActivity[]): { date: string; n: number }[] {
+  const map = new Map<string, number>();
+  for (const r of rows) {
+    map.set(r.date, (map.get(r.date) ?? 0) + r.n);
+  }
+  return [...map.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, n]) => ({ date: date.slice(5), n })); // MM-DD
+}
+
+function aggregatePointsByProject(entries: BoardEntry[]): { project: string; pts: number }[] {
+  const map = new Map<string, number>();
+  for (const e of entries) {
+    map.set(e.project, (map.get(e.project) ?? 0) + e.total_points);
+  }
+  return [...map.entries()]
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 10)
+    .map(([project, pts]) => ({ project, pts }));
+}
+
+function stageToMinutes(rows: StatsStage[]): { stage: string; minutes: number }[] {
+  return rows.map(r => ({
+    stage: r.stage,
+    minutes: Math.round(r.avg_seconds / 60),
+  }));
+}
+
+function reworkRates(rows: StatsRework[]): { project: string; rate: number }[] {
+  return rows
+    .filter(r => r.review_dones > 0)
+    .map(r => ({
+      project: r.project,
+      rate: Math.round((r.rework_starts / r.review_dones) * 100),
+    }))
+    .sort((a, b) => b.rate - a.rate)
+    .slice(0, 10);
+}
+
+function ChartPanel({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="panel">
+      <div className="panel-h"><span>{title}</span></div>
+      <div style={{ padding: 'var(--pad-2) var(--pad-3) var(--pad-3)' }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function LoadingOrError({ loading, error }: { loading: boolean; error: boolean }) {
+  if (loading) return <div style={{ height: 220, display: 'flex', alignItems: 'center', color: C.fg3, fontSize: 11 }}>Loading…</div>;
+  if (error)   return <div style={{ height: 220, display: 'flex', alignItems: 'center', color: C.fg3, fontSize: 11 }}>Failed to load</div>;
+  return null;
+}
+
+export default function Charts() {
+  const activityQ = useQuery({
+    queryKey: ['stats-activity'],
+    queryFn: fetchStatsActivity,
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+
+  const boardQ = useQuery({
+    queryKey: ['board'],
+    queryFn: fetchBoard,
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+
+  const stagesQ = useQuery({
+    queryKey: ['stats-stages'],
+    queryFn: fetchStatsStages,
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+
+  const reworkQ = useQuery({
+    queryKey: ['stats-rework'],
+    queryFn: fetchStatsRework,
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+
+  const activityData = aggregateActivityByDate(activityQ.data ?? []);
+  const pointsData   = aggregatePointsByProject(boardQ.data ?? []);
+  const stagesData   = stageToMinutes(stagesQ.data ?? []);
+  const reworkData   = reworkRates(reworkQ.data ?? []);
+
+  return (
+    <div className="charts-grid">
+      {/* Events/Day */}
+      <ChartPanel title="Events / Day">
+        {activityQ.isLoading || activityQ.isError ? (
+          <LoadingOrError loading={activityQ.isLoading} error={activityQ.isError} />
+        ) : (
+          <ResponsiveContainer width="100%" height={220}>
+            <BarChart data={activityData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+              <XAxis dataKey="date" tick={{ fill: C.fg3, fontSize: 9 }} axisLine={false} tickLine={false} />
+              <YAxis tick={{ fill: C.fg3, fontSize: 9 }} axisLine={false} tickLine={false} />
+              <Tooltip contentStyle={TOOLTIP_STYLE} cursor={{ fill: 'oklch(1 0 0 / 0.03)' }} />
+              <Bar dataKey="n" name="Events" fill={C.accent} radius={[2, 2, 0, 0]} maxBarSize={24} />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </ChartPanel>
+
+      {/* Total Points by Project */}
+      <ChartPanel title="Total Points by Project">
+        {boardQ.isLoading || boardQ.isError ? (
+          <LoadingOrError loading={boardQ.isLoading} error={boardQ.isError} />
+        ) : (
+          <ResponsiveContainer width="100%" height={220}>
+            <BarChart data={pointsData} layout="vertical" margin={{ top: 0, right: 8, left: 4, bottom: 0 }}>
+              <XAxis type="number" tick={{ fill: C.fg3, fontSize: 9 }} axisLine={false} tickLine={false} />
+              <YAxis type="category" dataKey="project" tick={{ fill: C.fg3, fontSize: 9 }} axisLine={false} tickLine={false} width={90} />
+              <Tooltip contentStyle={TOOLTIP_STYLE} cursor={{ fill: 'oklch(1 0 0 / 0.03)' }} />
+              <Bar dataKey="pts" name="Points" fill={C.dev} radius={[0, 2, 2, 0]} maxBarSize={16} />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </ChartPanel>
+
+      {/* Avg Minutes per Stage */}
+      <ChartPanel title="Avg Minutes per Stage">
+        {stagesQ.isLoading || stagesQ.isError ? (
+          <LoadingOrError loading={stagesQ.isLoading} error={stagesQ.isError} />
+        ) : (
+          <ResponsiveContainer width="100%" height={220}>
+            <BarChart data={stagesData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+              <XAxis dataKey="stage" tick={{ fill: C.fg3, fontSize: 9 }} axisLine={false} tickLine={false} />
+              <YAxis tick={{ fill: C.fg3, fontSize: 9 }} axisLine={false} tickLine={false} />
+              <Tooltip contentStyle={TOOLTIP_STYLE} cursor={{ fill: 'oklch(1 0 0 / 0.03)' }} formatter={(v) => [`${v} min`, 'Avg']} />
+              <Bar dataKey="minutes" name="Avg min" radius={[2, 2, 0, 0]} maxBarSize={40}>
+                {stagesData.map((entry) => (
+                  <Cell key={entry.stage} fill={STAGE_COLORS[entry.stage] ?? C.accent} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </ChartPanel>
+
+      {/* Rework Rate */}
+      <ChartPanel title="Rework Rate">
+        {reworkQ.isLoading || reworkQ.isError ? (
+          <LoadingOrError loading={reworkQ.isLoading} error={reworkQ.isError} />
+        ) : reworkData.length === 0 ? (
+          <div style={{ height: 220, display: 'flex', alignItems: 'center', color: C.fg3, fontSize: 11 }}>No rework data</div>
+        ) : (
+          <ResponsiveContainer width="100%" height={220}>
+            <BarChart data={reworkData} layout="vertical" margin={{ top: 0, right: 8, left: 4, bottom: 0 }}>
+              <XAxis type="number" tick={{ fill: C.fg3, fontSize: 9 }} axisLine={false} tickLine={false} unit="%" />
+              <YAxis type="category" dataKey="project" tick={{ fill: C.fg3, fontSize: 9 }} axisLine={false} tickLine={false} width={90} />
+              <Tooltip contentStyle={TOOLTIP_STYLE} cursor={{ fill: 'oklch(1 0 0 / 0.03)' }} formatter={(v) => [`${v}%`, 'Rework rate']} />
+              <Bar dataKey="rate" name="Rework %" fill={C.warn} radius={[0, 2, 2, 0]} maxBarSize={16} />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </ChartPanel>
+    </div>
+  );
+}

--- a/web/src/panels/ClaudeUsage.tsx
+++ b/web/src/panels/ClaudeUsage.tsx
@@ -1,0 +1,69 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchClaudeUsage } from '../lib/api';
+
+function fmtDur(seconds: number): string {
+  if (seconds >= 86400) {
+    const d = Math.floor(seconds / 86400);
+    const h = Math.floor((seconds % 86400) / 3600);
+    return h > 0 ? `${d}d ${h}h` : `${d}d`;
+  }
+  if (seconds >= 3600) {
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    return m > 0 ? `${h}h ${m}m` : `${h}h`;
+  }
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return m > 0 ? `${m}m ${s}s` : `${s}s`;
+}
+
+export default function ClaudeUsage() {
+  const { data, isError } = useQuery({
+    queryKey: ['claude-usage'],
+    queryFn: fetchClaudeUsage,
+    refetchInterval: (query) => {
+      const d = query.state.data;
+      return ((d?.refresh_seconds ?? 300) * 1000);
+    },
+    staleTime: 60_000,
+  });
+
+  if (!data || !data.enabled || isError) return null;
+
+  if (data.error) {
+    return (
+      <div className="panel">
+        <div className="panel-h"><span>Claude Usage</span></div>
+        <div style={{ padding: 'var(--pad-3)', fontSize: '0.82rem', color: 'var(--fg-3)' }}>
+          Claude usage unavailable: {data.error}
+        </div>
+      </div>
+    );
+  }
+
+  const pct = Math.min(100, Math.max(0, data.quota_pct ?? 0));
+  const fillClass = pct >= 90 ? 'usage-fill usage-critical' : pct >= 75 ? 'usage-fill usage-warn' : 'usage-fill';
+
+  const resetSecs = data.reset_at
+    ? Math.max(0, Math.floor((new Date(data.reset_at).getTime() - Date.now()) / 1000))
+    : null;
+  const resetStr = resetSecs != null ? `resets in ${fmtDur(resetSecs)}` : '';
+
+  const usedStr = data.quota_used != null ? data.quota_used.toLocaleString() : '?';
+  const limitStr = data.quota_limit != null ? data.quota_limit.toLocaleString() : '?';
+
+  return (
+    <div className="panel">
+      <div className="panel-h"><span>Claude Usage</span></div>
+      <div style={{ padding: 'var(--pad-3)' }}>
+        <div className="usage-bar">
+          <div className={fillClass} style={{ width: `${pct}%` }} />
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.75rem', color: 'var(--fg-3)' }}>
+          <span>{usedStr} / {limitStr} &middot; {pct}%</span>
+          {resetStr && <span>{resetStr}</span>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/screens/Overview.tsx
+++ b/web/src/screens/Overview.tsx
@@ -1,0 +1,14 @@
+import Charts from '../panels/Charts';
+import ClaudeUsage from '../panels/ClaudeUsage';
+
+export default function Overview() {
+  return (
+    <div>
+      <div className="screen-h">
+        <h1>Overview</h1>
+      </div>
+      <ClaudeUsage />
+      <Charts />
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #121

## Changes

### New files
- **`web/src/panels/Charts.tsx`** — Four recharts charts (Events/Day, Total Points by Project, Avg Minutes per Stage, Rework Rate) in a 2×2 responsive grid. Uses existing `fetchStatsActivity`, `fetchStatsStages`, `fetchStatsRework`, and `fetchBoard` from the typed API client. TanStack Query with 60s refetch interval.
- **`web/src/panels/ClaudeUsage.tsx`** — Quota bar panel reading from `/api/claude_usage` via `fetchClaudeUsage`. Hides itself when `data.enabled === false`. Shows progressive coloring (accent → warn → fail) at 75%/90% thresholds. Refetch interval driven by `data.refresh_seconds ?? 300`.
- **`web/src/screens/Overview.tsx`** — Overview screen mounting ClaudeUsage above the Charts grid.
- **`tests/visual/test_overview.py`** — Placeholder visual-diff tests (skipped; harness from #113 not yet merged).

### Modified files
- **`web/src/lib/types.ts`** — Added `ClaudeUsage` interface matching the server `/api/claude_usage` contract.
- **`web/src/lib/api.ts`** — Added `fetchClaudeUsage()` following the existing `get<T>()` + fixture-mode pattern. (Note: `fetchStatsActivity`, `fetchStatsStages`, `fetchStatsRework` were already present from #115.)
- **`web/src/lib/fixtures.ts`** — Added `getFixtureClaudeUsage()` with deterministic fixture data.
- **`web/src/lib/tokens.css`** — Added `.usage-bar`, `.usage-fill`, `.usage-warn`, `.usage-critical`, `.charts-grid` using design tokens only (no raw hex literals).
- **`web/src/App.tsx`** — Wired Overview screen + `1`/`2`/`3`/`4` keyboard shortcuts.
- **`web/package.json`** — Added `recharts` (v3.8.1). No `@types/recharts` needed; types are bundled.

## Mount decision

Both panels are placed on **Overview** (`web/src/screens/Overview.tsx`) rather than a new Stats screen. The four charts + usage bar fit the Overview page without crowding because the charts use a 2×2 grid and each chart is 220px tall. No new `Stats` screen or `5` keyboard shortcut was needed.

## Recharts vs Chart.js

All four charts are expressed in recharts using `BarChart` + `ResponsiveContainer`. No Chart.js fallback was needed. `ResponsiveContainer` is given an explicit `height={220}` per the hint in the issue.

## Chart color mapping

| Chart | Color token |
|-------|------------|
| Events/Day | `--accent` |
| Total Points | `--role-dev` |
| Avg min / dev stage | `--role-dev` |
| Avg min / review stage | `--role-reviewer` |
| Avg min / qa stage | `--role-qa` |
| Avg min / merge stage | `--role-merge` |
| Rework Rate | `--warn` |

## Test Plan

- `cd web && npm run typecheck` passes (zero errors)
- `cd web && npm test` passes (15/15 unit tests)
- `pytest tests/` — 99 pass, 2 skip (visual placeholders), 1 pre-existing failure in `test_graph.py::test_events_graph_with_data` (present on `main` before this PR)
- Manual: load `?fixtures=1` in browser → Overview screen shows Claude Usage quota bar + all 4 charts with fixture data