### PR TITLE
[LM-163] Fix project slug mappings

### DIFF
--- a/server/constants.py
+++ b/server/constants.py
@@ -7,11 +7,13 @@ MONITOR_VERSION = _version_file.read_text().strip() if _version_file.exists() el
 PROJECTS = {
     'ppl':               'svv2014/ppl-study',
     'boba-event':        'svv2014/boba-event',
-    'loop':             'svv2014/loop',
-    'bounty':            'svv2014/loop-monitor',
+    'loop':              'svv2014/loop',
+    'loop-monitor':      'svv2014/loop-monitor',
     'vrefm-classifier':  'svv2014/vrefm-classifier',
     'pa-scanner':        'svv2014/pa-scanner',
     'ntc':               'svv2014/NanoTraderCopilot',
+    'boba-orchestrator': 'svv2014/boba-orchestrator',
+    'suprun':            'svv2014/suprun.ca',
 }
 
 HANDLER_TIMEOUT = 30

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,22 @@
+import re
+
+from server.constants import PROJECTS
+
+
+def test_projects_include_loop_emitted_slugs():
+    assert "boba-orchestrator" in PROJECTS
+    assert "loop-monitor" in PROJECTS
+    assert "suprun" in PROJECTS
+
+
+def test_projects_drop_legacy_bounty_alias():
+    assert "bounty" not in PROJECTS
+
+
+def test_projects_values_use_owner_repo_shape():
+    owner_repo = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+    assert all(owner_repo.match(repo) for repo in PROJECTS.values())
+
+
+def test_loop_monitor_slug_maps_to_loop_monitor_repo():
+    assert PROJECTS["loop-monitor"] == "svv2014/loop-monitor"


### PR DESCRIPTION
Closes #163

## Summary
- replace the legacy `bounty` project alias with the emitted `loop-monitor` slug
- add missing `boba-orchestrator` and `suprun` project mappings
- add constants coverage for required slugs, legacy alias removal, owner/repo shape, and the `loop-monitor` mapping

## Manual smoke notes
- `GET /api/projects` should include `loop-monitor`, `boba-orchestrator`, and `suprun`
- `GET /api/action_queue` should now return non-null GitHub URLs for items from those project slugs

## Tests
- Not run (not requested).
