### PR TITLE
[LM-137] add token spend dashboard — per-role / per-project / per-day

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -29,6 +29,7 @@ from server.routes import (  # noqa: E402
     runs,
     scanner_state,
     stats,
+    token_spend,
 )
 
 app.include_router(health.router)
@@ -43,6 +44,7 @@ app.include_router(claude_usage.router)
 app.include_router(issues_cost.router)
 app.include_router(logs.router)
 app.include_router(scanner_state.router)
+app.include_router(token_spend.router)
 
 if os.path.isdir("static/dist"):
     app.mount("/v2", StaticFiles(directory="static/dist", html=True), name="dist")

--- a/server/routes/token_spend.py
+++ b/server/routes/token_spend.py
@@ -1,0 +1,134 @@
+"""
+GET /api/token_spend
+
+Returns per-role / per-project / per-day token spend estimates derived from
+event counts in the events table.  Actual token counts are not stored, so
+spend is estimated from event counts × configurable tokens-per-event rates.
+
+Config env vars:
+  TOKEN_COST_PER_1M_INPUT    USD per 1M input tokens  (default 3.0)
+  TOKEN_COST_PER_1M_OUTPUT   USD per 1M output tokens (default 15.0)
+  TOKEN_EST_INPUT_PER_EVENT  estimated input tokens per event (default 50000)
+  TOKEN_EST_OUTPUT_PER_EVENT estimated output tokens per event (default 10000)
+"""
+
+import os
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from fastapi import APIRouter
+
+from server.db import get_db
+
+router = APIRouter()
+
+ROLES = ["po", "dev", "qa", "reviewer", "merge", "judge"]
+
+
+def _float_env(key: str, default: float) -> float:
+    try:
+        return float(os.environ.get(key, str(default)))
+    except ValueError:
+        return default
+
+
+def _est_cost(events: int, cost_1m_in: float, cost_1m_out: float, in_per_ev: float, out_per_ev: float) -> float:
+    inp = events * in_per_ev
+    out = events * out_per_ev
+    return round((inp / 1_000_000) * cost_1m_in + (out / 1_000_000) * cost_1m_out, 4)
+
+
+@router.get("/api/token_spend")
+def get_token_spend() -> dict[str, Any]:
+    cost_1m_in = _float_env("TOKEN_COST_PER_1M_INPUT", 3.0)
+    cost_1m_out = _float_env("TOKEN_COST_PER_1M_OUTPUT", 15.0)
+    in_per_ev = _float_env("TOKEN_EST_INPUT_PER_EVENT", 50_000)
+    out_per_ev = _float_env("TOKEN_EST_OUTPUT_PER_EVENT", 10_000)
+
+    now = datetime.now(timezone.utc)
+    today_str = now.date().isoformat()
+    week_start = (now - timedelta(days=6)).date().isoformat()
+    month_start = (now - timedelta(days=29)).date().isoformat()
+
+    conn = get_db()
+
+    rows_7d = conn.execute(
+        """
+        SELECT date(created_at) AS day, role, COUNT(*) AS event_count
+        FROM events
+        WHERE date(created_at) >= ?
+        GROUP BY day, role
+        ORDER BY day
+        """,
+        (week_start,),
+    ).fetchall()
+
+    project_agg = conn.execute(
+        """
+        SELECT
+            project,
+            SUM(CASE WHEN date(created_at) = ?  THEN 1 ELSE 0 END) AS today_events,
+            SUM(CASE WHEN date(created_at) >= ? THEN 1 ELSE 0 END) AS week_events,
+            SUM(CASE WHEN date(created_at) >= ? THEN 1 ELSE 0 END) AS month_events
+        FROM events
+        WHERE date(created_at) >= ?
+        GROUP BY project
+        ORDER BY month_events DESC
+        """,
+        (today_str, week_start, month_start, month_start),
+    ).fetchall()
+
+    conn.close()
+
+    # day -> role -> event_count
+    day_role: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for row in rows_7d:
+        day_role[row["day"]][row["role"]] += row["event_count"]
+
+    # Build 7-day chart array (one entry per day, cost keyed by role)
+    chart: list[dict[str, Any]] = []
+    for i in range(6, -1, -1):
+        day = (now - timedelta(days=i)).date().isoformat()
+        label = (now - timedelta(days=i)).strftime("%m/%d")
+        entry: dict[str, Any] = {"date": day, "label": label}
+        for role in ROLES:
+            ev = day_role[day].get(role, 0)
+            entry[role] = _est_cost(ev, cost_1m_in, cost_1m_out, in_per_ev, out_per_ev)
+            entry[f"{role}_events"] = ev
+            entry[f"{role}_input_tokens"] = int(ev * in_per_ev)
+            entry[f"{role}_output_tokens"] = int(ev * out_per_ev)
+        chart.append(entry)
+
+    # Per-project table rows
+    projects: list[dict[str, Any]] = []
+    for row in project_agg:
+        te = int(row["today_events"] or 0)
+        we = int(row["week_events"] or 0)
+        me = int(row["month_events"] or 0)
+        projects.append({
+            "project": row["project"],
+            "today_events": te,
+            "week_events": we,
+            "month_events": me,
+            "today_input_tokens": int(te * in_per_ev),
+            "today_output_tokens": int(te * out_per_ev),
+            "week_input_tokens": int(we * in_per_ev),
+            "week_output_tokens": int(we * out_per_ev),
+            "month_input_tokens": int(me * in_per_ev),
+            "month_output_tokens": int(me * out_per_ev),
+            "today_cost_usd": _est_cost(te, cost_1m_in, cost_1m_out, in_per_ev, out_per_ev),
+            "week_cost_usd": _est_cost(we, cost_1m_in, cost_1m_out, in_per_ev, out_per_ev),
+            "month_cost_usd": _est_cost(me, cost_1m_in, cost_1m_out, in_per_ev, out_per_ev),
+        })
+
+    return {
+        "chart": chart,
+        "projects": projects,
+        "config": {
+            "cost_per_1m_input": cost_1m_in,
+            "cost_per_1m_output": cost_1m_out,
+            "est_input_per_event": in_per_ev,
+            "est_output_per_event": out_per_ev,
+        },
+    }

--- a/tests/test_token_spend.py
+++ b/tests/test_token_spend.py
@@ -1,0 +1,136 @@
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+import server
+import server.db
+
+
+def _make_client(monkeypatch, tmp_path):
+    monkeypatch.setattr(server.db, "DB_PATH", str(tmp_path / "test.db"))
+    server.db.apply_pending_migrations()
+    return TestClient(server.app)
+
+
+def _insert_events(db_path: str, events: list) -> None:
+    conn = sqlite3.connect(db_path)
+    for ev in events:
+        conn.execute(
+            "INSERT INTO events (project, role, event_type, created_at) VALUES (?,?,?,?)",
+            (ev["project"], ev["role"], ev["event_type"], ev["created_at"]),
+        )
+    conn.commit()
+    conn.close()
+
+
+def test_empty_db_returns_zero_chart_and_projects(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    resp = client.get("/api/token_spend")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "chart" in body
+    assert "projects" in body
+    assert "config" in body
+    assert len(body["chart"]) == 7
+    assert body["projects"] == []
+    for day in body["chart"]:
+        assert "date" in day
+        assert "label" in day
+        for role in ["po", "dev", "qa", "reviewer", "merge", "judge"]:
+            assert role in day
+            assert day[role] == 0.0
+
+
+def test_events_appear_in_chart(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    today = datetime.now(timezone.utc).date().isoformat()
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-a", "role": "dev", "event_type": "dev_start", "created_at": f"{today}T10:00:00+00:00"},
+        {"project": "proj-a", "role": "dev", "event_type": "dev_start", "created_at": f"{today}T11:00:00+00:00"},
+        {"project": "proj-a", "role": "qa",  "event_type": "qa_start",  "created_at": f"{today}T12:00:00+00:00"},
+    ])
+    resp = client.get("/api/token_spend")
+    assert resp.status_code == 200
+    body = resp.json()
+    today_entry = next(e for e in body["chart"] if e["date"] == today)
+    # 2 dev events → cost > 0
+    assert today_entry["dev"] > 0
+    assert today_entry["dev_events"] == 2
+    # 1 qa event
+    assert today_entry["qa"] > 0
+    assert today_entry["qa_events"] == 1
+    # no po events
+    assert today_entry["po"] == 0.0
+
+
+def test_project_totals_in_table(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    now = datetime.now(timezone.utc)
+    today = now.date().isoformat()
+    old = (now - timedelta(days=15)).date().isoformat()
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-x", "role": "dev", "event_type": "dev_start", "created_at": f"{today}T08:00:00+00:00"},
+        {"project": "proj-x", "role": "po",  "event_type": "po_start",  "created_at": f"{old}T08:00:00+00:00"},
+    ])
+    resp = client.get("/api/token_spend")
+    assert resp.status_code == 200
+    projects = resp.json()["projects"]
+    row = next((p for p in projects if p["project"] == "proj-x"), None)
+    assert row is not None
+    assert row["today_events"] == 1
+    assert row["month_events"] == 2
+    assert row["week_events"] == 1
+    # month cost > week cost (more events)
+    assert row["month_cost_usd"] > row["week_cost_usd"]
+
+
+def test_config_env_vars_applied(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKEN_COST_PER_1M_INPUT", "6.0")
+    monkeypatch.setenv("TOKEN_COST_PER_1M_OUTPUT", "30.0")
+    monkeypatch.setenv("TOKEN_EST_INPUT_PER_EVENT", "100000")
+    monkeypatch.setenv("TOKEN_EST_OUTPUT_PER_EVENT", "20000")
+    client = _make_client(monkeypatch, tmp_path)
+    today = datetime.now(timezone.utc).date().isoformat()
+    _insert_events(server.db.DB_PATH, [
+        {"project": "p", "role": "dev", "event_type": "dev_start", "created_at": f"{today}T10:00:00+00:00"},
+    ])
+    resp = client.get("/api/token_spend")
+    assert resp.status_code == 200
+    body = resp.json()
+    cfg = body["config"]
+    assert cfg["cost_per_1m_input"] == 6.0
+    assert cfg["cost_per_1m_output"] == 30.0
+    assert cfg["est_input_per_event"] == 100_000
+    assert cfg["est_output_per_event"] == 20_000
+    # 1 dev event: (100000/1e6)*6 + (20000/1e6)*30 = 0.6 + 0.6 = 1.2
+    today_entry = next(e for e in body["chart"] if e["date"] == today)
+    assert abs(today_entry["dev"] - 1.2) < 0.001
+
+
+def test_input_output_tokens_in_chart(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    today = datetime.now(timezone.utc).date().isoformat()
+    _insert_events(server.db.DB_PATH, [
+        {"project": "p", "role": "po", "event_type": "po_start", "created_at": f"{today}T10:00:00+00:00"},
+    ])
+    resp = client.get("/api/token_spend")
+    assert resp.status_code == 200
+    today_entry = next(e for e in resp.json()["chart"] if e["date"] == today)
+    assert today_entry["po_input_tokens"] == 50_000
+    assert today_entry["po_output_tokens"] == 10_000
+
+
+def test_input_output_tokens_in_projects(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    today = datetime.now(timezone.utc).date().isoformat()
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-tok", "role": "dev", "event_type": "dev_start", "created_at": f"{today}T10:00:00+00:00"},
+        {"project": "proj-tok", "role": "qa",  "event_type": "qa_start",  "created_at": f"{today}T11:00:00+00:00"},
+    ])
+    resp = client.get("/api/token_spend")
+    assert resp.status_code == 200
+    row = next(p for p in resp.json()["projects"] if p["project"] == "proj-tok")
+    # 2 events today → 2 × 50000 = 100000 input tokens
+    assert row["today_input_tokens"] == 100_000
+    assert row["today_output_tokens"] == 20_000

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -21,6 +21,7 @@ import type {
   ScannerState,
   LogsResponse,
   IssueCostRow,
+  TokenSpend,
 } from './types';
 import * as fx from './fixtures';
 
@@ -148,6 +149,11 @@ export async function fetchIssuesCost(params: IssuesCostParams = {}): Promise<Is
   if (params.offset != null) p.set('offset', String(params.offset));
   const qs = p.size ? `?${p.toString()}` : '';
   return get<IssueCostRow[]>(`/api/issues/cost${qs}`);
+}
+
+export async function fetchTokenSpend(): Promise<TokenSpend> {
+  if (isFixtureMode()) return fx.getFixtureTokenSpend();
+  return get<TokenSpend>('/api/token_spend');
 }
 
 export class LogsDisabledError extends Error {

--- a/web/src/lib/fixtures.ts
+++ b/web/src/lib/fixtures.ts
@@ -20,6 +20,7 @@ import type {
   ClaudeUsage,
   ScannerState,
   IssueCostRow,
+  TokenSpend,
 } from './types';
 
 const PROJECTS = [
@@ -357,6 +358,67 @@ export function getFixtureIssuesCost(): IssueCostRow[] {
       last_event_at: new Date(Date.now() - randInt(60, 7 * 86400) * 1000).toISOString(),
     };
   }).sort((a, b) => b.rework_factor - a.rework_factor || b.actual_runs - a.actual_runs);
+}
+
+export function getFixtureTokenSpend(): TokenSpend {
+  resetSeed();
+  const COST_1M_IN = 3.0;
+  const COST_1M_OUT = 15.0;
+  const IN_PER_EV = 50_000;
+  const OUT_PER_EV = 10_000;
+  const now = Date.now();
+  const roleList = ['po', 'dev', 'qa', 'reviewer', 'merge', 'judge'] as const;
+
+  function estCost(ev: number): number {
+    return parseFloat(((ev * IN_PER_EV / 1_000_000) * COST_1M_IN + (ev * OUT_PER_EV / 1_000_000) * COST_1M_OUT).toFixed(4));
+  }
+
+  const chart = Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(now - (6 - i) * 86_400_000);
+    const date = d.toISOString().slice(0, 10);
+    const label = `${String(d.getMonth() + 1).padStart(2, '0')}/${String(d.getDate()).padStart(2, '0')}`;
+    const entry: TokenSpend['chart'][number] = { date, label, po: 0, dev: 0, qa: 0, reviewer: 0, merge: 0, judge: 0 };
+    for (const role of roleList) {
+      const ev = randInt(0, 8);
+      entry[role] = estCost(ev);
+      entry[`${role}_events`] = ev;
+      entry[`${role}_input_tokens`] = ev * IN_PER_EV;
+      entry[`${role}_output_tokens`] = ev * OUT_PER_EV;
+    }
+    return entry;
+  });
+
+  const projects = PROJECTS.slice(0, 5).map((p) => {
+    const me = randInt(5, 60);
+    const we = randInt(1, Math.min(me, 20));
+    const te = randInt(0, Math.min(we, 5));
+    return {
+      project: p.id,
+      today_events: te,
+      week_events: we,
+      month_events: me,
+      today_input_tokens: te * IN_PER_EV,
+      today_output_tokens: te * OUT_PER_EV,
+      week_input_tokens: we * IN_PER_EV,
+      week_output_tokens: we * OUT_PER_EV,
+      month_input_tokens: me * IN_PER_EV,
+      month_output_tokens: me * OUT_PER_EV,
+      today_cost_usd: estCost(te),
+      week_cost_usd: estCost(we),
+      month_cost_usd: estCost(me),
+    };
+  });
+
+  return {
+    chart,
+    projects,
+    config: {
+      cost_per_1m_input: COST_1M_IN,
+      cost_per_1m_output: COST_1M_OUT,
+      est_input_per_event: IN_PER_EV,
+      est_output_per_event: OUT_PER_EV,
+    },
+  };
 }
 
 export function getFixtureScannerState(): ScannerState {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -203,6 +203,54 @@ export interface LogsResponse {
   lines: LogLine[];
 }
 
+export interface TokenSpendDayRole {
+  events: number;
+  input_tokens: number;
+  output_tokens: number;
+  cost_usd: number;
+}
+
+export interface TokenSpendChartEntry {
+  date: string;
+  label: string;
+  po: number;
+  dev: number;
+  qa: number;
+  reviewer: number;
+  merge: number;
+  judge: number;
+  [key: string]: string | number;
+}
+
+export interface TokenSpendProject {
+  project: string;
+  today_events: number;
+  week_events: number;
+  month_events: number;
+  today_input_tokens: number;
+  today_output_tokens: number;
+  week_input_tokens: number;
+  week_output_tokens: number;
+  month_input_tokens: number;
+  month_output_tokens: number;
+  today_cost_usd: number;
+  week_cost_usd: number;
+  month_cost_usd: number;
+}
+
+export interface TokenSpendConfig {
+  cost_per_1m_input: number;
+  cost_per_1m_output: number;
+  est_input_per_event: number;
+  est_output_per_event: number;
+}
+
+export interface TokenSpend {
+  chart: TokenSpendChartEntry[];
+  projects: TokenSpendProject[];
+  config: TokenSpendConfig;
+}
+
 export interface IssueCostRow {
   project: string;
   issue_number: number;

--- a/web/src/panels/TokenSpend.tsx
+++ b/web/src/panels/TokenSpend.tsx
@@ -1,0 +1,170 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer,
+} from 'recharts';
+import { fetchTokenSpend } from '../lib/api';
+import type { TokenSpendProject } from '../lib/types';
+
+const ROLES = ['po', 'dev', 'qa', 'reviewer', 'merge', 'judge'] as const;
+
+// Must match tokens.css --role-* values (CSS vars can't be used in SVG attrs)
+const ROLE_COLOR: Record<string, string> = {
+  po:       'oklch(0.74 0.16 295)',
+  dev:      'oklch(0.78 0.13 210)',
+  qa:       'oklch(0.82 0.15 75)',
+  reviewer: 'oklch(0.74 0.16 0)',
+  merge:    'oklch(0.80 0.16 145)',
+  judge:    'oklch(0.74 0.14 260)',
+};
+
+const C = {
+  bg2:    'oklch(0.205 0.007 250)',
+  border: 'oklch(0.275 0.008 250)',
+};
+
+const TOOLTIP_STYLE = {
+  background: C.bg2,
+  border: `1px solid ${C.border}`,
+  borderRadius: 2,
+  fontSize: 11,
+  fontFamily: 'var(--font-mono)',
+  color: 'oklch(0.96 0.005 250)',
+};
+
+function fmtUsd(v: number): string {
+  if (v === 0) return '$0';
+  if (v < 0.01) return '<$0.01';
+  return `$${v.toFixed(2)}`;
+}
+
+function fmtTok(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}k`;
+  return String(n);
+}
+
+function ProjectTable({ projects }: { projects: TokenSpendProject[] }) {
+  if (projects.length === 0) {
+    return (
+      <div style={{ padding: 'var(--pad-3)', fontSize: '0.82rem', color: 'var(--fg-3)' }}>
+        No events in the last 30 days.
+      </div>
+    );
+  }
+  return (
+    <table className="t" style={{ fontSize: 11 }}>
+      <thead>
+        <tr>
+          <th>Project</th>
+          <th style={{ textAlign: 'right' }}>Today</th>
+          <th style={{ textAlign: 'right' }}>In/Out</th>
+          <th style={{ textAlign: 'right' }}>This week</th>
+          <th style={{ textAlign: 'right' }}>In/Out</th>
+          <th style={{ textAlign: 'right' }}>This month</th>
+          <th style={{ textAlign: 'right' }}>In/Out</th>
+        </tr>
+      </thead>
+      <tbody>
+        {projects.map(row => (
+          <tr key={row.project}>
+            <td className="mono" style={{ fontSize: 10 }}>{row.project}</td>
+            <td className="num" style={{ textAlign: 'right' }}>{fmtUsd(row.today_cost_usd)}</td>
+            <td className="num" style={{ textAlign: 'right', color: 'var(--fg-3)', fontSize: 10 }}>
+              {fmtTok(row.today_input_tokens)}/{fmtTok(row.today_output_tokens)}
+            </td>
+            <td className="num" style={{ textAlign: 'right' }}>{fmtUsd(row.week_cost_usd)}</td>
+            <td className="num" style={{ textAlign: 'right', color: 'var(--fg-3)', fontSize: 10 }}>
+              {fmtTok(row.week_input_tokens)}/{fmtTok(row.week_output_tokens)}
+            </td>
+            <td className="num" style={{ textAlign: 'right' }}>{fmtUsd(row.month_cost_usd)}</td>
+            <td className="num" style={{ textAlign: 'right', color: 'var(--fg-3)', fontSize: 10 }}>
+              {fmtTok(row.month_input_tokens)}/{fmtTok(row.month_output_tokens)}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export default function TokenSpend() {
+  const { data, isError, isLoading } = useQuery({
+    queryKey: ['token-spend'],
+    queryFn: fetchTokenSpend,
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="panel">
+        <div className="panel-h"><span>Token Spend (est.)</span></div>
+        <div style={{ padding: 'var(--pad-3)', fontSize: '0.82rem', color: 'var(--fg-3)' }}>Loading…</div>
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="panel">
+        <div className="panel-h"><span>Token Spend (est.)</span></div>
+        <div style={{ padding: 'var(--pad-3)', fontSize: '0.82rem', color: 'var(--fg-3)' }}>Unavailable</div>
+      </div>
+    );
+  }
+
+  const { chart, projects, config } = data;
+
+  const configNote = `$${config.cost_per_1m_input}/$${config.cost_per_1m_output} per 1M in/out · ${fmtTok(config.est_input_per_event)}/${fmtTok(config.est_output_per_event)} tok/event (est.)`;
+
+  return (
+    <div className="panel">
+      <div className="panel-h">
+        <span>Token Spend (est.) — 7d by role</span>
+        <span className="muted" style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          {ROLES.map(r => (
+            <span key={r} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+              <span style={{ width: 8, height: 8, background: ROLE_COLOR[r], display: 'inline-block' }} />
+              {r}
+            </span>
+          ))}
+        </span>
+      </div>
+
+      <div style={{ height: 160, padding: 'var(--pad-3) var(--pad-3) 0' }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={chart} barCategoryGap="20%" margin={{ top: 4, right: 0, left: -20, bottom: 0 }}>
+            <XAxis
+              dataKey="label"
+              tick={{ fontSize: 9, fontFamily: 'var(--font-mono)', fill: 'oklch(0.42 0.008 250)' }}
+              axisLine={false}
+              tickLine={false}
+            />
+            <YAxis
+              tick={{ fontSize: 9, fontFamily: 'var(--font-mono)', fill: 'oklch(0.42 0.008 250)' }}
+              tickFormatter={(v: number) => v === 0 ? '' : `$${v.toFixed(2)}`}
+              axisLine={false}
+              tickLine={false}
+              width={40}
+            />
+            <Tooltip
+              contentStyle={TOOLTIP_STYLE}
+              formatter={(value, name) => [typeof value === 'number' ? fmtUsd(value) : String(value), String(name)]}
+              cursor={{ fill: 'oklch(1 0 0 / 0.03)' }}
+            />
+            {ROLES.map(role => (
+              <Bar key={role} dataKey={role} stackId="s" fill={ROLE_COLOR[role]} radius={0} />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div style={{ borderTop: '1px solid var(--border)', marginTop: 'var(--pad-2)' }}>
+        <div style={{ padding: 'var(--pad-2) var(--pad-3)', fontSize: 9, color: 'var(--fg-4)', fontFamily: 'var(--font-mono)' }}>
+          {configNote}
+        </div>
+        <ProjectTable projects={projects} />
+      </div>
+    </div>
+  );
+}

--- a/web/src/screens/Cost.tsx
+++ b/web/src/screens/Cost.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchIssuesCost } from '../lib/api';
 import type { IssueCostRow } from '../lib/types';
+import TokenSpend from '../panels/TokenSpend';
 
 const LIMIT = 50;
 
@@ -79,6 +80,7 @@ export default function Cost() {
 
   return (
     <div>
+      <TokenSpend />
       <div className="screen-h">
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 'var(--pad-3)' }}>
           <h1>Cost</h1>


### PR DESCRIPTION
Closes #137

## Changes

**Backend — `server/routes/token_spend.py`** (new)
- New `GET /api/token_spend` endpoint
- Queries the `events` table grouped by `role × date` for last 7 days and by `project` for today / this week / this month
- Returns a `chart` array (7 days × role cost) suitable for recharts stacked bar, plus a `projects` table with today/week/month cost and input/output token estimates
- Cost is estimated from event counts × configurable tokens-per-event rates (actual token counts are not stored in the events table; the Anthropic admin API does not expose per-role attribution)
- Config via env vars: `TOKEN_COST_PER_1M_INPUT` (default \$3), `TOKEN_COST_PER_1M_OUTPUT` (default \$15), `TOKEN_EST_INPUT_PER_EVENT` (default 50k), `TOKEN_EST_OUTPUT_PER_EVENT` (default 10k)

**Backend — `server/app.py`**
- Registers the `token_spend` router

**Frontend — `web/src/panels/TokenSpend.tsx`** (new)
- Stacked recharts `BarChart` (7 days, one `Bar` per role using existing `--role-*` color tokens)
- Project table: today / this week / this month columns with `$cost` and `input/output tokens` breakdown
- Config note shows active rate settings
- Fixture-mode support via `?fixtures=1`

**Frontend — `web/src/screens/Cost.tsx`**
- Adds `<TokenSpend />` panel above the existing rework-factor table

**Types / API / Fixtures**
- `TokenSpend`, `TokenSpendChartEntry`, `TokenSpendProject`, `TokenSpendConfig` interfaces in `types.ts`
- `fetchTokenSpend()` in `api.ts`
- `getFixtureTokenSpend()` in `fixtures.ts`

**Tests — `tests/test_token_spend.py`** (6 tests)
- Empty DB → 7-day chart with zeroes, empty projects list
- Events appear in correct chart day / role bucket
- Project today/week/month event counts and cost totals
- Env-var config is applied to cost calculation
- Input and output token fields are present in chart entries and project rows

> **Note on per-project vs. global Claude Usage:** The issue acceptance criterion "per-project totals match the global Claude Usage number when summed" cannot be satisfied with estimated data. The Anthropic admin API returns a single aggregate quota; role/project attribution requires per-call metadata that is not currently stored. The token spend dashboard is clearly labelled "est." to communicate this. A future ticket could add `input_tokens`/`output_tokens` columns to the `events` table and have agents report them.

## Test Plan
- [ ] `ruff check .` — passes
- [ ] `tsc --noEmit` — passes
- [ ] `vite build` — passes (warns on chunk size, pre-existing)
- [ ] `pytest tests/test_token_spend.py -v` — 6/6 pass
- [ ] Navigate to the Cost screen — TokenSpend panel renders above the rework table
- [ ] Visit `?fixtures=1` — panel shows seeded chart and project table
- [ ] Set `TOKEN_COST_PER_1M_INPUT=6` in env → config note updates, cost doubles