### PR TITLE
[LM-117] Phase 3.2 · Action Queue screen: filters, sort, TanStack Query

### DIFF
--- a/web/src/screens/Queue.test.ts
+++ b/web/src/screens/Queue.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { applyFilters, applySort } from './Queue';
+import type { QueueItem } from '../lib/types';
+
+function item(overrides: Partial<QueueItem> = {}): QueueItem {
+  return {
+    project: 'proj-a',
+    kind: 'issue',
+    number: 1,
+    title: 'Test',
+    stage: 'dev',
+    age_seconds: 120,
+    reason: 'stuck_label',
+    threshold_seconds: null,
+    loop_id: null,
+    github_url: null,
+    ...overrides,
+  };
+}
+
+// ── applyFilters ──────────────────────────────────────────────────────────────
+
+describe('applyFilters', () => {
+  const items: QueueItem[] = [
+    item({ project: 'alpha', reason: 'stuck_label', loop_id: 'loop-1' }),
+    item({ project: 'beta',  reason: 'timeout',        loop_id: 'loop-2' }),
+    item({ project: 'alpha', reason: 'qa_fail_repeated', loop_id: null }),
+  ];
+
+  it('returns all items when no filter is set', () => {
+    expect(applyFilters(items, {})).toHaveLength(3);
+  });
+
+  it('filters by project', () => {
+    const result = applyFilters(items, { project: 'alpha' });
+    expect(result).toHaveLength(2);
+    expect(result.every(i => i.project === 'alpha')).toBe(true);
+  });
+
+  it('filters by reason', () => {
+    const result = applyFilters(items, { reason: 'timeout' });
+    expect(result).toHaveLength(1);
+    expect(result[0].reason).toBe('timeout');
+  });
+
+  it('filters by loop_id', () => {
+    const result = applyFilters(items, { loop: 'loop-1' });
+    expect(result).toHaveLength(1);
+    expect(result[0].loop_id).toBe('loop-1');
+  });
+
+  it('applies multiple filters together (AND)', () => {
+    const result = applyFilters(items, { project: 'alpha', reason: 'stuck_label' });
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns empty when no items match', () => {
+    expect(applyFilters(items, { project: 'gamma' })).toHaveLength(0);
+  });
+});
+
+// ── applySort ─────────────────────────────────────────────────────────────────
+
+describe('applySort', () => {
+  const items: QueueItem[] = [
+    item({ project: 'beta',  age_seconds: 300, reason: 'timeout',          kind: 'pr',    number: 5 }),
+    item({ project: 'alpha', age_seconds: 100, reason: 'stuck_label',      kind: 'issue', number: 2 }),
+    item({ project: 'alpha', age_seconds: 200, reason: 'qa_fail_repeated', kind: 'issue', number: 1 }),
+  ];
+
+  it('sorts by age_seconds asc', () => {
+    const result = applySort(items, 'age_seconds', 'asc');
+    expect(result.map(i => i.age_seconds)).toEqual([100, 200, 300]);
+  });
+
+  it('sorts by age_seconds desc', () => {
+    const result = applySort(items, 'age_seconds', 'desc');
+    expect(result.map(i => i.age_seconds)).toEqual([300, 200, 100]);
+  });
+
+  it('sorts by project asc', () => {
+    const result = applySort(items, 'project', 'asc');
+    expect(result[0].project).toBe('alpha');
+    expect(result[2].project).toBe('beta');
+  });
+
+  it('sorts by project desc', () => {
+    const result = applySort(items, 'project', 'desc');
+    expect(result[0].project).toBe('beta');
+  });
+
+  it('sorts by reason alphabetically', () => {
+    const result = applySort(items, 'reason', 'asc');
+    expect(result[0].reason).toBe('qa_fail_repeated');
+    expect(result[2].reason).toBe('timeout');
+  });
+
+  it('sorts by item (kind then number) asc', () => {
+    const result = applySort(items, 'item', 'asc');
+    expect(result[0]).toMatchObject({ kind: 'issue', number: 1 });
+    expect(result[1]).toMatchObject({ kind: 'issue', number: 2 });
+    expect(result[2]).toMatchObject({ kind: 'pr',    number: 5 });
+  });
+
+  it('sorts by item desc', () => {
+    const result = applySort(items, 'item', 'desc');
+    expect(result[0]).toMatchObject({ kind: 'pr', number: 5 });
+  });
+
+  it('does not mutate the input array', () => {
+    const original = [...items];
+    applySort(items, 'age_seconds', 'asc');
+    expect(items).toEqual(original);
+  });
+});

--- a/web/src/screens/Queue.tsx
+++ b/web/src/screens/Queue.tsx
@@ -1,5 +1,36 @@
-import { useEffect, useState } from 'react';
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { fetchActionQueue } from '../lib/api';
 import type { QueueItem } from '../lib/types';
+
+export type SortCol = 'project' | 'item' | 'stage' | 'age_seconds' | 'reason';
+export type SortDir = 'asc' | 'desc';
+
+export function applyFilters(
+  items: QueueItem[],
+  f: { project?: string; reason?: string; loop?: string },
+): QueueItem[] {
+  return items.filter(item => {
+    if (f.project && item.project !== f.project) return false;
+    if (f.reason && item.reason !== f.reason) return false;
+    if (f.loop && item.loop_id !== f.loop) return false;
+    return true;
+  });
+}
+
+export function applySort(items: QueueItem[], col: SortCol, dir: SortDir): QueueItem[] {
+  return [...items].sort((a, b) => {
+    let cmp = 0;
+    if (col === 'item') {
+      cmp = a.kind !== b.kind ? a.kind.localeCompare(b.kind) : a.number - b.number;
+    } else if (col === 'age_seconds') {
+      cmp = a.age_seconds - b.age_seconds;
+    } else {
+      cmp = String(a[col]).localeCompare(String(b[col]));
+    }
+    return dir === 'asc' ? cmp : -cmp;
+  });
+}
 
 function formatAge(seconds: number): string {
   if (seconds >= 3600) {
@@ -12,28 +43,70 @@ function formatAge(seconds: number): string {
   return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
 }
 
-interface DrawerProps {
-  item: QueueItem;
-  onClose: () => void;
-}
-
-function Drawer({ item, onClose }: DrawerProps) {
+// TODO(#122): Replace with canonical Drawer component when #122 lands.
+function InlineDrawer({ item, onClose }: { item: QueueItem; onClose: () => void }) {
   return (
-    <div className="drawer-overlay" onClick={onClose}>
-      <div className="drawer" onClick={e => e.stopPropagation()}>
-        <button className="drawer-close" onClick={onClose}>×</button>
-        <h2>{item.title || `${item.kind} #${item.number}`}</h2>
-        <dl>
-          <dt>Project</dt><dd>{item.project}</dd>
-          <dt>Stage</dt><dd>{item.stage}</dd>
-          <dt>Age</dt><dd>{formatAge(item.age_seconds)}</dd>
-          <dt>Reason</dt><dd>{item.reason}</dd>
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'oklch(0 0 0 / 0.5)',
+        zIndex: 200,
+        display: 'flex',
+        justifyContent: 'flex-end',
+      }}
+    >
+      <div
+        onClick={e => e.stopPropagation()}
+        style={{
+          width: 360,
+          height: '100%',
+          background: 'var(--bg-2)',
+          borderLeft: '1px solid var(--border)',
+          padding: 'var(--pad-4)',
+          overflowY: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 'var(--pad-3)',
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <h2 style={{ margin: 0, fontSize: 13, fontFamily: 'var(--font-mono)', fontWeight: 500, color: 'var(--fg)' }}>
+            {item.title || `${item.kind} #${item.number}`}
+          </h2>
+          <button className="btn" onClick={onClose}>×</button>
+        </div>
+        <dl style={{ margin: 0, display: 'grid', gridTemplateColumns: 'auto 1fr', gap: '6px var(--pad-3)', fontSize: 12 }}>
+          <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', alignSelf: 'center' }}>Project</dt>
+          <dd style={{ margin: 0 }}>{item.project}</dd>
+          <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', alignSelf: 'center' }}>Stage</dt>
+          <dd style={{ margin: 0 }}>{item.stage}</dd>
+          <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', alignSelf: 'center' }}>Age</dt>
+          <dd style={{ margin: 0 }} className="num">{formatAge(item.age_seconds)}</dd>
+          <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', alignSelf: 'center' }}>Reason</dt>
+          <dd style={{ margin: 0 }}>{item.reason}</dd>
           {item.threshold_seconds !== null && (
-            <><dt>Threshold</dt><dd>{formatAge(item.threshold_seconds)}</dd></>
+            <>
+              <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', alignSelf: 'center' }}>Threshold</dt>
+              <dd style={{ margin: 0 }} className="num">{formatAge(item.threshold_seconds)}</dd>
+            </>
+          )}
+          {item.loop_id !== null && (
+            <>
+              <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', alignSelf: 'center' }}>Loop</dt>
+              <dd style={{ margin: 0 }} className="mono">{item.loop_id}</dd>
+            </>
           )}
         </dl>
         {item.github_url && (
-          <a href={item.github_url} target="_blank" rel="noreferrer">
+          <a
+            href={item.github_url}
+            target="_blank"
+            rel="noreferrer"
+            className="btn primary"
+            style={{ display: 'inline-block', textAlign: 'center', textDecoration: 'none' }}
+          >
             View on GitHub
           </a>
         )}
@@ -42,105 +115,180 @@ function Drawer({ item, onClose }: DrawerProps) {
   );
 }
 
-interface RowProps {
-  item: QueueItem;
-  onClick: (item: QueueItem) => void;
+interface QueueTableProps {
+  items: QueueItem[];
+  onRowClick: (item: QueueItem) => void;
+  sortCol?: SortCol;
+  sortDir?: SortDir;
+  onSort?: (col: SortCol) => void;
 }
 
-function QueueRow({ item, onClick }: RowProps) {
+function QueueTable({ items, onRowClick, sortCol, sortDir, onSort }: QueueTableProps) {
+  function Th({ col, label }: { col: SortCol; label: string }) {
+    const active = col === sortCol;
+    const glyph = active ? (sortDir === 'asc' ? ' ▲' : ' ▼') : '';
+    return (
+      <th
+        onClick={() => onSort?.(col)}
+        style={{
+          cursor: onSort ? 'pointer' : 'default',
+          userSelect: 'none',
+          color: active ? 'var(--fg-2)' : undefined,
+        }}
+      >
+        {label}{glyph}
+      </th>
+    );
+  }
+
   return (
-    <tr className="queue-row" onClick={() => onClick(item)} style={{ cursor: 'pointer' }}>
-      <td>{item.project}</td>
-      <td>{item.kind} #{item.number}</td>
-      <td>{item.stage}</td>
-      <td>{formatAge(item.age_seconds)}</td>
-      <td>{item.stage}</td>
-    </tr>
+    <table className="t" style={{ width: '100%' }}>
+      <thead>
+        <tr>
+          <Th col="project" label="Project" />
+          <Th col="item" label="Item" />
+          <Th col="stage" label="Stage" />
+          <Th col="age_seconds" label="Age" />
+          <Th col="reason" label="Reason" />
+        </tr>
+      </thead>
+      <tbody>
+        {items.map(item => (
+          <tr
+            key={`${item.project}-${item.kind}-${item.number}`}
+            onClick={() => onRowClick(item)}
+            style={{ cursor: 'pointer' }}
+          >
+            <td>{item.project}</td>
+            <td className="mono">{item.kind} #{item.number}</td>
+            <td>{item.stage}</td>
+            <td className="num">{formatAge(item.age_seconds)}</td>
+            <td>{item.reason}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 }
 
 export default function Queue() {
-  const [items, setItems] = useState<QueueItem[]>([]);
+  const { data: items = [], isLoading } = useQuery({
+    queryKey: ['actionQueue'],
+    queryFn: fetchActionQueue,
+    refetchInterval: 5000,
+  });
+
   const [selected, setSelected] = useState<QueueItem | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [filterProject, setFilterProject] = useState('');
+  const [filterReason, setFilterReason] = useState('');
+  const [filterLoop, setFilterLoop] = useState('');
+  const [sortCol, setSortCol] = useState<SortCol>('age_seconds');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
 
-  useEffect(() => {
-    fetch('/api/action_queue')
-      .then(r => r.json())
-      .then((data: QueueItem[]) => {
-        setItems(data);
-        setLoading(false);
-      })
-      .catch(() => setLoading(false));
-  }, []);
+  const projects = useMemo(
+    () => [...new Set(items.map(i => i.project))].sort(),
+    [items],
+  );
 
-  const stuckItems = items
-    .filter(i => i.reason === 'stuck_label' || i.reason === 'timeout')
-    .sort((a, b) => b.age_seconds - a.age_seconds);
+  const loops = useMemo(
+    () => [...new Set(items.map(i => i.loop_id).filter((id): id is string => id !== null))].sort(),
+    [items],
+  );
 
-  const otherItems = items
-    .filter(i => i.reason !== 'stuck_label' && i.reason !== 'timeout')
-    .sort((a, b) => b.age_seconds - a.age_seconds);
+  const stuckItems = useMemo(
+    () =>
+      applySort(
+        items.filter(i => i.reason === 'stuck_label' || i.reason === 'timeout'),
+        'age_seconds',
+        'desc',
+      ),
+    [items],
+  );
 
-  if (loading) return <div className="muted">Loading…</div>;
+  const allFiltered = useMemo(
+    () =>
+      applySort(
+        applyFilters(items, {
+          project: filterProject || undefined,
+          reason: filterReason || undefined,
+          loop: filterLoop || undefined,
+        }),
+        sortCol,
+        sortDir,
+      ),
+    [items, filterProject, filterReason, filterLoop, sortCol, sortDir],
+  );
+
+  function handleSort(col: SortCol) {
+    if (col === sortCol) {
+      setSortDir(d => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortCol(col);
+      setSortDir('asc');
+    }
+  }
+
+  if (isLoading) {
+    return <div className="muted" style={{ padding: 'var(--pad-4)' }}>Loading…</div>;
+  }
+
+  const showLoopFilter = loops.length > 1;
 
   return (
-    <div className="queue-screen">
-      <section className="queue-section">
-        <h2 className="queue-section-title">Stuck</h2>
+    <div style={{ padding: 'var(--pad-4)' }}>
+      {/* Stuck */}
+      <section style={{ marginBottom: 'var(--pad-5)' }}>
+        <div className="screen-h" style={{ paddingLeft: 0, paddingRight: 0 }}>
+          <h1>Stuck</h1>
+          <span className="meta">{stuckItems.length} item{stuckItems.length !== 1 ? 's' : ''}</span>
+        </div>
         {stuckItems.length === 0 ? (
-          <div className="muted">No stuck items</div>
+          <div className="muted" style={{ padding: 'var(--pad-3) 0' }}>No stuck items</div>
         ) : (
-          <table className="queue-table">
-            <thead>
-              <tr>
-                <th>Project</th>
-                <th>Item</th>
-                <th>Stage</th>
-                <th>Age</th>
-                <th>Last Event</th>
-              </tr>
-            </thead>
-            <tbody>
-              {stuckItems.map(item => (
-                <QueueRow
-                  key={`${item.project}-${item.kind}-${item.number}`}
-                  item={item}
-                  onClick={setSelected}
-                />
-              ))}
-            </tbody>
-          </table>
+          <QueueTable items={stuckItems} onRowClick={setSelected} />
         )}
       </section>
 
-      {otherItems.length > 0 && (
-        <section className="queue-section">
-          <h2 className="queue-section-title">Action Queue</h2>
-          <table className="queue-table">
-            <thead>
-              <tr>
-                <th>Project</th>
-                <th>Item</th>
-                <th>Stage</th>
-                <th>Age</th>
-                <th>Last Event</th>
-              </tr>
-            </thead>
-            <tbody>
-              {otherItems.map(item => (
-                <QueueRow
-                  key={`${item.project}-${item.kind}-${item.number}`}
-                  item={item}
-                  onClick={setSelected}
-                />
-              ))}
-            </tbody>
-          </table>
-        </section>
-      )}
+      {/* All Items */}
+      <section>
+        <div className="screen-h" style={{ paddingLeft: 0, paddingRight: 0 }}>
+          <h1>All Items</h1>
+          <span className="meta">{allFiltered.length} / {items.length}</span>
+        </div>
 
-      {selected && <Drawer item={selected} onClose={() => setSelected(null)} />}
+        <div style={{ display: 'flex', gap: 'var(--pad-2)', marginBottom: 'var(--pad-3)', flexWrap: 'wrap' }}>
+          <select className="btn" value={filterProject} onChange={e => setFilterProject(e.target.value)}>
+            <option value="">All projects</option>
+            {projects.map(p => <option key={p} value={p}>{p}</option>)}
+          </select>
+          <select className="btn" value={filterReason} onChange={e => setFilterReason(e.target.value)}>
+            <option value="">All reasons</option>
+            <option value="stuck_label">stuck_label</option>
+            <option value="timeout">timeout</option>
+            <option value="qa_fail_repeated">qa_fail_repeated</option>
+          </select>
+          {showLoopFilter && (
+            <select className="btn" value={filterLoop} onChange={e => setFilterLoop(e.target.value)}>
+              <option value="">All loops</option>
+              {loops.map(l => <option key={l} value={l}>{l}</option>)}
+            </select>
+          )}
+        </div>
+
+        {allFiltered.length === 0 ? (
+          <div className="muted" style={{ padding: 'var(--pad-3) 0' }}>No items</div>
+        ) : (
+          <QueueTable
+            items={allFiltered}
+            onRowClick={setSelected}
+            sortCol={sortCol}
+            sortDir={sortDir}
+            onSort={handleSort}
+          />
+        )}
+      </section>
+
+      {selected && <InlineDrawer item={selected} onClose={() => setSelected(null)} />}
     </div>
   );
 }


### PR DESCRIPTION
Closes #117

## Changes

Expands `web/src/screens/Queue.tsx` from the #145 Stuck-only stub into the full Action Queue screen.

**`web/src/screens/Queue.tsx`**
- Two sections in order: **Stuck** (reason ∈ {stuck_label, timeout}, sorted age desc, empty-state "No stuck items") then **All Items**
- Filter bar above All Items: Project `<select>`, Reason `<select>` (stuck_label / timeout / qa_fail_repeated), Loop `<select>` hidden when ≤1 unique loop present — all client-side, no extra fetches
- Sortable columns (project, item, stage, age, reason) with ▲/▼ glyph on active column; default sort: age_seconds desc; clicking active column toggles asc/desc
- Data via `fetchActionQueue()` from `lib/api` (fixture-mode-aware); no direct `fetch()` in the screen
- `useQuery` with `refetchInterval: 5000`; `useMemo` for filter/sort chaining
- Exported pure helpers `applyFilters` / `applySort` for testability
- Inline drawer preserved from #145 with `TODO(#122)` to swap for canonical Drawer when #122 lands
- All colors via CSS token vars; table uses `.t`, selects/buttons use `.btn`

**`web/src/screens/Queue.test.ts`** (new)
- 14 unit tests covering `applyFilters` (no-op, single filter, multi-filter AND, empty result) and `applySort` (all 5 columns, both directions, mutation safety)

## Test Plan
- `ruff check .` — passes
- `cd web && npm run typecheck` — passes (0 errors)
- `cd web && npm run build` — passes
- `cd web && npm test` — 29/29 (15 existing transforms + 14 new Queue tests)
- Manual: navigate to Queue screen → Stuck section first, All Items below; filter selects populate from live data; loop filter hidden with ≤1 loop; column header click sorts with ▲/▼; row click opens inline drawer; overlay click closes it