### PR TITLE
fix(v2): /v2 asset base + Activity24h relative-hour bucketing

### DIFF
--- a/web/src/screens/Overview.tsx
+++ b/web/src/screens/Overview.tsx
@@ -50,18 +50,23 @@ export default function Overview() {
 
   const buckets = useMemo(() => {
     if (eventsGraph) {
-      // Convert EventsGraph (row-per-role-per-hour) to HourBucket[]
-      const map = new Map<number, { hour: number; counts: Record<string, number>; total: number }>();
-      for (let h = 0; h < 24; h++) map.set(h, { hour: h, counts: {}, total: 0 });
+      // Bucket by relative hour from now (slot 23 = current hour, slot 0 = 23h ago).
+      // `b.hour` from /api/events_graph is a UTC ISO string with no Z suffix; append Z so JS parses as UTC.
+      const buckets = Array.from({ length: 24 }, (_, i) => ({
+        hour: i,
+        counts: {} as Record<string, number>,
+        total: 0,
+      }));
+      const now = Date.now();
       for (const b of eventsGraph.buckets) {
-        const hourNum = new Date(b.hour).getHours();
-        const bucket = map.get(hourNum);
-        if (bucket) {
-          bucket.counts[b.role] = (bucket.counts[b.role] ?? 0) + b.count;
-          bucket.total += b.count;
-        }
+        const ts = new Date(b.hour + 'Z').getTime();
+        const hoursAgo = Math.floor((now - ts) / (60 * 60 * 1000));
+        if (hoursAgo < 0 || hoursAgo >= 24) continue;
+        const idx = 23 - hoursAgo;
+        buckets[idx].counts[b.role] = (buckets[idx].counts[b.role] ?? 0) + b.count;
+        buckets[idx].total += b.count;
       }
-      return Array.from(map.values());
+      return buckets;
     }
     return build24hBuckets(history as (LoopEvent & { ts?: number })[]);
   }, [eventsGraph, history]);

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  base: '/v2/',
   build: {
     outDir: '../static/dist',
     emptyOutDir: true,


### PR DESCRIPTION
## Summary

Two bug fixes for the React UI at \`/v2/\`:

- **Blank page on /v2/** — \`web/vite.config.ts\` had no \`base\` configured, so the build emitted asset URLs as \`/assets/index-*.js\`. Since the app is mounted at \`/v2/\` (server/app.py), the browser requested \`/assets/...\` and got 404. Setting \`base: '/v2/'\` fixes the absolute URLs to \`/v2/assets/...\`.

- **Activity24h showed stale-looking data** — \`screens/Overview.tsx\` converted \`/api/events_graph\` rows via \`new Date(b.hour).getHours()\`. The server returns \`b.hour\` as a UTC ISO string with no \`Z\` suffix, so JS parsed it as local time (off by the local TZ offset). Compounded with bucketing by hour-of-day (0..23), events from yesterday and today at the same UTC hour collapsed into one bucket, hiding new activity.

  Switched to relative-hour bucketing matching \`build24hBuckets\` in \`lib/transforms.ts\`: parse \`b.hour\` with explicit \`Z\`, compute \`hoursAgo\` from \`Date.now()\`, index slot \`23 - hoursAgo\` (slot 23 = current hour, slot 0 = 23h ago).

## Test plan

- [x] \`npm run typecheck\` passes
- [x] \`npm run build\` succeeds
- [x] \`/v2/\` index.html now references \`/v2/assets/index-*.js\` and the bundle loads (verified via curl)
- [ ] Hard-refresh \`http://localhost:18792/v2/\` — Activity24h shows newest events on the right
- [ ] Compare with \`/\` (legacy) — counts should be in the same ballpark for overlapping window

🤖 Generated with [Claude Code](https://claude.com/claude-code)