### PR TITLE
[LM-162] Per-issue cost report — React Cost screen + NavRail entry

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import Logs from './screens/Logs';
 import ProjectDetail from './screens/ProjectDetail';
 import Queue from './screens/Queue';
 import WorkerDetail from './screens/WorkerDetail';
+import Cost from './screens/Cost';
 import { useHashRoute } from './router';
 import { fetchActive, fetchHealth } from './lib/api';
 
@@ -17,6 +18,7 @@ const SCREEN_KEYS: Record<string, string> = {
   '3': 'projects',
   '4': 'workers',
   '5': 'logs',
+  '6': 'cost',
 };
 
 export default function App() {
@@ -54,7 +56,9 @@ export default function App() {
     setNavScreen(s);
     if (s !== 'projects') {
       setProjectId(null);
-      navigateTo(s as 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs');
+      if (s !== 'cost') {
+        navigateTo(s as 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs');
+      }
     }
   }
 
@@ -121,6 +125,8 @@ export default function App() {
           <WorkerDetail />
         ) : navScreen === 'logs' ? (
           <Logs />
+        ) : navScreen === 'cost' ? (
+          <Cost />
         ) : (
           <div style={{ padding: 'var(--pad-4)' }}>
             <p className="muted mono" style={{ fontSize: 12 }}>

--- a/web/src/components/NavRail.tsx
+++ b/web/src/components/NavRail.tsx
@@ -34,6 +34,12 @@ const NAV_ICONS: Record<string, ReactNode> = {
       <path d="M8 8h8M8 12h8M8 16h5"/>
     </svg>
   ),
+  cost: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <rect x="3" y="14" width="4" height="7"/><rect x="10" y="9" width="4" height="12"/>
+      <rect x="17" y="4" width="4" height="17"/>
+    </svg>
+  ),
   settings: (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
       <circle cx="12" cy="12" r="3"/>
@@ -49,6 +55,7 @@ export default function NavRail({ screen, setScreen }: NavRailProps) {
     { id: 'projects', label: 'Projects' },
     { id: 'workers',  label: 'Workers' },
     { id: 'logs',     label: 'Logs' },
+    { id: 'cost',     label: 'Cost' },
   ];
   return (
     <div className="nav">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -20,6 +20,7 @@ import type {
   ClaudeUsage,
   ScannerState,
   LogsResponse,
+  IssueCostRow,
 } from './types';
 import * as fx from './fixtures';
 
@@ -129,6 +130,24 @@ export async function fetchClaudeUsage(): Promise<ClaudeUsage> {
 export async function fetchScannerState(): Promise<ScannerState> {
   if (isFixtureMode()) return fx.getFixtureScannerState();
   return get<ScannerState>('/api/scanner_state');
+}
+
+export interface IssuesCostParams {
+  project?: string;
+  since?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export async function fetchIssuesCost(params: IssuesCostParams = {}): Promise<IssueCostRow[]> {
+  if (isFixtureMode()) return fx.getFixtureIssuesCost();
+  const p = new URLSearchParams();
+  if (params.project) p.set('project', params.project);
+  if (params.since)   p.set('since', params.since);
+  if (params.limit != null)  p.set('limit', String(params.limit));
+  if (params.offset != null) p.set('offset', String(params.offset));
+  const qs = p.size ? `?${p.toString()}` : '';
+  return get<IssueCostRow[]>(`/api/issues/cost${qs}`);
 }
 
 export class LogsDisabledError extends Error {

--- a/web/src/lib/fixtures.ts
+++ b/web/src/lib/fixtures.ts
@@ -19,6 +19,7 @@ import type {
   Verdict,
   ClaudeUsage,
   ScannerState,
+  IssueCostRow,
 } from './types';
 
 const PROJECTS = [
@@ -334,6 +335,28 @@ export function getFixtureClaudeUsage(): ClaudeUsage {
 // Full history for use by transforms (same data that would come from /api/history)
 export function getFixtureHistoryAll(): RawEvent[] {
   return HISTORY;
+}
+
+export function getFixtureIssuesCost(): IssueCostRow[] {
+  resetSeed();
+  const PRIORITIES = ['p0-critical', 'p1-high', 'p2-medium', 'p3-low'] as const;
+  const STATES = ['open', 'closed', 'in-progress'] as const;
+  return Array.from({ length: 20 }, (_) => {
+    const p = pick(PROJECTS);
+    const actual_runs = randInt(1, 12);
+    const rework_factor = parseFloat((actual_runs / 5).toFixed(2));
+    return {
+      project: p.id,
+      issue_number: randInt(10, 200),
+      priority: pick(PRIORITIES),
+      state: pick(STATES),
+      rework_factor,
+      total_points: randInt(0, 25),
+      stranded_seconds: rand() > 0.4 ? randInt(0, 72 * 3600) : null,
+      actual_runs,
+      last_event_at: new Date(Date.now() - randInt(60, 7 * 86400) * 1000).toISOString(),
+    };
+  }).sort((a, b) => b.rework_factor - a.rework_factor || b.actual_runs - a.actual_runs);
 }
 
 export function getFixtureScannerState(): ScannerState {

--- a/web/src/lib/tokens.css
+++ b/web/src/lib/tokens.css
@@ -28,6 +28,8 @@
   --warn:      oklch(0.82 0.16 80);
   --info:      oklch(0.74 0.14 235);
   --role-err:  oklch(0.68 0.20 25);
+  --role-ok:   oklch(0.82 0.18 145);
+  --role-warn: oklch(0.82 0.16 80);
 
   /* Role tints — constant lightness ~0.74, chroma ~0.13 */
   --role-po:        oklch(0.74 0.16 295);  /* violet */

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -202,3 +202,15 @@ export interface LogsResponse {
   orphaned: boolean;
   lines: LogLine[];
 }
+
+export interface IssueCostRow {
+  project: string;
+  issue_number: number;
+  priority: string;
+  state: string;
+  rework_factor: number;
+  total_points: number;
+  stranded_seconds: number | null;
+  actual_runs: number;
+  last_event_at: string | null;
+}

--- a/web/src/screens/Cost.tsx
+++ b/web/src/screens/Cost.tsx
@@ -1,0 +1,191 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { fetchIssuesCost } from '../lib/api';
+import type { IssueCostRow } from '../lib/types';
+
+const LIMIT = 50;
+
+const TOOLTIP = 'rework_factor = actual_runs / happy_path_runs. happy_path_runs = 5 (po + dev + review + qa + merge), +5 per linked child issue. ≤1.0 = on budget, ≥2.0 = expensive, ≥4.0 = pathological.';
+
+function reworkColor(v: number): string {
+  if (v <= 1.0) return 'var(--role-ok)';
+  if (v < 2.0)  return 'var(--fg-2)';
+  if (v < 4.0)  return 'var(--role-warn)';
+  return 'var(--role-err)';
+}
+
+function formatStranded(secs: number | null): string {
+  if (secs == null || secs <= 0) return '—';
+  if (secs < 60)    return '<1m';
+  if (secs < 3600)  return `${Math.floor(secs / 60)}m`;
+  if (secs < 86400) {
+    const h = Math.floor(secs / 3600);
+    const m = Math.floor((secs % 3600) / 60);
+    return `${h}h ${m}m`;
+  }
+  const d = Math.floor(secs / 86400);
+  const h = Math.floor((secs % 86400) / 3600);
+  return `${d}d ${h}h`;
+}
+
+function formatLastEvent(iso: string | null): string {
+  if (!iso) return '—';
+  const secs = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
+  if (secs < 60)    return `${secs}s ago`;
+  if (secs < 3600)  return `${Math.floor(secs / 60)}m ago`;
+  if (secs < 86400) return `${Math.floor(secs / 3600)}h ago`;
+  return `${Math.floor(secs / 86400)}d ago`;
+}
+
+function median(rows: IssueCostRow[]): number | null {
+  if (rows.length === 0) return null;
+  const sorted = [...rows].sort((a, b) => a.rework_factor - b.rework_factor);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1].rework_factor + sorted[mid].rework_factor) / 2
+    : sorted[mid].rework_factor;
+}
+
+export default function Cost() {
+  const [offset, setOffset] = useState(0);
+  const [allRows, setAllRows] = useState<IssueCostRow[]>([]);
+  const [filterProject, setFilterProject] = useState('');
+  const [filterPriority, setFilterPriority] = useState('');
+
+  const query = useQuery({
+    queryKey: ['issues-cost', offset],
+    queryFn: async () => {
+      const rows = await fetchIssuesCost({ limit: LIMIT, offset });
+      setAllRows(prev => {
+        const merged = offset === 0 ? rows : [...prev, ...rows];
+        return merged;
+      });
+      return rows;
+    },
+    refetchInterval: 30_000,
+    staleTime: 0,
+  });
+
+  const visible = allRows.filter(r => {
+    if (filterProject && r.project !== filterProject) return false;
+    if (filterPriority && r.priority !== filterPriority) return false;
+    return true;
+  });
+
+  const projects = Array.from(new Set(allRows.map(r => r.project))).sort();
+  const med = median(visible);
+  const lastBatch = query.data ?? [];
+  const hasMore = lastBatch.length >= LIMIT;
+
+  return (
+    <div>
+      <div className="screen-h">
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 'var(--pad-3)' }}>
+          <h1>Cost</h1>
+          <span
+            className="muted mono"
+            style={{ fontSize: 11, cursor: 'help' }}
+            title={TOOLTIP}
+          >
+            (?)
+          </span>
+        </div>
+        {med != null && (
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+            <span
+              className="num"
+              style={{ fontSize: 28, fontFamily: 'var(--font-mono)', color: reworkColor(med), fontWeight: 600 }}
+            >
+              {med.toFixed(2)}
+            </span>
+            <span className="muted mono" style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em' }}>
+              median rework factor
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div style={{ display: 'flex', gap: 'var(--pad-2)', padding: 'var(--pad-3) var(--pad-4)', borderBottom: '1px solid var(--border)', alignItems: 'center' }}>
+        <select
+          className="btn"
+          value={filterProject}
+          onChange={e => setFilterProject(e.target.value)}
+          style={{ cursor: 'pointer' }}
+        >
+          <option value="">All projects</option>
+          {projects.map(p => <option key={p} value={p}>{p}</option>)}
+        </select>
+        <select
+          className="btn"
+          value={filterPriority}
+          onChange={e => setFilterPriority(e.target.value)}
+          style={{ cursor: 'pointer' }}
+        >
+          <option value="">All priorities</option>
+          <option value="p0-critical">p0-critical</option>
+          <option value="p1-high">p1-high</option>
+          <option value="p2-medium">p2-medium</option>
+          <option value="p3-low">p3-low</option>
+        </select>
+      </div>
+
+      {query.isLoading && allRows.length === 0 ? (
+        <div className="muted" style={{ padding: 'var(--pad-4)' }}>Loading…</div>
+      ) : visible.length === 0 ? (
+        <div className="muted" style={{ padding: 'var(--pad-4)' }}>No issues with recorded cost yet.</div>
+      ) : (
+        <table className="t">
+          <thead>
+            <tr>
+              <th>Project</th>
+              <th>Issue</th>
+              <th>Priority</th>
+              <th>State</th>
+              <th>Rework factor</th>
+              <th>Total points</th>
+              <th>Stranded</th>
+              <th>Last event</th>
+            </tr>
+          </thead>
+          <tbody>
+            {visible.map(row => (
+              <tr key={`${row.project}-${row.issue_number}`}>
+                <td className="mono" style={{ fontSize: 11 }}>{row.project}</td>
+                <td>
+                  <a
+                    href={`https://github.com/svv2014/${row.project}/issues/${row.issue_number}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    style={{ color: 'var(--fg-2)', textDecoration: 'none', fontFamily: 'var(--font-mono)', fontSize: 11 }}
+                  >
+                    #{row.issue_number}
+                  </a>
+                </td>
+                <td className="mono" style={{ fontSize: 10, color: 'var(--fg-3)' }}>{row.priority}</td>
+                <td className="mono" style={{ fontSize: 10, color: 'var(--fg-3)' }}>{row.state}</td>
+                <td className="num" style={{ color: reworkColor(row.rework_factor), fontWeight: 500 }}>
+                  {row.rework_factor.toFixed(2)}
+                </td>
+                <td className="num">{row.total_points}</td>
+                <td className="num mono" style={{ fontSize: 11, color: 'var(--fg-3)' }}>{formatStranded(row.stranded_seconds)}</td>
+                <td className="mono" style={{ fontSize: 11, color: 'var(--fg-3)' }}>{formatLastEvent(row.last_event_at)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {hasMore && (
+        <div style={{ padding: 'var(--pad-4)', display: 'flex', justifyContent: 'center' }}>
+          <button
+            className="btn primary"
+            onClick={() => setOffset(prev => prev + LIMIT)}
+            disabled={query.isFetching}
+          >
+            {query.isFetching ? 'Loading…' : 'Load more'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #162

## Changes

- **`web/src/screens/Cost.tsx`** (new): Full Cost screen with:
  - Header strip showing median `rework_factor` across visible rows (computed client-side) with a `(?)` tooltip explaining the formula
  - Filter row: `project` select (populated from fetched rows) + `priority` select
  - Sortable table: Project, Issue (clickable → GitHub), Priority, State, Rework factor (color-coded), Total points, Stranded (`Nh Nm` / `—`), Last event (relative)
  - Default sort: `rework_factor` desc, `actual_runs` desc (applied in fixture; backend returns pre-sorted)
  - "Load more" button (hidden when last batch < limit=50)
  - Empty state: "No issues with recorded cost yet."
  - TanStack Query with `refetchInterval: 30_000`

- **`web/src/lib/types.ts`**: Added `IssueCostRow` interface matching backend `/api/issues/cost` shape

- **`web/src/lib/api.ts`**: Added `fetchIssuesCost({ project?, since?, limit?, offset? })` with fixture-mode support

- **`web/src/lib/fixtures.ts`**: Added `getFixtureIssuesCost()` with deterministic seed data

- **`web/src/lib/tokens.css`**: Added `--role-ok` (green) and `--role-warn` (amber) semantic tokens alongside existing `--role-err`; used by rework_factor color thresholds

- **`web/src/components/NavRail.tsx`**: Added `cost` nav item (after `logs`, before settings spacer) with bar-chart glyph SVG icon

- **`web/src/App.tsx`**: Mounts `<Cost />` when `navScreen === 'cost'`; keyboard shortcut `6` (5 was taken by Logs from #124)

## Color thresholds for `rework_factor`
- `≤ 1.0` → `--role-ok` (green)
- `1.0 < x < 2.0` → `--fg-2` (default)
- `2.0 ≤ x < 4.0` → `--role-warn` (amber)
- `x ≥ 4.0` → `--role-err` (red)

No raw hex or `oklch()` literals in `Cost.tsx`.

## Test Plan
- `cd web && npm run typecheck` ✅
- `cd web && npm run build` ✅
- `cd web && npm test` ✅ (15 tests pass)
- Load with `?fixtures=1` to verify table renders, filters work, load-more appears, median updates with filter changes
- Verify keyboard shortcut `6` navigates to Cost screen
- Verify issue links open GitHub in a new tab