### PR TITLE
[LM-134] Phase 6.1 · Health panel (scanner / orchestrator / event-queue heartbeat)

### DIFF
--- a/server/routes/health.py
+++ b/server/routes/health.py
@@ -2,9 +2,9 @@ import os
 import subprocess
 import threading
 import time
-import urllib.request
 import urllib.error
-from datetime import datetime, timezone
+import urllib.request
+from datetime import datetime
 from pathlib import Path
 
 from fastapi import APIRouter

--- a/server/routes/health.py
+++ b/server/routes/health.py
@@ -1,4 +1,10 @@
+import os
 import subprocess
+import threading
+import time
+import urllib.request
+import urllib.error
+from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import APIRouter
@@ -7,6 +13,9 @@ from server.constants import MONITOR_VERSION, SUPPORTED_API_MAJOR
 from server.db import get_db
 
 router = APIRouter()
+
+_PIPELINE_CACHE: dict = {"ts": 0.0, "payload": None}
+_PIPELINE_LOCK = threading.Lock()
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -70,3 +79,99 @@ def get_loops():
         entry["core_versions"] = sorted(set(v for v in raw.split(",") if v)) if raw else []
         result.append(entry)
     return result
+
+
+def _compute_status(last_tick_iso, interval_seconds) -> str:
+    if last_tick_iso is None or interval_seconds is None or interval_seconds <= 0:
+        return "down"
+    try:
+        last_tick = datetime.fromisoformat(last_tick_iso.replace("Z", "+00:00"))
+        age = time.time() - last_tick.timestamp()
+    except (ValueError, AttributeError):
+        return "down"
+    if age > 4 * interval_seconds:
+        return "down"
+    if age > 2 * interval_seconds:
+        return "stale"
+    return "ok"
+
+
+def _probe_loop_status() -> dict:
+    result = {"scanner": None, "orchestrator": None}
+    try:
+        proc = subprocess.run(
+            ["loop", "status", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if proc.returncode != 0:
+            err = (proc.stderr or "")[:200]
+            down = {"status": "down", "last_tick_iso": None, "interval_seconds": None, "detail": err or "non-zero exit"}
+            return {"scanner": down, "orchestrator": down}
+        import json as _json
+        data = _json.loads(proc.stdout)
+        for key in ("scanner", "orchestrator"):
+            sub = data.get(key, {})
+            last_tick = sub.get("last_tick_iso")
+            interval = sub.get("interval_seconds")
+            status = _compute_status(last_tick, interval)
+            result[key] = {
+                "status": status,
+                "last_tick_iso": last_tick,
+                "interval_seconds": interval,
+                "detail": sub.get("detail", ""),
+            }
+    except FileNotFoundError:
+        down = {"status": "down", "last_tick_iso": None, "interval_seconds": None, "detail": "loop binary not found"}
+        result["scanner"] = down
+        result["orchestrator"] = down
+    except subprocess.TimeoutExpired:
+        down = {"status": "down", "last_tick_iso": None, "interval_seconds": None, "detail": "loop status timed out"}
+        result["scanner"] = down
+        result["orchestrator"] = down
+    except Exception as exc:
+        down = {"status": "down", "last_tick_iso": None, "interval_seconds": None, "detail": str(exc)[:200]}
+        result["scanner"] = down
+        result["orchestrator"] = down
+    return result
+
+
+def _probe_event_queue() -> dict:
+    url = os.getenv("EVENT_QUEUE_URL", "http://localhost:8765") + "/health"
+    try:
+        with urllib.request.urlopen(url, timeout=2) as resp:
+            if resp.status != 200:
+                return {"status": "down", "last_tick_iso": None, "interval_seconds": None,
+                        "detail": f"HTTP {resp.status}"}
+            import json as _json
+            body = _json.loads(resp.read().decode())
+            depth = body.get("queue_depth") or body.get("depth")
+            detail = f"queue depth: {depth}" if depth is not None else "healthy"
+            return {"status": "ok", "last_tick_iso": None, "interval_seconds": None, "detail": detail}
+    except urllib.error.URLError as exc:
+        return {"status": "down", "last_tick_iso": None, "interval_seconds": None, "detail": str(exc.reason)[:200]}
+    except Exception as exc:
+        return {"status": "down", "last_tick_iso": None, "interval_seconds": None, "detail": str(exc)[:200]}
+
+
+def _build_pipeline_payload() -> dict:
+    loop_data = _probe_loop_status()
+    eq_data = _probe_event_queue()
+    return {
+        "scanner": loop_data["scanner"],
+        "orchestrator": loop_data["orchestrator"],
+        "event_queue": eq_data,
+    }
+
+
+@router.get("/api/health/pipeline")
+def pipeline_health():
+    with _PIPELINE_LOCK:
+        now = time.monotonic()
+        if _PIPELINE_CACHE["payload"] is not None and (now - _PIPELINE_CACHE["ts"]) < 30:
+            return _PIPELINE_CACHE["payload"]
+        payload = _build_pipeline_payload()
+        _PIPELINE_CACHE["ts"] = now
+        _PIPELINE_CACHE["payload"] = payload
+        return payload

--- a/tests/test_pipeline_health.py
+++ b/tests/test_pipeline_health.py
@@ -1,6 +1,4 @@
 import json
-import urllib.error
-import urllib.request
 from unittest.mock import MagicMock
 
 import server.routes.health as health_module

--- a/tests/test_pipeline_health.py
+++ b/tests/test_pipeline_health.py
@@ -1,0 +1,111 @@
+import json
+import urllib.error
+import urllib.request
+from unittest.mock import MagicMock
+
+import server.routes.health as health_module
+
+
+def _reset_cache():
+    health_module._PIPELINE_CACHE["ts"] = 0.0
+    health_module._PIPELINE_CACHE["payload"] = None
+
+
+def test_pipeline_health_returns_three_keys(isolated_client, monkeypatch):
+    _reset_cache()
+
+    def fake_run(cmd, **kwargs):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = json.dumps({
+            "scanner": {"last_tick_iso": "2026-01-01T00:00:00+00:00", "interval_seconds": 60, "detail": "ok"},
+            "orchestrator": {"last_tick_iso": "2026-01-01T00:00:00+00:00", "interval_seconds": 60, "detail": "ok"},
+        })
+        result.stderr = ""
+        return result
+
+    def fake_urlopen(url, timeout=None):
+        resp = MagicMock()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        resp.status = 200
+        resp.read.return_value = json.dumps({"status": "ok", "queue_depth": 0}).encode()
+        return resp
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    resp = isolated_client.get("/api/health/pipeline")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "scanner" in data
+    assert "orchestrator" in data
+    assert "event_queue" in data
+    for key in ("scanner", "orchestrator", "event_queue"):
+        sub = data[key]
+        assert "status" in sub
+        assert sub["status"] in ("ok", "stale", "down")
+        assert "last_tick_iso" in sub
+        assert "interval_seconds" in sub
+        assert "detail" in sub
+
+
+def test_pipeline_health_loop_binary_missing_marks_down(isolated_client, monkeypatch):
+    _reset_cache()
+
+    def fake_run(cmd, **kwargs):
+        raise FileNotFoundError("loop not found")
+
+    def fake_urlopen(url, timeout=None):
+        resp = MagicMock()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        resp.status = 200
+        resp.read.return_value = json.dumps({"status": "ok"}).encode()
+        return resp
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    resp = isolated_client.get("/api/health/pipeline")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["scanner"]["status"] == "down"
+    assert data["orchestrator"]["status"] == "down"
+    assert "loop binary not found" in data["scanner"]["detail"]
+
+
+def test_pipeline_health_cache_returns_same_payload(isolated_client, monkeypatch):
+    _reset_cache()
+
+    call_count = {"n": 0}
+
+    def fake_run(cmd, **kwargs):
+        call_count["n"] += 1
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = json.dumps({
+            "scanner": {"last_tick_iso": "2026-01-01T00:00:00+00:00", "interval_seconds": 60, "detail": ""},
+            "orchestrator": {"last_tick_iso": "2026-01-01T00:00:00+00:00", "interval_seconds": 60, "detail": ""},
+        })
+        result.stderr = ""
+        return result
+
+    def fake_urlopen(url, timeout=None):
+        resp = MagicMock()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        resp.status = 200
+        resp.read.return_value = json.dumps({"status": "ok"}).encode()
+        return resp
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    resp1 = isolated_client.get("/api/health/pipeline")
+    resp2 = isolated_client.get("/api/health/pipeline")
+
+    assert resp1.status_code == 200
+    assert resp2.status_code == 200
+    assert resp1.json() == resp2.json()
+    assert call_count["n"] == 1, "subprocess.run should only be called once within the 30s cache window"

--- a/tests/visual/test_health_panel.py
+++ b/tests/visual/test_health_panel.py
@@ -1,0 +1,17 @@
+"""
+Visual-diff test for HealthPanel — depends on the screenshot harness from #113.
+
+This file is a stub. Enable once #113's harness is merged and
+design/reference-screenshots/health-panel.png is captured.
+"""
+import pytest
+
+
+@pytest.mark.skip(reason="visual-diff harness (#113) not yet merged")
+def test_health_panel_visual_diff():
+    """
+    Load HealthPanel at /?fixtures=1, capture a screenshot, and assert
+    pixel-diff against design/reference-screenshots/health-panel.png is ≤ 0.5%.
+    Implement using the harness API from #113.
+    """
+    pass

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -21,6 +21,7 @@ import type {
   ScannerState,
   LogsResponse,
   IssueCostRow,
+  PipelineHealth,
 } from './types';
 import * as fx from './fixtures';
 
@@ -164,4 +165,9 @@ export async function fetchLogs(handler: string, filter: string, tail: string): 
     throw new Error((body as { detail?: string }).detail || res.statusText);
   }
   return res.json() as Promise<LogsResponse>;
+}
+
+export async function fetchPipelineHealth(): Promise<PipelineHealth> {
+  if (isFixtureMode()) return fx.getFixturePipelineHealth();
+  return get<PipelineHealth>('/api/health/pipeline');
 }

--- a/web/src/lib/fixtures.ts
+++ b/web/src/lib/fixtures.ts
@@ -20,6 +20,7 @@ import type {
   ClaudeUsage,
   ScannerState,
   IssueCostRow,
+  PipelineHealth,
 } from './types';
 
 const PROJECTS = [
@@ -372,5 +373,28 @@ export function getFixtureScannerState(): ScannerState {
       { project: 'loop-monitor', kind: 'issue', number: 137, stage: 'po',  count: 1, max: 2 },
       { project: 'loop',         kind: 'issue', number: 142, stage: 'dev', count: 2, max: 2 },
     ],
+  };
+}
+
+export function getFixturePipelineHealth(): PipelineHealth {
+  return {
+    scanner: {
+      status: 'ok',
+      last_tick_iso: '2026-05-10T12:00:00+00:00',
+      interval_seconds: 60,
+      detail: 'scanner running normally',
+    },
+    orchestrator: {
+      status: 'stale',
+      last_tick_iso: '2026-05-10T11:57:00+00:00',
+      interval_seconds: 60,
+      detail: 'last invocation: 3 min ago',
+    },
+    event_queue: {
+      status: 'down',
+      last_tick_iso: null,
+      interval_seconds: null,
+      detail: 'connection refused at localhost:8765',
+    },
   };
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -214,3 +214,18 @@ export interface IssueCostRow {
   actual_runs: number;
   last_event_at: string | null;
 }
+
+export type SubsystemStatus = 'ok' | 'stale' | 'down';
+
+export interface SubsystemHealth {
+  status: SubsystemStatus;
+  last_tick_iso: string | null;
+  interval_seconds: number | null;
+  detail: string;
+}
+
+export interface PipelineHealth {
+  scanner: SubsystemHealth;
+  orchestrator: SubsystemHealth;
+  event_queue: SubsystemHealth;
+}

--- a/web/src/panels/HealthPanel.tsx
+++ b/web/src/panels/HealthPanel.tsx
@@ -1,0 +1,164 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { fetchPipelineHealth } from '../lib/api';
+import { getFixturePipelineHealth } from '../lib/fixtures';
+import type { SubsystemHealth, SubsystemStatus, PipelineHealth } from '../lib/types';
+
+const FIXTURE_MODE = new URLSearchParams(window.location.search).get('fixtures') === '1';
+
+function relativeTime(isoStr: string | null): string {
+  if (!isoStr) return 'never';
+  const delta = Math.floor((Date.now() - new Date(isoStr).getTime()) / 1000);
+  if (delta < 60) return `${delta}s ago`;
+  if (delta < 3600) return `${Math.floor(delta / 60)}m ago`;
+  return `${Math.floor(delta / 3600)}h ago`;
+}
+
+const STATUS_COLOR: Record<SubsystemStatus, string> = {
+  ok: 'var(--pass)',
+  stale: 'var(--warn)',
+  down: 'var(--fail)',
+};
+
+interface RowProps {
+  label: string;
+  sub: SubsystemHealth;
+  open: boolean;
+  onToggle: () => void;
+}
+
+function HealthRow({ label, sub, open, onToggle }: RowProps) {
+  const color = STATUS_COLOR[sub.status];
+  return (
+    <div style={{ borderBottom: '1px solid var(--border)' }}>
+      <button
+        onClick={onToggle}
+        style={{
+          width: '100%',
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--pad-2)',
+          padding: 'var(--pad-2) var(--pad-3)',
+          textAlign: 'left',
+        }}
+      >
+        <span
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 12,
+            color: 'var(--fg-2)',
+            minWidth: 110,
+          }}
+        >
+          {label}
+        </span>
+        <span
+          style={{
+            display: 'inline-block',
+            padding: '2px 8px',
+            borderRadius: 4,
+            fontSize: 11,
+            fontWeight: 600,
+            fontFamily: 'var(--font-mono)',
+            background: color,
+            color: 'var(--bg)',
+          }}
+        >
+          {sub.status}
+        </span>
+        <span style={{ fontSize: 12, color: 'var(--fg-4)', marginLeft: 'auto' }}>
+          last tick: {relativeTime(sub.last_tick_iso)}
+        </span>
+        <span style={{ fontSize: 10, color: 'var(--fg-4)', marginLeft: 'var(--pad-1)' }}>
+          {open ? '▲' : '▼'}
+        </span>
+      </button>
+
+      {open && (
+        <div
+          style={{
+            padding: 'var(--pad-2) var(--pad-3) var(--pad-3)',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 12,
+            color: 'var(--fg-3)',
+            background: 'var(--bg-1)',
+            borderTop: '1px solid var(--border)',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          }}
+        >
+          {sub.detail || '(no detail)'}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function HealthPanel() {
+  const [openRow, setOpenRow] = useState<string | null>(null);
+
+  const { data, isError } = useQuery<PipelineHealth>({
+    queryKey: ['pipeline-health'],
+    queryFn: FIXTURE_MODE ? getFixturePipelineHealth : fetchPipelineHealth,
+    refetchInterval: 30_000,
+  });
+
+  const toggle = (key: string) => setOpenRow(prev => (prev === key ? null : key));
+
+  const LABELS: [keyof PipelineHealth, string][] = [
+    ['scanner', 'scanner'],
+    ['orchestrator', 'orchestrator'],
+    ['event_queue', 'event-queue'],
+  ];
+
+  return (
+    <div
+      style={{
+        background: 'var(--bg-2)',
+        border: '1px solid var(--border)',
+        borderRadius: 6,
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          padding: 'var(--pad-2) var(--pad-3)',
+          borderBottom: '1px solid var(--border)',
+          fontFamily: 'var(--font-mono)',
+          fontSize: 11,
+          fontWeight: 600,
+          color: 'var(--fg-3)',
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+        }}
+      >
+        Pipeline Health
+      </div>
+
+      {isError && (
+        <div style={{ padding: 'var(--pad-2) var(--pad-3)', color: 'var(--fail)', fontSize: 12 }}>
+          Failed to load pipeline health
+        </div>
+      )}
+
+      {data && LABELS.map(([key, label]) => (
+        <HealthRow
+          key={key}
+          label={label}
+          sub={data[key]}
+          open={openRow === key}
+          onToggle={() => toggle(key)}
+        />
+      ))}
+
+      {!data && !isError && (
+        <div style={{ padding: 'var(--pad-2) var(--pad-3)', color: 'var(--fg-4)', fontSize: 12 }}>
+          Loading…
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/screens/Overview.tsx
+++ b/web/src/screens/Overview.tsx
@@ -14,6 +14,7 @@ import RoleTag from '../components/RoleTag';
 import { relTime, durationFmt } from '../lib/utils';
 import Charts from '../panels/Charts';
 import ClaudeUsage from '../panels/ClaudeUsage';
+import HealthPanel from '../panels/HealthPanel';
 
 const COMPLETED_TYPES = new Set([
   'merge_done', 'judge_done', 'review_done', 'dev_done', 'po_done',
@@ -110,7 +111,10 @@ export default function Overview() {
               ))}
             </div>
           </div>
-          <Leaderboard events={history} />
+          <div style={{ display: 'grid', gap: 'var(--pad-3)', alignContent: 'start' }}>
+            <Leaderboard events={history} />
+            <HealthPanel />
+          </div>
         </div>
 
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--pad-3)' }}>


### PR DESCRIPTION
Closes #134

## Changes

### Backend (`server/routes/health.py`)
- Added `GET /api/health/pipeline` endpoint alongside the existing `/api/health` route
- Each subsystem object has `status` (`ok|stale|down`), `last_tick_iso`, `interval_seconds`, `detail`
- Shells out to `loop status --json` via `subprocess.run(..., timeout=5)` for scanner + orchestrator; gracefully handles `FileNotFoundError`, `TimeoutExpired`, non-zero exit (detail = first 200 chars of stderr)
- Event queue probed via **`urllib.request`** (stdlib only — no `requests` added) against `$EVENT_QUEUE_URL/health` (defaults to `http://localhost:8765/health`; overridable in CI)
- 30s in-process cache using `time.monotonic()` + `threading.Lock` to prevent concurrent re-shells
- Stale detection computed server-side: `>2×interval` → `stale`, `>4×interval` or absent → `down`

### Frontend
- `web/src/lib/types.ts` — added `SubsystemStatus`, `SubsystemHealth`, `PipelineHealth` types
- `web/src/lib/api.ts` — added `fetchPipelineHealth()` following the existing `isFixtureMode()` / `get<T>()` pattern
- `web/src/lib/fixtures.ts` — added `getFixturePipelineHealth()` with deterministic static timestamps for `?fixtures=1` mode
- `web/src/panels/HealthPanel.tsx` — vertical stack of 3 rows; uses only `var(--pass)`, `var(--warn)`, `var(--fail)` CSS tokens; click expands inline detail; TanStack Query polling at `refetchInterval: 30000`
- `web/src/screens/Overview.tsx` — `<HealthPanel />` mounted in the right-rail column below `<Leaderboard>`

### Tests
- `tests/test_pipeline_health.py` — 3 tests: (a) 200 + three keys, (b) missing `loop` binary → down, (c) cache prevents re-shell within 30s window
- `tests/visual/test_health_panel.py` — stub, skipped pending #113 harness

## Stdlib choice
`urllib.request` used for the event-queue probe — keeps `requirements.txt` unchanged (no `requests` added).

## Notes
- **Drawer**: #122's drawer now exists; `HealthPanel.tsx` uses inline expand (collapsible rows) to show `detail`. Migrating to the shared drawer is a one-line swap and can be done in a follow-up.
- **`loop status --json`** (svv2014/loop#248): endpoint degrades gracefully to `down` with detail `"loop binary not found"` if the binary isn't present.
- **Visual screenshot**: `design/reference-screenshots/health-panel.png` placeholder — capture requires running browser automation; visual-diff test is stubbed with `@pytest.mark.skip` pending #113.

## CI validation
```
ruff check .               → All checks passed
tsc --noEmit               → exit 0
vite build                 → ✓ built in 1.33s
pytest test_pipeline_health.py test_health.py  → 10 passed
```

## Test Plan
- `python3 -m pytest tests/test_pipeline_health.py -v` → 3 passed
- `python3 -m pytest tests/test_health.py -v` → 7 passed (no regressions on existing `/api/health`)
- `curl localhost:18792/api/health/pipeline | jq` → well-formed JSON with `scanner`, `orchestrator`, `event_queue`
- Open `/v2?fixtures=1` → Overview right-rail shows HealthPanel with scanner=ok, orchestrator=stale, event_queue=down