### PR TITLE
[LM-124] Phase 4.4 · Port Logs tab to React

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import Logo from './components/Logo';
 import TopBar from './components/TopBar';
 import NavRail from './components/NavRail';
 import Overview from './screens/Overview';
+import Logs from './screens/Logs';
 import { fetchActive, fetchHealth } from './lib/api';
 
 const SCREEN_KEYS: Record<string, string> = {
@@ -11,6 +12,7 @@ const SCREEN_KEYS: Record<string, string> = {
   '2': 'queue',
   '3': 'projects',
   '4': 'workers',
+  '5': 'logs',
 };
 
 export default function App() {
@@ -52,6 +54,7 @@ export default function App() {
       <NavRail screen={screen} setScreen={setScreen} />
       <main className="main">
         {screen === 'overview' && <Overview />}
+        {screen === 'logs' && <Logs />}
       </main>
     </div>
   );

--- a/web/src/components/NavRail.tsx
+++ b/web/src/components/NavRail.tsx
@@ -28,6 +28,12 @@ const NAV_ICONS: Record<string, ReactNode> = {
       <circle cx="17" cy="9" r="2.5"/><path d="M14 18c0-2.5 1.6-4 3-4s3 1.5 3 4"/>
     </svg>
   ),
+  logs: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <rect x="4" y="3" width="16" height="18" rx="1"/>
+      <path d="M8 8h8M8 12h8M8 16h5"/>
+    </svg>
+  ),
   settings: (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
       <circle cx="12" cy="12" r="3"/>
@@ -42,6 +48,7 @@ export default function NavRail({ screen, setScreen }: NavRailProps) {
     { id: 'queue',    label: 'Action Queue' },
     { id: 'projects', label: 'Projects' },
     { id: 'workers',  label: 'Workers' },
+    { id: 'logs',     label: 'Logs' },
   ];
   return (
     <div className="nav">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -19,6 +19,7 @@ import type {
   StatsRework,
   ClaudeUsage,
   ScannerState,
+  LogsResponse,
 } from './types';
 import * as fx from './fixtures';
 
@@ -128,4 +129,20 @@ export async function fetchClaudeUsage(): Promise<ClaudeUsage> {
 export async function fetchScannerState(): Promise<ScannerState> {
   if (isFixtureMode()) return fx.getFixtureScannerState();
   return get<ScannerState>('/api/scanner_state');
+}
+
+export class LogsDisabledError extends Error {
+  constructor() { super('Logs are disabled. Set LOOPMON_EXPOSE_LOGS=1 or access via loopback.'); }
+}
+
+export async function fetchLogs(handler: string, filter: string, tail: string): Promise<LogsResponse> {
+  const params = new URLSearchParams({ handler, tail });
+  if (filter) params.set('filter', filter);
+  const res = await fetch(`/api/logs?${params.toString()}`);
+  if (res.status === 403) throw new LogsDisabledError();
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error((body as { detail?: string }).detail || res.statusText);
+  }
+  return res.json() as Promise<LogsResponse>;
 }

--- a/web/src/lib/tokens.css
+++ b/web/src/lib/tokens.css
@@ -27,6 +27,7 @@
   --fail:      oklch(0.68 0.20 25);
   --warn:      oklch(0.82 0.16 80);
   --info:      oklch(0.74 0.14 235);
+  --role-err:  oklch(0.68 0.20 25);
 
   /* Role tints — constant lightness ~0.74, chroma ~0.13 */
   --role-po:        oklch(0.74 0.16 295);  /* violet */

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -187,3 +187,18 @@ export interface ScannerState {
   stages: Record<string, StageInfo>;
   retries: RetryRow[];
 }
+
+export interface LogLine {
+  ts?: string;
+  handler?: string;
+  msg?: string;
+  raw?: string;
+}
+
+export interface LogsResponse {
+  path: string;
+  on_disk_bytes: number;
+  fd_bytes: number | null;
+  orphaned: boolean;
+  lines: LogLine[];
+}

--- a/web/src/screens/Logs.tsx
+++ b/web/src/screens/Logs.tsx
@@ -1,0 +1,157 @@
+// TODO(#113): capture reference screenshot once visual-diff harness lands
+import { useState } from 'react';
+import { fetchLogs, LogsDisabledError } from '../lib/api';
+import type { LogsResponse, LogLine } from '../lib/types';
+
+const HANDLERS = [
+  'scanner', 'reconciler', 'po-handler', 'dev-handler',
+  'dev-rework-handler', 'review-handler', 'qa-handler', 'merge-handler',
+];
+
+function fmtBytes(n: number | null | undefined): string {
+  if (n == null) return '?';
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function LogLineRow({ line }: { line: LogLine }) {
+  return (
+    <div style={{ fontFamily: 'var(--font-mono)', fontSize: 12, lineHeight: '1.6', padding: '1px 0' }}>
+      {line.ts && <span style={{ color: 'var(--fg-3)' }}>{line.ts} </span>}
+      {line.handler && <span style={{ color: 'var(--info)' }}>[{line.handler}] </span>}
+      <span>{line.msg ?? line.raw ?? ''}</span>
+    </div>
+  );
+}
+
+export default function Logs() {
+  const [handler, setHandler] = useState('scanner');
+  const [filter, setFilter] = useState('');
+  const [tail, setTail] = useState('200');
+  const [data, setData] = useState<LogsResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [disabled, setDisabled] = useState(false);
+
+  async function refresh() {
+    setLoading(true);
+    setError(null);
+    setDisabled(false);
+    try {
+      const result = await fetchLogs(handler, filter, tail);
+      setData(result);
+    } catch (e) {
+      setData(null);
+      if (e instanceof LogsDisabledError) {
+        setDisabled(true);
+      } else {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div style={{ padding: 'var(--pad-4)', display: 'flex', flexDirection: 'column', gap: 'var(--pad-3)', height: '100%', boxSizing: 'border-box' }}>
+      <div className="screen-h" style={{ padding: 0, border: 'none' }}>
+        <h1>Logs</h1>
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--pad-2)', flexWrap: 'wrap' }}>
+        <select
+          value={handler}
+          onChange={e => setHandler(e.target.value)}
+          style={{
+            fontFamily: 'var(--font-mono)', fontSize: 12, padding: '4px 8px',
+            background: 'var(--bg-2)', color: 'var(--fg)', border: '1px solid var(--border)',
+            borderRadius: 2, cursor: 'pointer',
+          }}
+        >
+          {HANDLERS.map(h => <option key={h} value={h}>{h}</option>)}
+        </select>
+
+        <input
+          type="text"
+          placeholder="filter"
+          value={filter}
+          onChange={e => setFilter(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') refresh(); }}
+          style={{
+            fontFamily: 'var(--font-mono)', fontSize: 12, padding: '4px 8px',
+            background: 'var(--bg-2)', color: 'var(--fg)', border: '1px solid var(--border)',
+            borderRadius: 2, width: 180,
+          }}
+        />
+
+        <input
+          type="text"
+          placeholder="tail"
+          value={tail}
+          onChange={e => setTail(e.target.value)}
+          style={{
+            fontFamily: 'var(--font-mono)', fontSize: 12, padding: '4px 8px',
+            background: 'var(--bg-2)', color: 'var(--fg)', border: '1px solid var(--border)',
+            borderRadius: 2, width: 70,
+          }}
+        />
+
+        <button className="btn primary" onClick={refresh} disabled={loading}>
+          {loading ? 'Loading…' : 'Refresh'}
+        </button>
+      </div>
+
+      {data && (
+        <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--fg-3)' }}>
+          {data.path} · disk={fmtBytes(data.on_disk_bytes)} · fd={fmtBytes(data.fd_bytes)}
+        </div>
+      )}
+
+      {data?.orphaned && (
+        <div style={{
+          background: 'var(--bg-2)',
+          borderLeft: '3px solid var(--accent)',
+          padding: 'var(--pad-3)',
+          fontFamily: 'var(--font-mono)',
+          fontSize: 12,
+          color: 'var(--warn)',
+        }}>
+          WARNING: {handler} log appears orphaned (FD {fmtBytes(data.fd_bytes)}, file {fmtBytes(data.on_disk_bytes)}). See svv2014/loop#194.
+        </div>
+      )}
+
+      {disabled && (
+        <div style={{ color: 'var(--role-err)', fontFamily: 'var(--font-mono)', fontSize: 12 }}>
+          Logs are disabled. Set LOOPMON_EXPOSE_LOGS=1 or access via loopback.
+        </div>
+      )}
+
+      {error && (
+        <div style={{ color: 'var(--role-err)', fontFamily: 'var(--font-mono)', fontSize: 12 }}>
+          Error: {error}
+        </div>
+      )}
+
+      {data && (
+        <div style={{
+          flex: 1, overflow: 'auto',
+          background: 'var(--bg-1)', border: '1px solid var(--border)',
+          padding: 'var(--pad-3)',
+          minHeight: 0,
+        }}>
+          {data.lines.length === 0
+            ? <div style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 12 }}>No matching lines.</div>
+            : data.lines.map((line, i) => <LogLineRow key={i} line={line} />)
+          }
+        </div>
+      )}
+
+      {!data && !disabled && !error && !loading && (
+        <div style={{ color: 'var(--fg-4)', fontFamily: 'var(--font-mono)', fontSize: 12 }}>
+          Select a handler and click Refresh to load logs.
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #124

## Changes

- **`web/src/screens/Logs.tsx`** — New Logs screen with handler `<select>` (8 handlers), free-text filter input, tail count input (default 200), refresh button, meta line (path · disk=X · fd=X), orphan warning banner, and scrollable log line list. Empty state shows "No matching lines."; 403 shows disabled message; other errors show detail/statusText.
- **`web/src/lib/types.ts`** — Added `LogLine` and `LogsResponse` interfaces mirroring the `/api/logs` payload shape exactly.
- **`web/src/lib/api.ts`** — Added `fetchLogs(handler, filter, tail)` and `LogsDisabledError` class. 403 throws `LogsDisabledError` so the screen can branch without parsing the body twice.
- **`web/src/components/NavRail.tsx`** — Added `logs` nav item (after `workers`, before settings spacer) with a document/lines SVG icon.
- **`web/src/App.tsx`** — Mounts `<Logs />` when `screen === 'logs'`; keyboard shortcut `5` opens Logs.
- **`web/src/lib/tokens.css`** — Added `--role-err` semantic token (single-line, mirrors `--fail`).

Vanilla files (`static/js/components/logs.js`, `static/index.html`) are untouched — deletion is owned by Phase 5 cutover (#123).

Visual-diff screenshot deferred to follow-up after #113 merges (consistent with #117, #135, #136).

## Test Plan

- `ruff check .` — passes
- `cd web && npm run typecheck` — passes (Charts.tsx recharts errors are pre-existing on main)
- `cd web && npm test` — 15/15 pass
- `cd web && npm run build` — builds successfully
- Human visual review: select a handler, click Refresh, verify log lines render; test 403 path with LOOPMON_EXPOSE_LOGS unset; test orphan banner when `orphaned: true`; press `5` to navigate to Logs tab