### PR TITLE
[LM-127] make apply_pending_migrations atomic — DDL + schema_migrations INSERT in one transaction

### DIFF
--- a/server/db.py
+++ b/server/db.py
@@ -103,13 +103,13 @@ def _migration_already_applied(conn: sqlite3.Connection, version_id: str) -> boo
 
 def apply_pending_migrations():
     conn = sqlite3.connect(DB_PATH)
+    conn.isolation_level = None  # manual transaction control — required so DDL stays in our transaction
     conn.execute("""
         CREATE TABLE IF NOT EXISTS schema_migrations (
             version_id TEXT PRIMARY KEY,
             applied_at TEXT
         )
     """)
-    conn.commit()
 
     now = datetime.now(timezone.utc).isoformat()
     applied = {r[0] for r in conn.execute("SELECT version_id FROM schema_migrations")}
@@ -118,20 +118,29 @@ def apply_pending_migrations():
         if version_id in applied:
             continue
         if _migration_already_applied(conn, version_id):
+            conn.execute("BEGIN IMMEDIATE")
             conn.execute(
                 "INSERT INTO schema_migrations (version_id, applied_at) VALUES (?, ?)",
                 (version_id, now),
             )
-            conn.commit()
+            conn.execute("COMMIT")
             continue
+        # Statement splitting: existing MIGRATIONS contain no ';' inside string literals.
+        statements = [s.strip() for s in sql.split(";") if s.strip()]
         try:
-            conn.executescript(sql)
+            conn.execute("BEGIN IMMEDIATE")
+            for stmt in statements:
+                conn.execute(stmt)
             conn.execute(
                 "INSERT INTO schema_migrations (version_id, applied_at) VALUES (?, ?)",
                 (version_id, now),
             )
-            conn.commit()
+            conn.execute("COMMIT")
         except Exception:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.OperationalError:
+                pass
             print(f"Migration failed: {version_id}\nSQL:\n{sql}")
             raise
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,5 +1,7 @@
 import sqlite3
 
+import pytest
+
 import server
 import server.db
 
@@ -33,3 +35,30 @@ def test_apply_pending_migrations_idempotent(tmp_path, monkeypatch):
     conn.close()
     version_ids = [r[0] for r in rows]
     assert version_ids == ["0001_initial", "0002_add_loop_id", "0003_add_pipeline_run_cols"]
+
+
+def test_migration_rolls_back_on_mid_script_failure(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(server.db, "DB_PATH", str(db_path))
+
+    fake_migration_sql = """
+        CREATE TABLE rollback_target (id INTEGER PRIMARY KEY);
+        CREATE INDEX rollback_idx ON rollback_target(id);
+        THIS IS NOT VALID SQL;
+    """
+    monkeypatch.setattr(server.db, "MIGRATIONS", [("9999_test_rollback", fake_migration_sql)])
+    monkeypatch.setattr(server.db, "_migration_already_applied", lambda c, v: False)
+
+    with pytest.raises(sqlite3.OperationalError):
+        server.db.apply_pending_migrations()
+
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='rollback_target'"
+    ).fetchone()
+    assert row is None, "DDL should have been rolled back"
+    applied = conn.execute(
+        "SELECT version_id FROM schema_migrations WHERE version_id='9999_test_rollback'"
+    ).fetchone()
+    assert applied is None, "schema_migrations should not have the failed version"
+    conn.close()


### PR DESCRIPTION
Closes #127

## Changes

- **`server/db.py`** — replaced `conn.executescript(sql)` with individual `conn.execute()` calls inside an explicit `BEGIN IMMEDIATE` … `COMMIT` transaction. Each migration's DDL statements and its `INSERT INTO schema_migrations` row now commit atomically, so a crash between them is impossible.
  - Set `conn.isolation_level = None` on the migration connection for manual transaction control (required for DDL to stay inside our transaction; does not affect `get_db()`).
  - Statement splitting uses `sql.split(";")` — safe for existing migrations which contain no `;` inside string literals (commented in code).
  - `_migration_already_applied` is left unchanged per the issue spec.

- **`tests/test_migrations.py`** — added `test_migration_rolls_back_on_mid_script_failure`: injects a fake migration with invalid SQL as the third statement, asserts `OperationalError` propagates, then verifies the DDL table does not exist and no `schema_migrations` row was recorded.

## Test Plan

- `pytest tests/test_migrations.py -v` — all 3 tests pass (fresh DB, idempotent, rollback regression)
- `ruff check .` — no issues
- `pyright server/` — 0 errors
- `cd web && npm run typecheck && npm run build` — clean