### PR TITLE
[LM-126] Fix SQLite connection leak — add db_dep() FastAPI dependency

### DIFF
--- a/server/db.py
+++ b/server/db.py
@@ -138,9 +138,19 @@ def apply_pending_migrations():
     conn.close()
 
 
-def get_db():
+def get_db() -> sqlite3.Connection:
+    """Direct caller — must close explicitly. Used by background tasks / scripts."""
     conn = sqlite3.connect(DB_PATH)
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA busy_timeout=10000")
     return conn
+
+
+def db_dep():
+    """FastAPI dependency — opens, yields, closes in finally."""
+    conn = get_db()
+    try:
+        yield conn
+    finally:
+        conn.close()

--- a/server/routes/action_queue.py
+++ b/server/routes/action_queue.py
@@ -1,11 +1,12 @@
 import os
+import sqlite3
 from datetime import datetime, timezone
 from typing import Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from server.constants import PROJECTS
-from server.db import get_db
+from server.db import db_dep
 from server.helpers.timeline import parse_ts
 
 router = APIRouter()
@@ -65,12 +66,11 @@ def _action_queue_reason(
 
 
 @router.get("/api/action_queue")
-def action_queue():
+def action_queue(conn: sqlite3.Connection = Depends(db_dep)):
     """Items across all projects awaiting human input.
 
     Derived from the latest event per (project, kind, number). No GitHub API call.
     """
-    conn = get_db()
     rows = conn.execute(
         """
         SELECT e.project, e.role, e.event_type, e.issue_number, e.pr_number,
@@ -100,7 +100,6 @@ def action_queue():
         )
         """
     ).fetchall()
-    conn.close()
 
     now = datetime.now(timezone.utc)
     result = []

--- a/server/routes/board.py
+++ b/server/routes/board.py
@@ -1,25 +1,23 @@
-from fastapi import APIRouter
+import sqlite3
 
-from server.db import get_db
+from fastapi import APIRouter, Depends
+
+from server.db import db_dep
 
 router = APIRouter()
 
 
 @router.get("/api/board")
-def board():
-    conn = get_db()
+def board(conn: sqlite3.Connection = Depends(db_dep)):
     rows = conn.execute(
         "SELECT project, role, model, total_points, verdict_count FROM scores ORDER BY total_points DESC"
     ).fetchall()
-    conn.close()
     return [dict(r) for r in rows]
 
 
 @router.get("/api/verdicts")
-def get_verdicts():
-    conn = get_db()
+def get_verdicts(conn: sqlite3.Connection = Depends(db_dep)):
     rows = conn.execute(
         "SELECT id, project, role, model, points, reason, created_at FROM verdicts ORDER BY id DESC LIMIT 50"
     ).fetchall()
-    conn.close()
     return [dict(r) for r in rows]

--- a/server/routes/feed.py
+++ b/server/routes/feed.py
@@ -1,18 +1,18 @@
 import json
+import sqlite3
 from datetime import datetime, timezone
 from typing import Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
-from server.db import get_db
+from server.db import db_dep
 
 router = APIRouter()
 
 
 @router.get("/api/history")
-def history(limit: int = 50, loop_id: Optional[str] = None):
+def history(conn: sqlite3.Connection = Depends(db_dep), limit: int = 50, loop_id: Optional[str] = None):
     """Completed jobs: *_done/*_pass events paired with their *_start for duration."""
-    conn = get_db()
     loop_clause = "AND d.loop_id = ?" if loop_id is not None else ""
     params = (loop_id, limit) if loop_id is not None else (limit,)
     rows = conn.execute(f"""
@@ -50,14 +50,12 @@ def history(limit: int = 50, loop_id: Optional[str] = None):
         ORDER BY d.id DESC
         LIMIT ?
     """, params).fetchall()
-    conn.close()
     return [dict(r) for r in rows]
 
 
 @router.get("/api/active")
-def active():
+def active(conn: sqlite3.Connection = Depends(db_dep)):
     """Currently running workers: latest event per project+role is a *_start within last 4h."""
-    conn = get_db()
     rows = conn.execute("""
         SELECT e.project, e.role, e.model, e.event_type, e.issue_number, e.pr_number,
                e.detail, e.created_at
@@ -69,7 +67,6 @@ def active():
           AND e.created_at >= datetime('now', '-4 hours')
         ORDER BY e.created_at DESC
     """).fetchall()
-    conn.close()
     return [dict(r) for r in rows]
 
 
@@ -88,7 +85,12 @@ def _derive_status(event_type: str) -> str:
 
 
 @router.get("/api/feed")
-def feed(role: Optional[str] = None, status: Optional[str] = None, loop_id: Optional[str] = None):
+def feed(
+    conn: sqlite3.Connection = Depends(db_dep),
+    role: Optional[str] = None,
+    status: Optional[str] = None,
+    loop_id: Optional[str] = None,
+):
     status_lower = status.lower() if status else None
     if status_lower is not None and status_lower not in VALID_FEED_STATUSES:
         return []
@@ -111,14 +113,12 @@ def feed(role: Optional[str] = None, status: Optional[str] = None, loop_id: Opti
 
     where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
 
-    conn = get_db()
     rows = conn.execute(
         f"""SELECT id, project, role, model, event_type, issue_number, pr_number,
                   detail, payload, created_at
            FROM events {where_sql} ORDER BY id DESC LIMIT 50""",
         params,
     ).fetchall()
-    conn.close()
     now = datetime.now(timezone.utc)
     result = []
     for r in rows:
@@ -138,8 +138,7 @@ def feed(role: Optional[str] = None, status: Optional[str] = None, loop_id: Opti
 
 
 @router.get("/api/status")
-def status():
-    conn = get_db()
+def status(conn: sqlite3.Connection = Depends(db_dep)):
     rows = conn.execute("""
         SELECT e.project, e.role, e.model, e.event_type, e.issue_number, e.pr_number,
                e.detail, e.payload, e.created_at
@@ -149,7 +148,6 @@ def status():
         ) latest ON e.id = latest.max_id
         ORDER BY e.project, e.role
     """).fetchall()
-    conn.close()
     result = []
     for r in rows:
         entry = dict(r)

--- a/server/routes/graph.py
+++ b/server/routes/graph.py
@@ -1,16 +1,17 @@
-from fastapi import APIRouter, HTTPException
+import sqlite3
+
+from fastapi import APIRouter, Depends, HTTPException
 
 from server.constants import PROJECTS
-from server.db import get_db
+from server.db import db_dep
 from server.helpers.timeline import build_timeline_events, parse_ts
 
 router = APIRouter()
 
 
 @router.get("/api/stats/timeline/pr/{project}/{pr_number}")
-def get_timeline_by_pr(project: str, pr_number: int):
+def get_timeline_by_pr(project: str, pr_number: int, conn: sqlite3.Connection = Depends(db_dep)):
     """Look up issue_number from pipeline_runs then return the same timeline payload."""
-    conn = get_db()
     run_row = conn.execute(
         "SELECT issue_number FROM pipeline_runs WHERE project=? AND pr_number=? ORDER BY id DESC LIMIT 1",
         (project, pr_number),
@@ -21,7 +22,6 @@ def get_timeline_by_pr(project: str, pr_number: int):
             "SELECT * FROM events WHERE project=? AND pr_number=? ORDER BY created_at",
             (project, pr_number),
         ).fetchall()
-        conn.close()
         if not rows:
             raise HTTPException(status_code=404, detail="PR not found")
         return {
@@ -32,15 +32,12 @@ def get_timeline_by_pr(project: str, pr_number: int):
             "events": [dict(r) for r in rows],
         }
 
-    conn.close()
-    return get_timeline(project, run_row["issue_number"])
+    return get_timeline(project, run_row["issue_number"], conn=conn)
 
 
 @router.get("/api/stats/timeline/{project}/{issue}")
-def get_timeline(project: str, issue: int):
+def get_timeline(project: str, issue: int, conn: sqlite3.Connection = Depends(db_dep)):
     """Stage-by-stage timeline for a single issue."""
-    conn = get_db()
-
     summary_row = conn.execute(
         """SELECT title, outcome, total_duration_seconds, rework_count, pr_number,
                   issue_lifetime_seconds, pr_lifetime_seconds
@@ -76,8 +73,6 @@ def get_timeline(project: str, issue: int):
             (project, issue),
         ).fetchall()
 
-    conn.close()
-
     events = build_timeline_events(history_rows)
 
     total_elapsed_seconds = None
@@ -104,9 +99,8 @@ def get_timeline(project: str, issue: int):
 
 
 @router.get("/api/events_graph")
-def get_events_graph(window: int = 24):
+def get_events_graph(window: int = 24, conn: sqlite3.Connection = Depends(db_dep)):
     window = max(1, min(window, 168))
-    conn = get_db()
     rows = conn.execute(
         """SELECT strftime('%Y-%m-%dT%H:00:00', created_at) AS hour, role, COUNT(*) AS count
            FROM events
@@ -115,5 +109,4 @@ def get_events_graph(window: int = 24):
            ORDER BY hour""",
         (f"-{window}",),
     ).fetchall()
-    conn.close()
     return {"window_hours": window, "buckets": [dict(r) for r in rows]}

--- a/server/routes/health.py
+++ b/server/routes/health.py
@@ -1,10 +1,11 @@
+import sqlite3
 import subprocess
 from pathlib import Path
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from server.constants import MONITOR_VERSION, SUPPORTED_API_MAJOR
-from server.db import get_db
+from server.db import db_dep
 
 router = APIRouter()
 
@@ -29,8 +30,7 @@ def _git_sha() -> str:
 
 
 @router.get("/api/health")
-def health():
-    conn = get_db()
+def health(conn: sqlite3.Connection = Depends(db_dep)):
     rows = conn.execute(
         "SELECT core_version, COUNT(*) as cnt FROM events WHERE core_version IS NOT NULL GROUP BY core_version"
     ).fetchall()
@@ -39,7 +39,6 @@ def health():
         "SELECT DISTINCT COALESCE(loop_id, '(unknown)') AS loop_id FROM events ORDER BY loop_id"
     ).fetchall()
     loop_ids = [r["loop_id"] for r in loop_rows]
-    conn.close()
     return {
         "status": "ok",
         "monitor_version": MONITOR_VERSION,
@@ -51,8 +50,7 @@ def health():
 
 
 @router.get("/api/loops")
-def get_loops():
-    conn = get_db()
+def get_loops(conn: sqlite3.Connection = Depends(db_dep)):
     rows = conn.execute("""
         SELECT COALESCE(loop_id, '(unknown)') AS loop_id,
                MAX(created_at) AS last_seen,
@@ -62,7 +60,6 @@ def get_loops():
         GROUP BY COALESCE(loop_id, '(unknown)')
         ORDER BY 1
     """).fetchall()
-    conn.close()
     result = []
     for r in rows:
         entry = dict(r)

--- a/server/routes/ingest.py
+++ b/server/routes/ingest.py
@@ -26,108 +26,111 @@ def _insert_event(data: ReportPayload):
 
 def _do_insert_event(data: ReportPayload):
     conn = get_db()
-    now = datetime.now(timezone.utc).isoformat()
-    conn.execute(
-        """INSERT INTO events
-           (project, role, model, event_type, issue_number, pr_number, detail, payload,
-            core_version, loop_id, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-        (
-            data.project,
-            data.role,
-            data.model,
-            data.event_type,
-            data.issue_number,
-            data.pr_number,
-            data.detail,
-            json.dumps(data.payload) if data.payload else None,
-            data.core_version,
-            data.loop_id,
-            now,
-        ),
-    )
-
-    if data.issue_number is not None:
+    try:
+        now = datetime.now(timezone.utc).isoformat()
         conn.execute(
-            """INSERT INTO issue_history
-               (project, issue_number, pr_number, role, event_type, agent, model,
-                duration_seconds, rework_count, created_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            """INSERT INTO events
+               (project, role, model, event_type, issue_number, pr_number, detail, payload,
+                core_version, loop_id, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 data.project,
+                data.role,
+                data.model,
+                data.event_type,
                 data.issue_number,
                 data.pr_number,
-                data.role,
-                data.event_type,
-                data.agent,
-                data.model,
-                data.duration_seconds,
-                data.rework_count or 0,
+                data.detail,
+                json.dumps(data.payload) if data.payload else None,
+                data.core_version,
+                data.loop_id,
                 now,
             ),
         )
 
-        existing_run = conn.execute(
-            "SELECT id, rework_count FROM pipeline_runs WHERE project=? AND issue_number=?",
-            (data.project, data.issue_number),
-        ).fetchone()
-
-        if existing_run:
-            updates = ["completed_at=?"]
-            params: list = [now]
-            if data.pr_number is not None:
-                updates.append("pr_number=?")
-                params.append(data.pr_number)
-            if data.rework_count is not None:
-                updates.append("rework_count=rework_count+?")
-                params.append(data.rework_count)
-            params.append(existing_run["id"])
+        if data.issue_number is not None:
             conn.execute(
-                f"UPDATE pipeline_runs SET {', '.join(updates)} WHERE id=?",
-                params,
-            )
-        else:
-            conn.execute(
-                """INSERT INTO pipeline_runs
-                   (project, issue_number, pr_number, started_at, completed_at, created_at)
-                   VALUES (?, ?, ?, ?, ?, ?)""",
-                (data.project, data.issue_number, data.pr_number, now, now, now),
+                """INSERT INTO issue_history
+                   (project, issue_number, pr_number, role, event_type, agent, model,
+                    duration_seconds, rework_count, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    data.project,
+                    data.issue_number,
+                    data.pr_number,
+                    data.role,
+                    data.event_type,
+                    data.agent,
+                    data.model,
+                    data.duration_seconds,
+                    data.rework_count or 0,
+                    now,
+                ),
             )
 
-    if data.event_type == "finished" and data.issue_number is not None:
-        now_dt = datetime.fromisoformat(now)
-        run = conn.execute(
-            "SELECT id, started_at FROM pipeline_runs WHERE project=? AND issue_number=? ORDER BY id DESC LIMIT 1",
-            (data.project, data.issue_number),
-        ).fetchone()
-        if run:
-            try:
-                started = datetime.fromisoformat(run["started_at"].replace("Z", "+00:00"))
-                issue_secs = int((now_dt - started).total_seconds())
-            except Exception:
-                issue_secs = None
-            first_pr = conn.execute(
-                "SELECT created_at FROM issue_history"
-                " WHERE project=? AND issue_number=? AND pr_number IS NOT NULL"
-                " ORDER BY id ASC LIMIT 1",
+            existing_run = conn.execute(
+                "SELECT id, rework_count FROM pipeline_runs WHERE project=? AND issue_number=?",
                 (data.project, data.issue_number),
             ).fetchone()
-            pr_secs = None
-            if first_pr:
-                try:
-                    pr_start = datetime.fromisoformat(first_pr["created_at"].replace("Z", "+00:00"))
-                    pr_secs = int((now_dt - pr_start).total_seconds())
-                except Exception:
-                    pass
-            conn.execute(
-                """UPDATE pipeline_runs SET outcome=?, completed_at=?, issue_lifetime_seconds=?, pr_lifetime_seconds=?
-                   WHERE id=?""",
-                (data.detail or "finished", now, issue_secs, pr_secs, run["id"]),
-            )
 
-    auto_bounty(conn, data, now)
-    conn.commit()
-    conn.close()
+            if existing_run:
+                updates = ["completed_at=?"]
+                params: list = [now]
+                if data.pr_number is not None:
+                    updates.append("pr_number=?")
+                    params.append(data.pr_number)
+                if data.rework_count is not None:
+                    updates.append("rework_count=rework_count+?")
+                    params.append(data.rework_count)
+                params.append(existing_run["id"])
+                conn.execute(
+                    f"UPDATE pipeline_runs SET {', '.join(updates)} WHERE id=?",
+                    params,
+                )
+            else:
+                conn.execute(
+                    """INSERT INTO pipeline_runs
+                       (project, issue_number, pr_number, started_at, completed_at, created_at)
+                       VALUES (?, ?, ?, ?, ?, ?)""",
+                    (data.project, data.issue_number, data.pr_number, now, now, now),
+                )
+
+        if data.event_type == "finished" and data.issue_number is not None:
+            now_dt = datetime.fromisoformat(now)
+            run = conn.execute(
+                "SELECT id, started_at FROM pipeline_runs WHERE project=? AND issue_number=? ORDER BY id DESC LIMIT 1",
+                (data.project, data.issue_number),
+            ).fetchone()
+            if run:
+                try:
+                    started = datetime.fromisoformat(run["started_at"].replace("Z", "+00:00"))
+                    issue_secs = int((now_dt - started).total_seconds())
+                except Exception:
+                    issue_secs = None
+                first_pr = conn.execute(
+                    "SELECT created_at FROM issue_history"
+                    " WHERE project=? AND issue_number=? AND pr_number IS NOT NULL"
+                    " ORDER BY id ASC LIMIT 1",
+                    (data.project, data.issue_number),
+                ).fetchone()
+                pr_secs = None
+                if first_pr:
+                    try:
+                        pr_start = datetime.fromisoformat(first_pr["created_at"].replace("Z", "+00:00"))
+                        pr_secs = int((now_dt - pr_start).total_seconds())
+                    except Exception:
+                        pass
+                conn.execute(
+                    "UPDATE pipeline_runs"
+                    " SET outcome=?, completed_at=?, issue_lifetime_seconds=?, pr_lifetime_seconds=?"
+                    " WHERE id=?",
+                    (data.detail or "finished", now, issue_secs, pr_secs, run["id"]),
+                )
+
+        auto_bounty(conn, data, now)
+        conn.commit()
+    finally:
+        conn.close()
 
 
 def _insert_verdict(data: VerdictPayload):
@@ -142,33 +145,35 @@ def _insert_verdict(data: VerdictPayload):
 
 def _do_insert_verdict(data: VerdictPayload):
     conn = get_db()
-    now = datetime.now(timezone.utc).isoformat()
-    conn.execute(
-        "INSERT INTO verdicts (project, role, model, points, reason, created_at) VALUES (?, ?, ?, ?, ?, ?)",
-        (data.project, data.role, data.model, data.points, data.reason, now),
-    )
-    existing = conn.execute(
-        "SELECT id, total_points, verdict_count FROM scores WHERE project=? AND role=? AND model IS ?",
-        (data.project, data.role, data.model),
-    ).fetchone()
-    if existing:
+    try:
+        now = datetime.now(timezone.utc).isoformat()
         conn.execute(
-            "UPDATE scores SET total_points=?, verdict_count=?, updated_at=? WHERE id=?",
-            (
-                existing["total_points"] + data.points,
-                existing["verdict_count"] + 1,
-                now,
-                existing["id"],
-            ),
+            "INSERT INTO verdicts (project, role, model, points, reason, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (data.project, data.role, data.model, data.points, data.reason, now),
         )
-    else:
-        conn.execute(
-            "INSERT INTO scores (project, role, model, total_points, verdict_count, updated_at)"
-            " VALUES (?, ?, ?, ?, 1, ?)",
-            (data.project, data.role, data.model, data.points, now),
-        )
-    conn.commit()
-    conn.close()
+        existing = conn.execute(
+            "SELECT id, total_points, verdict_count FROM scores WHERE project=? AND role=? AND model IS ?",
+            (data.project, data.role, data.model),
+        ).fetchone()
+        if existing:
+            conn.execute(
+                "UPDATE scores SET total_points=?, verdict_count=?, updated_at=? WHERE id=?",
+                (
+                    existing["total_points"] + data.points,
+                    existing["verdict_count"] + 1,
+                    now,
+                    existing["id"],
+                ),
+            )
+        else:
+            conn.execute(
+                "INSERT INTO scores (project, role, model, total_points, verdict_count, updated_at)"
+                " VALUES (?, ?, ?, ?, 1, ?)",
+                (data.project, data.role, data.model, data.points, now),
+            )
+        conn.commit()
+    finally:
+        conn.close()
 
 
 @router.post("/api/report", status_code=202)

--- a/server/routes/issues_cost.py
+++ b/server/routes/issues_cost.py
@@ -1,12 +1,13 @@
 import json
 import re
+import sqlite3
 import subprocess
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
-from server.db import get_db
+from server.db import db_dep
 
 router = APIRouter()
 
@@ -115,6 +116,7 @@ def get_issues_cost(
     since: Optional[str] = None,
     limit: int = 50,
     offset: int = 0,
+    conn: sqlite3.Connection = Depends(db_dep),
 ) -> list:
     if since is None:
         since_dt = datetime.now(timezone.utc) - timedelta(days=30)
@@ -122,7 +124,6 @@ def get_issues_cost(
     else:
         since_iso = since
 
-    conn = get_db()
     project_param: Optional[str] = project
 
     rows = conn.execute(
@@ -171,7 +172,6 @@ def get_issues_cost(
         """,
         (since_iso, project_param, project_param, limit, offset),
     ).fetchall()
-    conn.close()
 
     now_ts = datetime.now(timezone.utc).timestamp()
     result = []

--- a/server/routes/runs.py
+++ b/server/routes/runs.py
@@ -1,11 +1,12 @@
 import json
+import sqlite3
 from datetime import datetime, timezone
 from typing import Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from server.constants import PROJECTS
-from server.db import get_db
+from server.db import db_dep
 from server.helpers.timeline import parse_ts
 
 router = APIRouter()
@@ -40,8 +41,7 @@ def _derive_stage(event_type: Optional[str]) -> Optional[str]:
 
 
 @router.get("/api/history/{project}/{issue}")
-def get_history(project: str, issue: int):
-    conn = get_db()
+def get_history(project: str, issue: int, conn: sqlite3.Connection = Depends(db_dep)):
     rows = conn.execute(
         """SELECT id, project, issue_number, pr_number, role, event_type, agent, model,
                   duration_seconds, rework_count, created_at
@@ -55,13 +55,11 @@ def get_history(project: str, issue: int):
            FROM pipeline_runs WHERE project=? AND issue_number=? ORDER BY id DESC LIMIT 1""",
         (project, issue),
     ).fetchone()
-    conn.close()
     return {"events": [dict(r) for r in rows], "run": dict(run_row) if run_row else None}
 
 
 @router.get("/api/runs")
-def get_runs():
-    conn = get_db()
+def get_runs(conn: sqlite3.Connection = Depends(db_dep)):
     rows = conn.execute(
         """SELECT id, project, issue_number, pr_number, title, outcome,
                   started_at, completed_at, total_duration_seconds,
@@ -69,13 +67,11 @@ def get_runs():
            FROM pipeline_runs
            ORDER BY id DESC"""
     ).fetchall()
-    conn.close()
     return [dict(r) for r in rows]
 
 
 @router.get("/api/runs/{project}")
-def get_runs_by_project(project: str):
-    conn = get_db()
+def get_runs_by_project(project: str, conn: sqlite3.Connection = Depends(db_dep)):
     rows = conn.execute(
         """SELECT id, project, issue_number, pr_number, title, outcome,
                   started_at, completed_at, total_duration_seconds,
@@ -85,14 +81,12 @@ def get_runs_by_project(project: str):
            ORDER BY id DESC""",
         (project,),
     ).fetchall()
-    conn.close()
     return [dict(r) for r in rows]
 
 
 @router.get("/api/projects/{slug}/prs")
-def get_project_prs(slug: str, include_finished: bool = False):
+def get_project_prs(slug: str, include_finished: bool = False, conn: sqlite3.Connection = Depends(db_dep)):
     """PR monitor: every PR seen by the pipeline with current stage and time-in-stage."""
-    conn = get_db()
     finished_clause = "" if include_finished else " AND outcome IS NULL"
     runs = conn.execute(
         f"""SELECT issue_number, pr_number, title, outcome, completed_at, rework_count
@@ -152,5 +146,4 @@ def get_project_prs(slug: str, include_finished: bool = False):
             "is_draft": is_draft,
         })
 
-    conn.close()
     return result

--- a/server/routes/stats.py
+++ b/server/routes/stats.py
@@ -1,15 +1,15 @@
+import sqlite3
 from typing import Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
-from server.db import get_db
+from server.db import db_dep
 
 router = APIRouter()
 
 
 @router.get("/api/stats")
-def get_stats():
-    conn = get_db()
+def get_stats(conn: sqlite3.Connection = Depends(db_dep)):
     row = conn.execute(
         """SELECT
                COUNT(*) AS total_runs,
@@ -18,14 +18,12 @@ def get_stats():
                ROUND(100.0 * SUM(CASE WHEN rework_count > 0 THEN 1 ELSE 0 END) / MAX(COUNT(*), 1), 2) AS rework_rate
            FROM pipeline_runs"""
     ).fetchone()
-    conn.close()
     return dict(row) if row else {}
 
 
 @router.get("/api/stats/stages")
-def get_stats_stages():
+def get_stats_stages(conn: sqlite3.Connection = Depends(db_dep)):
     """Avg duration per pipeline stage by pairing *_start and *_done events."""
-    conn = get_db()
     rows = conn.execute("""
         SELECT
             REPLACE(d.event_type, '_done', '') AS stage,
@@ -47,14 +45,12 @@ def get_stats_stages():
         GROUP BY stage
         ORDER BY stage
     """).fetchall()
-    conn.close()
     return [dict(r) for r in rows]
 
 
 @router.get("/api/stats/activity")
-def get_stats_activity():
+def get_stats_activity(conn: sqlite3.Connection = Depends(db_dep)):
     """Daily event counts per project for the last 14 days."""
-    conn = get_db()
     rows = conn.execute("""
         SELECT DATE(created_at) as date, project, COUNT(*) as n
         FROM events
@@ -62,14 +58,12 @@ def get_stats_activity():
         GROUP BY DATE(created_at), project
         ORDER BY date
     """).fetchall()
-    conn.close()
     return [dict(r) for r in rows]
 
 
 @router.get("/api/stats/rework")
-def get_stats_rework():
+def get_stats_rework(conn: sqlite3.Connection = Depends(db_dep)):
     """Per-project rework_start and review_done counts for rework rate cards."""
-    conn = get_db()
     rows = conn.execute("""
         SELECT
             project,
@@ -79,16 +73,13 @@ def get_stats_rework():
         GROUP BY project
         ORDER BY project
     """).fetchall()
-    conn.close()
     return [dict(r) for r in rows]
 
 
 @router.get("/api/projects")
-def get_projects():
+def get_projects(conn: sqlite3.Connection = Depends(db_dep)):
     from server.constants import PROJECTS
-    conn = get_db()
     rows = conn.execute("SELECT DISTINCT project FROM events").fetchall()
-    conn.close()
     active = {r["project"] for r in rows}
     return [{"project": p, "repo": r} for p, r in PROJECTS.items() if p in active]
 
@@ -109,9 +100,8 @@ def _percentile_stats(values: list) -> Optional[dict]:
 
 
 @router.get("/api/projects/{slug}/cycle_times")
-def get_cycle_times(slug: str):
+def get_cycle_times(slug: str, conn: sqlite3.Connection = Depends(db_dep)):
     null_response = {"total_duration": None, "issue_lifetime": None, "pr_lifetime": None}
-    conn = get_db()
     rows = conn.execute(
         """SELECT total_duration_seconds, issue_lifetime_seconds, pr_lifetime_seconds
            FROM pipeline_runs
@@ -119,7 +109,6 @@ def get_cycle_times(slug: str):
            ORDER BY id ASC""",
         (slug,),
     ).fetchall()
-    conn.close()
 
     if not rows:
         return null_response

--- a/tests/test_db_connection_leak.py
+++ b/tests/test_db_connection_leak.py
@@ -1,0 +1,43 @@
+import sqlite3
+
+from fastapi.testclient import TestClient
+
+import server
+import server.db
+from server.app import app
+
+
+def test_no_connection_leak_on_handler_error(monkeypatch, tmp_path):
+    monkeypatch.setattr(server.db, "DB_PATH", str(tmp_path / "test.db"))
+    server.apply_pending_migrations()
+
+    open_count = {"n": 0}
+    real_get_db = server.db.get_db
+
+    class TrackingConnection:
+        def __init__(self, real_conn: sqlite3.Connection):
+            self._conn = real_conn
+            open_count["n"] += 1
+
+        def execute(self, sql: str, *args, **kwargs):
+            if "scores" in sql:
+                raise sqlite3.OperationalError("injected error")
+            return self._conn.execute(sql, *args, **kwargs)
+
+        def close(self):
+            open_count["n"] -= 1
+            self._conn.close()
+
+        def __getattr__(self, name: str):
+            return getattr(self._conn, name)
+
+    def patched_get_db():
+        return TrackingConnection(real_get_db())  # type: ignore[return-value]
+
+    monkeypatch.setattr(server.db, "get_db", patched_get_db)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.get("/api/board")
+
+    assert resp.status_code >= 500
+    assert open_count["n"] == 0, f"Expected 0 open connections, got {open_count['n']}"


### PR DESCRIPTION
Closes #126

## Changes

- **`server/db.py`**: Added `db_dep()` generator that opens a connection via `get_db()`, yields it, and closes it in a `finally` block. The original `get_db()` is kept unchanged for background tasks and scripts.

- **`server/routes/{board,feed,graph,health,runs,stats,action_queue,issues_cost}.py`**: All route handlers converted from `conn = get_db()` / `conn.close()` to `conn: sqlite3.Connection = Depends(db_dep)`. Manual `conn.close()` calls removed — the generator's `finally` handles both happy and exception paths.

- **`server/routes/graph.py`**: `get_timeline_by_pr` calls `get_timeline` directly (not via HTTP). Fixed by passing `conn=conn` explicitly so both handlers share the same injected connection and no second connection is opened.

- **`server/routes/ingest.py`**: `_do_insert_event` and `_do_insert_verdict` (background tasks — cannot use `Depends`) wrapped in `try/finally: conn.close()`.

- **`tests/test_db_connection_leak.py`**: New regression test. Patches `server.db.get_db` to return a tracking wrapper that counts open/close calls. Forces a `sqlite3.OperationalError` on the `/api/board` handler's SQL query, asserts the response is ≥500, and asserts `open_count["n"] == 0` confirming the connection was closed by the dep's `finally` block.

Note: `claude_usage.py`, `scanner_state.py`, and `logs.py` do not use `get_db()` and were not modified.

## Test Plan

- `ruff check .` — passes
- `pytest tests/ --ignore=tests/visual` — 122 passed, 1 pre-existing failure (`test_events_graph_with_data` uses hardcoded dates from 2026-04-28 which is outside its 168-hour window as of today; verified failing on main before this PR)
- New test `tests/test_db_connection_leak.py::test_no_connection_leak_on_handler_error` — PASSED