### PR TITLE
[LM-116] Phase 3.1 · Overview screen — five panels

### DIFF
--- a/web/src/components/EventGlyph.tsx
+++ b/web/src/components/EventGlyph.tsx
@@ -1,0 +1,32 @@
+const GLYPH_MAP: Record<string, { sym: string; cls: string; color?: string }> = {
+  po_start:    { sym: '▸', cls: 'role-po' },
+  po_done:     { sym: '◆', cls: 'role-po' },
+  dev_start:   { sym: '▸', cls: 'role-dev' },
+  dev_done:    { sym: '◆', cls: 'role-dev' },
+  qa_pass:     { sym: '✓', cls: 'role-qa' },
+  qa_fail:     { sym: '✗', cls: 'role-qa', color: 'var(--fail)' },
+  review_done: { sym: '◆', cls: 'role-reviewer' },
+  merge_done:  { sym: '⬢', cls: 'role-merge' },
+  judge_done:  { sym: '★', cls: 'role-judge' },
+};
+
+interface EventGlyphProps {
+  event: string;
+}
+
+export default function EventGlyph({ event }: EventGlyphProps) {
+  const m = GLYPH_MAP[event] ?? { sym: '·', cls: 'muted' };
+  return (
+    <span
+      className={m.cls}
+      style={{
+        fontFamily: 'var(--font-mono)',
+        fontSize: 13,
+        lineHeight: 1,
+        ...(m.color ? { color: m.color } : {}),
+      }}
+    >
+      {m.sym}
+    </span>
+  );
+}

--- a/web/src/components/RoleTag.tsx
+++ b/web/src/components/RoleTag.tsx
@@ -1,0 +1,19 @@
+interface RoleTagProps {
+  role: string;
+  solid?: boolean;
+}
+
+export default function RoleTag({ role, solid }: RoleTagProps) {
+  return (
+    <span
+      className={`tag role-${role}`}
+      style={solid ? {
+        background: `var(--role-${role})`,
+        color: 'var(--bg)',
+        borderColor: `var(--role-${role})`,
+      } : {}}
+    >
+      {role}
+    </span>
+  );
+}

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+
+export function relTime(ts: number): string {
+  const s = Math.max(0, Math.floor((Date.now() - ts) / 1000));
+  if (s < 60) return s + 's';
+  if (s < 3600) return Math.floor(s / 60) + 'm';
+  if (s < 86400) return Math.floor(s / 3600) + 'h';
+  return Math.floor(s / 86400) + 'd';
+}
+
+export function durationFmt(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return s + 's';
+  const m = Math.floor(s / 60);
+  const r = s % 60;
+  if (m < 60) return `${m}m ${String(r).padStart(2, '0')}s`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+export function useTick(ms = 1000): void {
+  const [, setN] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setN(n => n + 1), ms);
+    return () => clearInterval(id);
+  }, [ms]);
+}

--- a/web/src/panels/Activity24h.tsx
+++ b/web/src/panels/Activity24h.tsx
@@ -1,0 +1,58 @@
+import type { HourBucket } from '../lib/transforms';
+
+const ROLE_ORDER = ['po', 'dev', 'qa', 'reviewer', 'merge', 'judge'] as const;
+
+interface Activity24hProps {
+  buckets: HourBucket[];
+}
+
+export default function Activity24h({ buckets }: Activity24hProps) {
+  const max = Math.max(1, ...buckets.map(b => b.total));
+
+  return (
+    <div className="panel">
+      <div className="panel-h">
+        <span>24h pipeline activity</span>
+        <span className="muted">
+          {ROLE_ORDER.map(r => (
+            <span key={r} style={{ marginLeft: 12 }}>
+              <span style={{
+                display: 'inline-block',
+                width: 8,
+                height: 8,
+                marginRight: 4,
+                verticalAlign: 'middle',
+                background: `var(--role-${r})`,
+              }}></span>{r}
+            </span>
+          ))}
+        </span>
+      </div>
+      <div style={{ position: 'relative', height: 130, padding: '14px 0 24px' }}>
+        <div className="bars">
+          {buckets.map((b, i) => (
+            <div key={i} className="bar-col">
+              {ROLE_ORDER.map(r => {
+                const v = b.counts[r] ?? 0;
+                if (!v) return null;
+                return (
+                  <div
+                    key={r}
+                    className="bar-seg"
+                    style={{
+                      background: `var(--role-${r})`,
+                      height: `${(v / max) * 100}%`,
+                    }}
+                  />
+                );
+              })}
+              {(i % 6 === 0) && (
+                <div className="bar-tick">{String(b.hour).padStart(2, '0')}:00</div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/panels/ActivityFeed.tsx
+++ b/web/src/panels/ActivityFeed.tsx
@@ -1,0 +1,64 @@
+import { useState, useMemo } from 'react';
+import type { FeedItem } from '../lib/types';
+import { relTime } from '../lib/utils';
+import RoleTag from '../components/RoleTag';
+import EventGlyph from '../components/EventGlyph';
+
+const ROLES = ['all', 'po', 'dev', 'qa', 'reviewer', 'merge', 'judge'] as const;
+
+interface ActivityFeedProps {
+  events: FeedItem[];
+}
+
+export default function ActivityFeed({ events }: ActivityFeedProps) {
+  const [filter, setFilter] = useState('all');
+  const rows = useMemo(() => {
+    const r = filter === 'all' ? events : events.filter(e => e.role === filter);
+    return r.slice(0, 60);
+  }, [events, filter]);
+
+  return (
+    <div className="panel" style={{ display: 'flex', flexDirection: 'column' }}>
+      <div className="panel-h">
+        <span>Activity feed</span>
+        <span className="actions">
+          {ROLES.map(r => (
+            <button
+              key={r}
+              className={`btn ${filter === r ? 'primary' : ''}`}
+              onClick={() => setFilter(r)}
+            >
+              {r}
+            </button>
+          ))}
+        </span>
+      </div>
+      <div style={{ overflow: 'auto', maxHeight: 480 }}>
+        {rows.map(e => {
+          const ts = new Date(e.created_at).getTime();
+          return (
+            <div key={e.id} className="feed-row">
+              <EventGlyph event={e.event_type} />
+              <div style={{ minWidth: 0 }}>
+                <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                  <RoleTag role={e.role} />
+                  <span className="mono" style={{ fontSize: 12 }}>{e.event_type}</span>
+                  <span className="muted mono" style={{ fontSize: 11 }}>
+                    · {e.project}
+                    {e.issue_number != null ? `#${e.issue_number}` : ''}
+                  </span>
+                </div>
+                <div className="muted" style={{ fontSize: 11, marginTop: 2 }}>
+                  <span className="mono">{e.model ?? '—'}</span>
+                </div>
+              </div>
+              <div style={{ textAlign: 'right' }}>
+                <div className="muted mono" style={{ fontSize: 10 }}>{relTime(ts)}</div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/src/panels/Leaderboard.tsx
+++ b/web/src/panels/Leaderboard.tsx
@@ -1,0 +1,73 @@
+import { useState, useMemo } from 'react';
+import type { LoopEvent } from '../lib/types';
+import { buildLeaderboard } from '../lib/transforms';
+import RoleTag from '../components/RoleTag';
+
+interface LeaderboardProps {
+  events: LoopEvent[];
+}
+
+export default function Leaderboard({ events }: LeaderboardProps) {
+  const [by, setBy] = useState<'role' | 'agent'>('role');
+  const rows = useMemo(
+    () => buildLeaderboard(events as Parameters<typeof buildLeaderboard>[0], by).slice(0, 8),
+    [events, by],
+  );
+  const maxPts = Math.max(1, ...rows.map(r => r.points));
+
+  return (
+    <div className="panel">
+      <div className="panel-h">
+        <span>Leaderboard</span>
+        <span className="actions">
+          <button
+            className={`btn ${by === 'role' ? 'primary' : ''}`}
+            onClick={() => setBy('role')}
+          >
+            by role
+          </button>
+          <button
+            className={`btn ${by === 'agent' ? 'primary' : ''}`}
+            onClick={() => setBy('agent')}
+          >
+            by agent
+          </button>
+        </span>
+      </div>
+      <table className="t">
+        <thead>
+          <tr>
+            <th style={{ width: 30 }}>#</th>
+            <th>{by === 'role' ? 'Role' : 'Agent'}</th>
+            <th style={{ textAlign: 'right' }}>Verdicts</th>
+            <th style={{ textAlign: 'right' }}>Points</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r, i) => (
+            <tr key={r.key}>
+              <td className="muted mono">{String(i + 1).padStart(2, '0')}</td>
+              <td>
+                {by === 'role'
+                  ? <RoleTag role={r.key} />
+                  : <span className="mono" style={{ fontSize: 12 }}>{r.key}</span>}
+              </td>
+              <td className="num muted" style={{ textAlign: 'right' }}>{r.verdicts}</td>
+              <td style={{ textAlign: 'right', position: 'relative' }}>
+                <div style={{
+                  position: 'absolute', right: 0, top: 0, bottom: 0,
+                  width: `${(r.points / maxPts) * 100}%`,
+                  background: 'var(--accent-bg, oklch(0.82 0.18 145 / 0.08))',
+                  pointerEvents: 'none',
+                }} />
+                <span className="num" style={{ position: 'relative', color: 'var(--fg)' }}>
+                  {r.points}
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/web/src/panels/NowStrip.tsx
+++ b/web/src/panels/NowStrip.tsx
@@ -1,0 +1,97 @@
+import type { Worker, FeedItem } from '../lib/types';
+import { relTime, durationFmt, useTick } from '../lib/utils';
+import EventGlyph from '../components/EventGlyph';
+
+interface NowStripProps {
+  workers: Worker[];
+  events: FeedItem[];
+}
+
+export default function NowStrip({ workers, events }: NowStripProps) {
+  useTick(1000);
+  const lastEvent = events[0];
+  const lastTs = lastEvent ? new Date(lastEvent.created_at).getTime() : 0;
+
+  return (
+    <div className="now-strip">
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '10px 20px 6px',
+        borderBottom: '1px solid var(--border)',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span className="dot"></span>
+          <span style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 11,
+            textTransform: 'uppercase',
+            letterSpacing: '0.12em',
+            color: 'var(--fg)',
+          }}>LIVE — {workers.length} worker{workers.length !== 1 ? 's' : ''} running</span>
+        </div>
+        <div className="ticker" style={{ maxWidth: '50%' }}>
+          {lastEvent && (
+            <span className="item">
+              <EventGlyph event={lastEvent.event_type} />
+              <span className="mono">{lastEvent.event_type}</span>
+              <span className="muted">·</span>
+              <span className="muted mono">
+                {lastEvent.project}
+                {lastEvent.issue_number != null ? `#${lastEvent.issue_number}` : ''}
+              </span>
+              <span className="muted">·</span>
+              <span className="muted">{relTime(lastTs)} ago</span>
+            </span>
+          )}
+        </div>
+      </div>
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: workers.length
+          ? `repeat(${Math.min(workers.length, 5)}, 1fr)`
+          : '1fr',
+      }}>
+        {workers.length === 0 && (
+          <div style={{
+            padding: '24px 20px',
+            color: 'var(--fg-3)',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 12,
+            textAlign: 'center',
+          }}>
+            pipeline is idle — no active workers
+          </div>
+        )}
+        {workers.map((w, i) => {
+          const startedAt = new Date(w.created_at).getTime();
+          const name = w.model ?? w.role;
+          return (
+            <div
+              key={i}
+              className="worker-beat"
+              style={{ '--role-c': `var(--role-${w.role})` } as React.CSSProperties}
+            >
+              <span className="role-stripe"></span>
+              <span className="pulse"></span>
+              <div className="meta">
+                <div className="agent">
+                  <span style={{ color: `var(--role-${w.role})` }}>{w.role}</span>
+                  <span style={{ color: 'var(--fg-4)' }}> · </span>
+                  <span>{name}</span>
+                </div>
+                <div className="task">
+                  <span className="mono" style={{ color: 'var(--fg-2)' }}>{w.project}</span>
+                  <span style={{ color: 'var(--fg-4)' }}> — </span>
+                  {w.event_type}
+                </div>
+              </div>
+              <span className="timer">{durationFmt(Date.now() - startedAt)}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/src/panels/ProjectCard.tsx
+++ b/web/src/panels/ProjectCard.tsx
@@ -1,0 +1,50 @@
+import type { ProjectStatusRow } from '../lib/transforms';
+import { relTime } from '../lib/utils';
+import RoleTag from '../components/RoleTag';
+
+interface ProjectCardProps {
+  p: ProjectStatusRow;
+  onClick: () => void;
+}
+
+export default function ProjectCard({ p, onClick }: ProjectCardProps) {
+  const isBusy = p.status === 'busy';
+
+  return (
+    <div className={`proj-card ${isBusy ? 'busy' : ''}`} onClick={onClick}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span className={`status-dot ${isBusy ? 'busy' : 'idle'}`}></span>
+          <span style={{ fontWeight: 500, fontSize: 13 }}>{p.id}</span>
+        </div>
+        <span className="tag" style={{ color: isBusy ? 'var(--accent)' : 'var(--fg-4)' }}>
+          {isBusy ? 'BUSY' : 'IDLE'}
+        </span>
+      </div>
+      {isBusy && p.busyWorker ? (
+        <div style={{ fontSize: 11, color: 'var(--fg-3)' }}>
+          <RoleTag role={p.busyWorker.role} />
+          <span className="mono" style={{ marginLeft: 6 }}>
+            {p.busyWorker.model ?? p.busyWorker.role}
+          </span>
+        </div>
+      ) : (
+        <div style={{ fontSize: 11, color: 'var(--fg-3)' }}>
+          last: <span className="mono">{p.lastEvent ?? '—'}</span>
+          {' · '}
+          {p.lastTs ? relTime(p.lastTs) + ' ago' : '—'}
+        </div>
+      )}
+      <div style={{
+        display: 'flex',
+        alignItems: 'baseline',
+        justifyContent: 'space-between',
+        paddingTop: 8,
+        borderTop: '1px solid var(--border)',
+      }}>
+        <span className="num" style={{ fontSize: 20, color: 'var(--fg)' }}>{p.points}</span>
+        <span className="muted mono" style={{ fontSize: 10 }}>{p.totalEvents} ev / 24h</span>
+      </div>
+    </div>
+  );
+}

--- a/web/src/screens/Overview.tsx
+++ b/web/src/screens/Overview.tsx
@@ -1,14 +1,160 @@
+// TODO(#113): wire visual-diff once harness lands
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { fetchActive, fetchFeed, fetchHistory, fetchEventsGraph } from '../lib/api';
+import { buildProjectStatus, build24hBuckets } from '../lib/transforms';
+import type { LoopEvent } from '../lib/types';
+import NowStrip from '../panels/NowStrip';
+import Activity24h from '../panels/Activity24h';
+import ProjectCard from '../panels/ProjectCard';
+import Leaderboard from '../panels/Leaderboard';
+import ActivityFeed from '../panels/ActivityFeed';
+import EventGlyph from '../components/EventGlyph';
+import RoleTag from '../components/RoleTag';
+import { relTime, durationFmt } from '../lib/utils';
 import Charts from '../panels/Charts';
 import ClaudeUsage from '../panels/ClaudeUsage';
 
+const COMPLETED_TYPES = new Set([
+  'merge_done', 'judge_done', 'review_done', 'dev_done', 'po_done',
+]);
+
 export default function Overview() {
+  const { data: workers = [] } = useQuery({
+    queryKey: ['active'],
+    queryFn: () => fetchActive(),
+    refetchInterval: 5_000,
+    staleTime: 0,
+  });
+
+  const { data: feed = [] } = useQuery({
+    queryKey: ['feed'],
+    queryFn: () => fetchFeed(),
+    refetchInterval: 5_000,
+    staleTime: 0,
+  });
+
+  const { data: history = [] } = useQuery({
+    queryKey: ['history'],
+    queryFn: () => fetchHistory(),
+    refetchInterval: 5_000,
+    staleTime: 0,
+  });
+
+  const { data: eventsGraph } = useQuery({
+    queryKey: ['eventsGraph'],
+    queryFn: () => fetchEventsGraph(24),
+    refetchInterval: 60_000,
+    staleTime: 0,
+  });
+
+  const buckets = useMemo(() => {
+    if (eventsGraph) {
+      // Convert EventsGraph (row-per-role-per-hour) to HourBucket[]
+      const map = new Map<number, { hour: number; counts: Record<string, number>; total: number }>();
+      for (let h = 0; h < 24; h++) map.set(h, { hour: h, counts: {}, total: 0 });
+      for (const b of eventsGraph.buckets) {
+        const hourNum = new Date(b.hour).getHours();
+        const bucket = map.get(hourNum);
+        if (bucket) {
+          bucket.counts[b.role] = (bucket.counts[b.role] ?? 0) + b.count;
+          bucket.total += b.count;
+        }
+      }
+      return Array.from(map.values());
+    }
+    return build24hBuckets(history as (LoopEvent & { ts?: number })[]);
+  }, [eventsGraph, history]);
+
+  const projects = useMemo(
+    () => buildProjectStatus(
+      history as Parameters<typeof buildProjectStatus>[0],
+      workers,
+    ),
+    [history, workers],
+  );
+
+  const completed = useMemo(
+    () => history.filter(e => COMPLETED_TYPES.has(e.event_type)).slice(0, 30),
+    [history],
+  );
+
   return (
-    <div>
-      <div className="screen-h">
-        <h1>Overview</h1>
+    <>
+      <NowStrip workers={workers} events={feed} />
+      <div style={{ padding: 'var(--pad-4)', display: 'grid', gap: 'var(--pad-3)' }}>
+
+        <Activity24h buckets={buckets} />
+
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 360px', gap: 'var(--pad-3)' }}>
+          <div className="panel">
+            <div className="panel-h">
+              <span>Project status · {projects.length}</span>
+              <span className="muted">
+                {projects.filter(p => p.status === 'busy').length} busy
+              </span>
+            </div>
+            <div style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))',
+              gap: 1,
+              background: 'var(--border)',
+            }}>
+              {projects.map(p => (
+                <ProjectCard key={p.id} p={p} onClick={() => undefined} />
+              ))}
+            </div>
+          </div>
+          <Leaderboard events={history} />
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--pad-3)' }}>
+          <ActivityFeed events={feed} />
+          <div className="panel">
+            <div className="panel-h"><span>Completed jobs · last 30</span></div>
+            <div style={{ overflow: 'auto', maxHeight: 480 }}>
+              {completed.map(e => {
+                const ts = new Date(e.created_at).getTime();
+                const durMs = (e.duration_seconds ?? 0) * 1000;
+                return (
+                  <div key={e.id} className="feed-row">
+                    <EventGlyph event={e.event_type} />
+                    <div>
+                      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                        <span
+                          className="mono"
+                          style={{ color: `var(--role-${e.role})`, fontWeight: 500 }}
+                        >
+                          {e.project}
+                        </span>
+                        <RoleTag role={e.role} />
+                        <span className="muted mono" style={{ fontSize: 11 }}>{e.model}</span>
+                      </div>
+                      <div className="muted mono" style={{ fontSize: 11, marginTop: 2 }}>
+                        {e.event_type}
+                        {e.issue_number != null ? ` · #${e.issue_number}` : ''}
+                        {durMs > 0 ? ` · ${durationFmt(durMs)}` : ''}
+                      </div>
+                    </div>
+                    <div style={{ textAlign: 'right' }}>
+                      {(e.points ?? 0) > 0 && (
+                        <div className="mono" style={{ color: 'var(--accent)', fontSize: 12 }}>
+                          +{e.points}
+                        </div>
+                      )}
+                      <div className="muted mono" style={{ fontSize: 10 }}>{relTime(ts)}</div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        <ClaudeUsage />
+        <Charts />
+
       </div>
-      <ClaudeUsage />
-      <Charts />
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
Closes #116

## Changes

Extends the stub `web/src/screens/Overview.tsx` with the five panels from the frozen prototype (`design/new-design/screens.jsx :: OverviewScreen`). The existing `ClaudeUsage` and `Charts` panels (added in #121) are kept mounted below the prototype panels.

**New files:**
- `web/src/panels/NowStrip.tsx` — hero worker strip with live timer and last-event ticker
- `web/src/panels/Activity24h.tsx` — stacked hourly bar chart, role-coloured
- `web/src/panels/ProjectCard.tsx` — project tile showing busy/idle status, points, last event
- `web/src/panels/Leaderboard.tsx` — rank table toggleable by role / by agent
- `web/src/panels/ActivityFeed.tsx` — filterable rolling event list
- `web/src/components/RoleTag.tsx` — role chip shared component
- `web/src/components/EventGlyph.tsx` — event symbol shared component
- `web/src/lib/utils.ts` — `relTime`, `durationFmt`, `useTick` time helpers

**Modified:**
- `web/src/screens/Overview.tsx` — extended to compose all five prototype panels + CompletedJobs inline panel + existing ClaudeUsage + Charts below

**Design compliance:**
- JSX structure and CSS class names match `design/new-design/screens.jsx :: OverviewScreen` and `design/new-design/panels.jsx` exactly
- All panels receive data as props; no `fetch()` calls inside panels
- Data fetched in the screen via `useQuery` (5s refetch for hot endpoints, 60s for events graph)
- Styling uses CSS custom properties from `tokens.css`; no raw hex/oklch literals in panel files
- `TODO(#113)` comment added for visual-diff wiring once harness lands

**No changes to:** `App.tsx`, `router.tsx`, `NavRail.tsx`, `Queue.tsx`, `ProjectDetail.tsx`, `ClaudeUsage.tsx`, `Charts.tsx`, `ScannerState.tsx`, `server/`, `static/`

## Test Plan
- [ ] `ruff check .` passes ✓
- [ ] `cd web && npm run typecheck` passes ✓
- [ ] `cd web && npm run build` succeeds ✓
- [ ] Navigate to `/` — Overview renders: live workers strip, 24h bar chart, project grid, leaderboard, activity feed, completed jobs, Claude usage, charts
- [ ] Fixture mode: `/?fixtures=1` — deterministic render for visual comparison
- [ ] Human eyeball: compare rendered output to `design/reference-screenshots/overview.png`