### PR TITLE
[LM-161] Per-issue cost report — GET /api/issues/cost endpoint

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -24,6 +24,7 @@ from server.routes import (  # noqa: E402
     graph,
     health,
     ingest,
+    issues_cost,
     logs,
     runs,
     scanner_state,
@@ -39,6 +40,7 @@ app.include_router(stats.router)
 app.include_router(graph.router)
 app.include_router(action_queue.router)
 app.include_router(claude_usage.router)
+app.include_router(issues_cost.router)
 app.include_router(logs.router)
 app.include_router(scanner_state.router)
 

--- a/server/routes/issues_cost.py
+++ b/server/routes/issues_cost.py
@@ -1,0 +1,186 @@
+import json
+import re
+import subprocess
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import APIRouter
+
+from server.db import get_db
+
+router = APIRouter()
+
+# (project, issue_number) -> (expiry_timestamp, meta_dict)
+_gh_cache: dict[tuple[str, int], tuple[float, dict]] = {}
+_GH_TTL = 60
+
+_PRIORITY_LABELS = {"p0-critical", "p1-high", "p2-medium", "p3-low"}
+_ROLES = ["po", "dev", "review", "qa", "merge"]
+_CHILD_RE = re.compile(r"(?:closes|depends\s+on)\s+#(\d+)", re.IGNORECASE)
+
+
+def _fetch_gh_meta(project: str, issue_number: int) -> dict:
+    key = (project, issue_number)
+    now = datetime.now(timezone.utc).timestamp()
+    if key in _gh_cache:
+        expiry, data = _gh_cache[key]
+        if now < expiry:
+            return data
+
+    default: dict = {"title": "", "state": "unknown", "priority": None, "body": "", "merged": False}
+    try:
+        result = subprocess.run(
+            [
+                "gh", "api",
+                f"repos/svv2014/{project}/issues/{issue_number}",
+                "--jq",
+                "{title, state, body, labels: [.labels[].name], pull_request}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            _gh_cache[key] = (now + _GH_TTL, default)
+            return default
+        raw = json.loads(result.stdout)
+        labels: list[str] = raw.get("labels") or []
+        priority: Optional[str] = next((lbl for lbl in labels if lbl in _PRIORITY_LABELS), None)
+        pr_field = raw.get("pull_request") or {}
+        merged = bool(pr_field.get("merged_at"))
+        meta: dict = {
+            "title": raw.get("title") or "",
+            "state": raw.get("state") or "unknown",
+            "priority": priority,
+            "body": raw.get("body") or "",
+            "merged": merged,
+        }
+        _gh_cache[key] = (now + _GH_TTL, meta)
+        return meta
+    except Exception:
+        _gh_cache[key] = (now + _GH_TTL, default)
+        return default
+
+
+def _parse_children(body: str) -> int:
+    return len(set(_CHILD_RE.findall(body)))
+
+
+def _build_row(raw: dict, meta: dict, now_ts: float) -> dict:
+    actual_runs: int = raw.get("actual_runs") or 0
+    child_count = _parse_children(meta.get("body") or "")
+    happy_path_runs = 5 + (5 * child_count)
+    rework_factor = 0.0 if actual_runs == 0 else round(actual_runs / happy_path_runs, 2)
+
+    state: str = meta.get("state") or "unknown"
+    merged: bool = meta.get("merged") or False
+    stranded_seconds: Optional[int] = None
+    if state == "open" and not merged:
+        last_event: Optional[str] = raw.get("last_event")
+        if last_event:
+            try:
+                last_dt = datetime.fromisoformat(last_event.replace(" ", "T"))
+                if last_dt.tzinfo is None:
+                    last_dt = last_dt.replace(tzinfo=timezone.utc)
+                stranded_seconds = int(now_ts - last_dt.timestamp())
+            except Exception:
+                pass
+
+    stage_runs: dict = {}
+    for role in _ROLES:
+        stage_runs[role] = raw.get(f"{role}_runs") or 0
+        stage_runs[f"{role}_failed"] = raw.get(f"{role}_failed") or 0
+
+    return {
+        "project": raw["project"],
+        "issue_number": raw["issue_number"],
+        "title": meta.get("title") or "",
+        "priority": meta.get("priority"),
+        "state": state,
+        "first_event": raw.get("first_event"),
+        "last_event": raw.get("last_event"),
+        "stage_runs": stage_runs,
+        "happy_path_runs": happy_path_runs,
+        "actual_runs": actual_runs,
+        "rework_factor": rework_factor,
+        "total_points": raw.get("total_points") or 0,
+        "verdict_count": raw.get("verdict_count") or 0,
+        "stranded_seconds": stranded_seconds,
+    }
+
+
+@router.get("/api/issues/cost")
+def get_issues_cost(
+    project: Optional[str] = None,
+    since: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> list:
+    if since is None:
+        since_dt = datetime.now(timezone.utc) - timedelta(days=30)
+        since_iso = since_dt.isoformat()
+    else:
+        since_iso = since
+
+    conn = get_db()
+    project_param: Optional[str] = project
+
+    rows = conn.execute(
+        """
+        WITH agg AS (
+            SELECT
+                project,
+                issue_number,
+                MIN(created_at)                                                    AS first_event,
+                MAX(created_at)                                                    AS last_event,
+                SUM(CASE WHEN event_type LIKE '%_start'   THEN 1 ELSE 0 END)      AS actual_runs,
+                SUM(CASE WHEN event_type = 'po_start'     THEN 1 ELSE 0 END)      AS po_runs,
+                SUM(CASE WHEN event_type = 'po_failed'    THEN 1 ELSE 0 END)      AS po_failed,
+                SUM(CASE WHEN event_type = 'dev_start'    THEN 1 ELSE 0 END)      AS dev_runs,
+                SUM(CASE WHEN event_type = 'dev_failed'   THEN 1 ELSE 0 END)      AS dev_failed,
+                SUM(CASE WHEN event_type = 'review_start' THEN 1 ELSE 0 END)      AS review_runs,
+                SUM(CASE WHEN event_type = 'review_failed' THEN 1 ELSE 0 END)     AS review_failed,
+                SUM(CASE WHEN event_type = 'qa_start'     THEN 1 ELSE 0 END)      AS qa_runs,
+                SUM(CASE WHEN event_type = 'qa_failed'    THEN 1 ELSE 0 END)      AS qa_failed,
+                SUM(CASE WHEN event_type = 'merge_start'  THEN 1 ELSE 0 END)      AS merge_runs,
+                SUM(CASE WHEN event_type = 'merge_failed' THEN 1 ELSE 0 END)      AS merge_failed
+            FROM events
+            WHERE issue_number IS NOT NULL
+              AND created_at >= ?
+              AND (? IS NULL OR project = ?)
+            GROUP BY project, issue_number
+            HAVING actual_runs > 0
+            ORDER BY actual_runs DESC
+            LIMIT ? OFFSET ?
+        )
+        SELECT
+            a.*,
+            (
+                SELECT COUNT(*)
+                FROM verdicts v
+                WHERE v.project = a.project
+                  AND v.created_at BETWEEN a.first_event AND a.last_event
+            ) AS verdict_count,
+            (
+                SELECT COALESCE(SUM(v.points), 0)
+                FROM verdicts v
+                WHERE v.project = a.project
+                  AND v.created_at BETWEEN a.first_event AND a.last_event
+            ) AS total_points
+        FROM agg a
+        """,
+        (since_iso, project_param, project_param, limit, offset),
+    ).fetchall()
+    conn.close()
+
+    now_ts = datetime.now(timezone.utc).timestamp()
+    result = []
+    for raw in rows:
+        raw_dict = dict(raw)
+        project_slug = raw_dict["project"]
+        issue_num = raw_dict["issue_number"]
+        meta = _fetch_gh_meta(project_slug, issue_num)
+        result.append(_build_row(raw_dict, meta, now_ts))
+
+    result.sort(key=lambda r: (-r["rework_factor"], -r["actual_runs"]))
+    return result

--- a/tests/test_issues_cost.py
+++ b/tests/test_issues_cost.py
@@ -1,0 +1,161 @@
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+import server
+import server.db
+import server.routes.issues_cost as issues_cost_module
+
+
+def _make_client(monkeypatch, tmp_path, gh_meta_fn=None):
+    monkeypatch.setattr(server.db, "DB_PATH", str(tmp_path / "test.db"))
+    server.db.apply_pending_migrations()
+    issues_cost_module._gh_cache.clear()
+    if gh_meta_fn is not None:
+        monkeypatch.setattr(issues_cost_module, "_fetch_gh_meta", gh_meta_fn)
+    return TestClient(server.app)
+
+
+def _open_meta(project, issue_number):
+    return {"title": f"Issue {issue_number}", "state": "open", "priority": None, "body": "", "merged": False}
+
+
+def _insert_events(db_path: str, events: list) -> None:
+    conn = sqlite3.connect(db_path)
+    for ev in events:
+        conn.execute(
+            "INSERT INTO events (project, role, event_type, issue_number, created_at) VALUES (?,?,?,?,?)",
+            (ev["project"], ev["role"], ev["event_type"], ev["issue_number"], ev["created_at"]),
+        )
+    conn.commit()
+    conn.close()
+
+
+# (a) exactly 5 *_start events, one per role → rework_factor == 1.0, actual_runs == 5
+def test_happy_path_issue(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    roles = ["po", "dev", "review", "qa", "merge"]
+    ts = "2026-04-01T10:00:00+00:00"
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-a", "role": r, "event_type": f"{r}_start", "issue_number": 10, "created_at": ts}
+        for r in roles
+    ])
+    resp = client.get("/api/issues/cost?since=2026-01-01")
+    assert resp.status_code == 200
+    row = next((r for r in resp.json() if r["issue_number"] == 10 and r["project"] == "proj-a"), None)
+    assert row is not None
+    assert row["actual_runs"] == 5
+    assert row["rework_factor"] == 1.0
+
+
+# (b) 10 *_start events (rework loop) → rework_factor == 2.0, actual_runs == 10
+def test_rework_issue(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    ts = "2026-04-01T11:00:00+00:00"
+    events = []
+    for _ in range(2):
+        for r in ["po", "dev", "review", "qa", "merge"]:
+            events.append({"project": "proj-b", "role": r, "event_type": f"{r}_start",
+                           "issue_number": 20, "created_at": ts})
+    _insert_events(server.db.DB_PATH, events)
+    resp = client.get("/api/issues/cost?since=2026-01-01")
+    assert resp.status_code == 200
+    row = next((r for r in resp.json() if r["issue_number"] == 20 and r["project"] == "proj-b"), None)
+    assert row is not None
+    assert row["actual_runs"] == 10
+    assert row["rework_factor"] == 2.0
+
+
+# (c) merged/closed issue → stranded_seconds is None
+def test_merged_issue_no_stranded(tmp_path, monkeypatch):
+    def _merged_meta(project, issue_number):
+        return {"title": "Closed", "state": "closed", "priority": None, "body": "", "merged": True}
+
+    client = _make_client(monkeypatch, tmp_path, _merged_meta)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-c", "role": "dev", "event_type": "dev_start",
+         "issue_number": 30, "created_at": "2026-04-01T09:00:00+00:00"},
+    ])
+    resp = client.get("/api/issues/cost?since=2026-01-01")
+    assert resp.status_code == 200
+    row = next((r for r in resp.json() if r["issue_number"] == 30), None)
+    assert row is not None
+    assert row["stranded_seconds"] is None
+
+
+# (d) open issue with last event ~1h ago → stranded_seconds ≈ 3600
+def test_open_issue_stranded(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    one_hour_ago = (datetime.now(timezone.utc) - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-d", "role": "dev", "event_type": "dev_start",
+         "issue_number": 40, "created_at": one_hour_ago},
+    ])
+    resp = client.get("/api/issues/cost?since=2026-01-01")
+    assert resp.status_code == 200
+    row = next((r for r in resp.json() if r["issue_number"] == 40), None)
+    assert row is not None
+    assert row["stranded_seconds"] is not None
+    assert abs(row["stranded_seconds"] - 3600) < 5
+
+
+# (e) GH API unavailable → 200 with priority=null, title=""
+def test_gh_api_unavailable(tmp_path, monkeypatch):
+    monkeypatch.setattr(server.db, "DB_PATH", str(tmp_path / "test.db"))
+    server.db.apply_pending_migrations()
+    issues_cost_module._gh_cache.clear()
+
+    import subprocess as subprocess_mod
+
+    def _raise(*args, **kwargs):
+        raise OSError("gh not found")
+
+    monkeypatch.setattr(subprocess_mod, "run", _raise)
+
+    client = TestClient(server.app)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-e", "role": "dev", "event_type": "dev_start",
+         "issue_number": 50, "created_at": "2026-04-01T10:00:00+00:00"},
+    ])
+    resp = client.get("/api/issues/cost?since=2026-01-01")
+    assert resp.status_code == 200
+    row = next((r for r in resp.json() if r["issue_number"] == 50), None)
+    assert row is not None
+    assert row["priority"] is None
+    assert row["title"] == ""
+
+
+# (f) since filter excludes events older than the cutoff
+def test_since_filter(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-f", "role": "dev", "event_type": "dev_start",
+         "issue_number": 60, "created_at": "2025-01-01T00:00:00+00:00"},
+        {"project": "proj-f", "role": "dev", "event_type": "dev_start",
+         "issue_number": 61, "created_at": "2026-05-01T00:00:00+00:00"},
+    ])
+    resp = client.get("/api/issues/cost?since=2026-04-01&project=proj-f")
+    assert resp.status_code == 200
+    issue_numbers = [r["issue_number"] for r in resp.json()]
+    assert 60 not in issue_numbers
+    assert 61 in issue_numbers
+
+
+# (g) limit + offset paginate correctly
+def test_limit_offset(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    ts = "2026-04-15T00:00:00+00:00"
+    for i in range(5):
+        _insert_events(server.db.DB_PATH, [
+            {"project": "proj-g", "role": "dev", "event_type": "dev_start",
+             "issue_number": 100 + i, "created_at": ts},
+        ])
+    all_rows = client.get("/api/issues/cost?since=2026-01-01&project=proj-g&limit=5&offset=0").json()
+    assert len(all_rows) == 5
+
+    page1 = client.get("/api/issues/cost?since=2026-01-01&project=proj-g&limit=2&offset=0").json()
+    page2 = client.get("/api/issues/cost?since=2026-01-01&project=proj-g&limit=2&offset=2").json()
+    assert len(page1) == 2
+    assert len(page2) == 2
+    assert {r["issue_number"] for r in page1}.isdisjoint({r["issue_number"] for r in page2})


### PR DESCRIPTION
Closes #161

## Changes

- **`server/routes/issues_cost.py`** (new): `GET /api/issues/cost` endpoint with `project`, `since`, `limit`, `offset` query params. Groups events by `(project, issue_number)`, computes `actual_runs`, `rework_factor`, `happy_path_runs`, `stage_runs`, `stranded_seconds`, then enriches with GitHub metadata (title, state, priority) via `gh api` subprocess with 60s module-level TTL cache. Falls back gracefully when GH is unavailable.
- **`server/app.py`**: One-line router registration for `issues_cost.router`.
- **`tests/test_issues_cost.py`** (new): 7 tests covering happy path (rework_factor=1.0), rework loop (rework_factor=2.0), merged issue stranded=None, open issue stranded≈3600s, GH API failure → 200 with null priority, `since` filter exclusion, and `limit`/`offset` pagination.

**Schema note:** `events` table has no `points` column and no `target_kind`/`target_number` — grouped by `issue_number`, `total_points` from `verdicts` via time-window join.

## Test Plan
- `pytest tests/test_issues_cost.py -v` — 7/7 pass
- `ruff check .` — clean
- `mypy server` — no issues (21 files)
- `npm run typecheck && npm run build` — clean