### PR TITLE
[LM-163] fix PROJECTS map — add missing slugs, drop bounty alias

### DIFF
--- a/server/constants.py
+++ b/server/constants.py
@@ -7,11 +7,13 @@ MONITOR_VERSION = _version_file.read_text().strip() if _version_file.exists() el
 PROJECTS = {
     'ppl':               'svv2014/ppl-study',
     'boba-event':        'svv2014/boba-event',
-    'loop':             'svv2014/loop',
-    'bounty':            'svv2014/loop-monitor',
+    'loop':              'svv2014/loop',
+    'loop-monitor':      'svv2014/loop-monitor',     # was 'bounty'
     'vrefm-classifier':  'svv2014/vrefm-classifier',
     'pa-scanner':        'svv2014/pa-scanner',
     'ntc':               'svv2014/NanoTraderCopilot',
+    'boba-orchestrator': 'svv2014/boba-orchestrator',
+    'suprun':            'svv2014/suprun.ca',
 }
 
 HANDLER_TIMEOUT = 30

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,22 @@
+import re
+
+from server.constants import PROJECTS
+
+
+def test_new_slugs_present():
+    for slug in ('loop-monitor', 'boba-orchestrator', 'suprun'):
+        assert slug in PROJECTS, f"missing slug: {slug}"
+
+
+def test_bounty_key_absent():
+    assert 'bounty' not in PROJECTS
+
+
+def test_all_values_owner_repo_shape():
+    pattern = re.compile(r'^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$')
+    for slug, repo in PROJECTS.items():
+        assert pattern.match(repo), f"{slug!r} value {repo!r} is not owner/repo"
+
+
+def test_loop_monitor_maps_correctly():
+    assert PROJECTS['loop-monitor'] == 'svv2014/loop-monitor'


### PR DESCRIPTION
Closes #163

## Changes

- **`server/constants.py`**: Replaced `'bounty'` key with `'loop-monitor'` (loop emits this slug, not `bounty`); added `'boba-orchestrator' → 'svv2014/boba-orchestrator'` and `'suprun' → 'svv2014/suprun.ca'`. All existing entries (`ppl`, `boba-event`, `loop`, `vrefm-classifier`, `pa-scanner`, `ntc`) untouched.
- **`tests/test_constants.py`** (new): Asserts the three previously-missing slugs are present, `bounty` key is absent, every value matches `^owner/repo$` shape, and `loop-monitor` maps to `svv2014/loop-monitor`.

## Test Plan

- `ruff check .` — passes
- `pytest tests/test_constants.py -v` — 4 tests pass
- `pytest tests/` — pre-existing failures in visual/Playwright tests and `test_graph` are unrelated; all other tests pass
- Manual smoke: `curl localhost:8000/api/projects` will include `loop-monitor`, `boba-orchestrator`, `suprun`; `curl localhost:8000/api/action_queue` will return non-null `github_url` for items in those projects