### PR TITLE
[LM-148] Modernize Python tooling: 3.13 floor, single-source version, pyright

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,8 +15,10 @@ jobs:
         with:
           python-version-file: pyproject.toml
 
-      - name: Install linting tools
-        run: pip install ruff pyright
+      - name: Install project + linting tools
+        run: |
+          pip install -r requirements.txt
+          pip install ruff pyright
 
       - name: ruff check
         run: ruff check .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,16 +13,16 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version-file: pyproject.toml
 
       - name: Install linting tools
-        run: pip install ruff mypy
+        run: pip install ruff pyright
 
       - name: ruff check
         run: ruff check .
 
-      - name: mypy
-        run: mypy server
+      - name: pyright
+        run: pyright server/
 
   web:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,9 +6,8 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.409
     hooks:
-      - id: mypy
-        files: ^server\.py$
-        additional_dependencies: []
+      - id: pyright
+        files: ^server/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ uvicorn server:app --host 127.0.0.1 --port 18792 --reload
 ## Code quality
 
 This repo uses [ruff](https://docs.astral.sh/ruff/) for linting/formatting and
-[mypy](https://mypy.readthedocs.io/) for type checking.
+[pyright](https://github.com/microsoft/pyright) for type checking.
 
 **One-time setup** — install the pre-commit hooks so checks run automatically before every commit:
 
@@ -40,13 +40,13 @@ pre-commit install
 ruff check .
 
 # Type check (server only)
-mypy server.py
+pyright server/
 
 # Run all pre-commit hooks against every file
 pre-commit run --all-files
 ```
 
-CI runs `ruff check .` and `mypy server.py` on every PR and push to `main`.
+CI runs `ruff check .` and `pyright server/` on every PR and push to `main`.
 
 Open http://127.0.0.1:18792.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,14 @@
+[project]
+name = "loop-monitor"
+requires-python = ">=3.13"
+
 [tool.ruff]
 line-length = 120
-target-version = "py39"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]
 
-[tool.mypy]
-strict_optional = true
-warn_unused_ignores = true
-ignore_missing_imports = true
+[tool.pyright]
+include = ["server"]
+pythonVersion = "3.13"
+typeCheckingMode = "basic"


### PR DESCRIPTION
Closes #148

## Changes

- **`pyproject.toml`**: Added `[project]` block with `name = "loop-monitor"` and `requires-python = ">=3.13"`. Removed `target-version` from `[tool.ruff]` (ruff now infers from `requires-python`). Replaced `[tool.mypy]` with `[tool.pyright]` (`include = ["server"]`, `pythonVersion = "3.13"`, `typeCheckingMode = "basic"`).
- **`.github/workflows/lint.yml`**: Replaced `python-version: "3.11"` with `python-version-file: pyproject.toml` so CI reads Python version from a single source. Replaced `pip install ruff mypy` + `mypy server` with `pip install ruff pyright` + `pyright server/` for full package coverage.
- **`.pre-commit-config.yaml`**: Removed `mirrors-mypy` hook. Added `RobertCraigie/pyright-python` hook (rev `v1.1.409`) scoped to `^server/` — real coverage gain over the old hook that targeted `^server\.py$` (a single legacy file that no longer exists).
- **`CONTRIBUTING.md`**: Updated mypy references to pyright in the Code Quality section and CI description.

### pyright result
`pyright server/` → `0 errors, 0 warnings, 0 informations` (no type fixes needed; codebase was already clean under basic mode).

### CONTRIBUTING.md mypy references
Found and updated three references: tool description, manual run command, and CI description line.

## Test Plan
- [ ] `ruff check .` passes (verified locally)
- [ ] `pyright server/` passes with 0 errors (verified locally with pyright 1.1.409)
- [ ] CI `lint` job goes green (Python 3.13 via `python-version-file`, ruff + pyright)
- [ ] CI `web` job unchanged — not touched
- [ ] Existing `pytest tests/` suite unaffected — no runtime changes