### PR TITLE
[LM-130] add in-flight guards for issue_history and pipeline_runs pruning

### DIFF
--- a/scripts/prune.py
+++ b/scripts/prune.py
@@ -65,6 +65,50 @@ def _delete_events(conn: sqlite3.Connection, cutoff: str) -> int:
     return cur.rowcount
 
 
+def _count_issue_history(conn: sqlite3.Connection, cutoff: str) -> int:
+    return conn.execute(
+        """
+        SELECT COUNT(*) FROM issue_history
+        WHERE created_at < ?
+          AND (project, issue_number) NOT IN (
+            SELECT project, issue_number FROM pipeline_runs
+            WHERE completed_at IS NULL
+          )
+        """,
+        (cutoff,),
+    ).fetchone()[0]
+
+
+def _delete_issue_history(conn: sqlite3.Connection, cutoff: str) -> int:
+    cur = conn.execute(
+        """
+        DELETE FROM issue_history
+        WHERE created_at < ?
+          AND (project, issue_number) NOT IN (
+            SELECT project, issue_number FROM pipeline_runs
+            WHERE completed_at IS NULL
+          )
+        """,
+        (cutoff,),
+    )
+    return cur.rowcount
+
+
+def _count_pipeline_runs(conn: sqlite3.Connection, cutoff: str) -> int:
+    return conn.execute(
+        "SELECT COUNT(*) FROM pipeline_runs WHERE created_at < ? AND completed_at IS NOT NULL",
+        (cutoff,),
+    ).fetchone()[0]
+
+
+def _delete_pipeline_runs(conn: sqlite3.Connection, cutoff: str) -> int:
+    cur = conn.execute(
+        "DELETE FROM pipeline_runs WHERE created_at < ? AND completed_at IS NOT NULL",
+        (cutoff,),
+    )
+    return cur.rowcount
+
+
 _TS_COLUMN = {
     "events": "created_at",
     "verdicts": "created_at",
@@ -107,7 +151,9 @@ def run(db_path: str, dry_run: bool = False) -> None:
         if dry_run:
             counts = {}
             counts["events"] = _count_events(conn, _cutoff(horizons["events"]))
-            for table in ("verdicts", "scores", "issue_history", "pipeline_runs"):
+            counts["issue_history"] = _count_issue_history(conn, _cutoff(horizons["issue_history"]))
+            counts["pipeline_runs"] = _count_pipeline_runs(conn, _cutoff(horizons["pipeline_runs"]))
+            for table in ("verdicts", "scores"):
                 counts[table] = _count_simple(conn, table, _cutoff(horizons[table]))
             conn.close()
             parts = " ".join(f"{t}={n}" for t, n in counts.items())
@@ -115,7 +161,9 @@ def run(db_path: str, dry_run: bool = False) -> None:
         else:
             deleted = {}
             deleted["events"] = _delete_events(conn, _cutoff(horizons["events"]))
-            for table in ("verdicts", "scores", "issue_history", "pipeline_runs"):
+            deleted["issue_history"] = _delete_issue_history(conn, _cutoff(horizons["issue_history"]))
+            deleted["pipeline_runs"] = _delete_pipeline_runs(conn, _cutoff(horizons["pipeline_runs"]))
+            for table in ("verdicts", "scores"):
                 deleted[table] = _delete_simple(conn, table, _cutoff(horizons[table]))
             conn.commit()
             conn.execute("VACUUM")

--- a/tests/test_prune.py
+++ b/tests/test_prune.py
@@ -220,3 +220,43 @@ def test_recent_rows_kept(db_path, monkeypatch):
     assert conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] == 1
     assert conn.execute("SELECT COUNT(*) FROM verdicts").fetchone()[0] == 1
     conn.close()
+
+
+def test_prune_preserves_in_flight(db_path, monkeypatch):
+    monkeypatch.setenv("RETAIN_ISSUE_HISTORY_DAYS", "0")
+    monkeypatch.setenv("RETAIN_PIPELINE_RUNS_DAYS", "0")
+    monkeypatch.setenv("RETAIN_EVENTS_DAYS", "0")
+    monkeypatch.setenv("RETAIN_VERDICTS_DAYS", "0")
+    monkeypatch.setenv("RETAIN_SCORES_DAYS", "0")
+
+    conn = _conn(db_path)
+    # completed run (safe to delete) and in-flight run (must survive)
+    _insert_pipeline_run(conn, project="loop-monitor", issue_number=100, completed=True, days_ago=10)
+    _insert_pipeline_run(conn, project="loop-monitor", issue_number=200, completed=False, days_ago=10)
+    # matching issue_history rows
+    conn.execute(
+        "INSERT INTO issue_history (project, issue_number, role, event_type, created_at)"
+        " VALUES ('loop-monitor', 100, 'builder', 'started', ?)",
+        (_ts(10),),
+    )
+    conn.execute(
+        "INSERT INTO issue_history (project, issue_number, role, event_type, created_at)"
+        " VALUES ('loop-monitor', 200, 'builder', 'started', ?)",
+        (_ts(10),),
+    )
+    conn.commit()
+    conn.close()
+
+    run(db_path=db_path, dry_run=False)
+
+    conn = _conn(db_path)
+    runs = conn.execute(
+        "SELECT issue_number FROM pipeline_runs ORDER BY issue_number"
+    ).fetchall()
+    history = conn.execute(
+        "SELECT issue_number FROM issue_history ORDER BY issue_number"
+    ).fetchall()
+    conn.close()
+
+    assert [r[0] for r in runs] == [200], "in-flight pipeline_runs row must survive"
+    assert [r[0] for r in history] == [200], "issue_history for in-flight run must survive"


### PR DESCRIPTION
Closes #130

## Changes

Added four new guarded helpers to `scripts/prune.py` that mirror the existing `_count_events`/`_delete_events` pattern:

- `_count_issue_history` / `_delete_issue_history` — skip rows whose `(project, issue_number)` matches any `pipeline_runs` row with `completed_at IS NULL`
- `_count_pipeline_runs` / `_delete_pipeline_runs` — filter `WHERE created_at < ? AND completed_at IS NOT NULL`, never touching in-flight runs

Updated `run()` to dispatch `issue_history` and `pipeline_runs` through the new helpers. `_count_simple`/`_delete_simple` remain in use only for `verdicts` and `scores`.

Added `test_prune_preserves_in_flight` to `tests/test_prune.py`: seeds one completed and one in-flight pipeline run (both older than cutoff), with matching `issue_history` rows, then asserts only the in-flight rows survive after `prune.run(..., dry_run=False)` with retention=0.

## Test Plan

- `pytest tests/test_prune.py -v` — all 8 tests pass (7 existing + 1 new regression)
- `ruff check .` — clean