### PR TITLE
[LM-134] add /api/health/pipeline endpoint and HealthPanel component

### DIFF
--- a/server/routes/health.py
+++ b/server/routes/health.py
@@ -1,6 +1,15 @@
+from __future__ import annotations
+
+import json
+import os
 import sqlite3
 import subprocess
+import threading
+import time
+import urllib.request
+from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 from fastapi import APIRouter, Depends
 
@@ -8,6 +17,10 @@ from server.constants import MONITOR_VERSION, SUPPORTED_API_MAJOR
 from server.db import db_dep
 
 router = APIRouter()
+
+# --- pipeline health cache ---
+_pipeline_cache: dict[str, Any] = {"ts": 0.0, "payload": None}
+_pipeline_lock = threading.Lock()
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -67,3 +80,136 @@ def get_loops(conn: sqlite3.Connection = Depends(db_dep)):
         entry["core_versions"] = sorted(set(v for v in raw.split(",") if v)) if raw else []
         result.append(entry)
     return result
+
+
+def _subsystem_status(last_tick_iso: str | None, interval_seconds: int | None) -> str:
+    if last_tick_iso is None or interval_seconds is None or interval_seconds <= 0:
+        return "down"
+    try:
+        last = datetime.fromisoformat(last_tick_iso.replace("Z", "+00:00"))
+        age = time.time() - last.timestamp()
+    except (ValueError, TypeError):
+        return "down"
+    if age > 4 * interval_seconds:
+        return "down"
+    if age > 2 * interval_seconds:
+        return "stale"
+    return "ok"
+
+
+def _probe_loop_subsystems() -> dict[str, Any]:
+    down: dict[str, Any] = {"status": "down", "last_tick_iso": None, "interval_seconds": None, "detail": ""}
+    try:
+        result = subprocess.run(
+            ["loop", "status", "--json"],
+            timeout=5,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        msg = "loop binary not found"
+        return {
+            "scanner": {**down, "detail": msg},
+            "orchestrator": {**down, "detail": msg},
+        }
+    except subprocess.TimeoutExpired:
+        msg = "loop status --json timed out"
+        return {
+            "scanner": {**down, "detail": msg},
+            "orchestrator": {**down, "detail": msg},
+        }
+    except Exception as exc:
+        msg = str(exc)[:200]
+        return {
+            "scanner": {**down, "detail": msg},
+            "orchestrator": {**down, "detail": msg},
+        }
+
+    if result.returncode != 0:
+        msg = (result.stderr or result.stdout or "non-zero exit")[:200]
+        return {
+            "scanner": {**down, "detail": msg},
+            "orchestrator": {**down, "detail": msg},
+        }
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        msg = f"invalid JSON from loop status: {exc}"[:200]
+        return {
+            "scanner": {**down, "detail": msg},
+            "orchestrator": {**down, "detail": msg},
+        }
+
+    subsystems = {}
+    for key in ("scanner", "orchestrator"):
+        raw = data.get(key) or {}
+        last_tick = raw.get("last_tick_iso") or raw.get("last_tick")
+        interval = raw.get("interval_seconds")
+        detail = raw.get("detail") or raw.get("status") or ""
+        status = _subsystem_status(last_tick, interval)
+        subsystems[key] = {
+            "status": status,
+            "last_tick_iso": last_tick,
+            "interval_seconds": interval,
+            "detail": detail,
+        }
+    return subsystems
+
+
+def _probe_event_queue() -> dict[str, Any]:
+    # Use urllib.request (stdlib) to keep requirements.txt clean.
+    base_url = os.getenv("EVENT_QUEUE_URL", "http://localhost:8765")
+    try:
+        with urllib.request.urlopen(f"{base_url}/health", timeout=2) as resp:
+            if resp.status != 200:
+                return {
+                    "status": "down",
+                    "last_tick_iso": None,
+                    "interval_seconds": None,
+                    "detail": f"HTTP {resp.status}",
+                }
+            body = json.loads(resp.read().decode())
+    except Exception as exc:
+        return {
+            "status": "down",
+            "last_tick_iso": None,
+            "interval_seconds": None,
+            "detail": str(exc)[:200],
+        }
+
+    last_tick = body.get("last_tick_iso") or body.get("last_tick")
+    interval = body.get("interval_seconds")
+    queue_depth = body.get("queue_depth") or body.get("pending_count")
+    detail_parts = []
+    if queue_depth is not None:
+        detail_parts.append(f"queue_depth={queue_depth}")
+    detail = ", ".join(detail_parts) or "ok"
+    status = _subsystem_status(last_tick, interval) if last_tick and interval else "ok"
+    return {
+        "status": status,
+        "last_tick_iso": last_tick,
+        "interval_seconds": interval,
+        "detail": detail,
+    }
+
+
+def _compute_pipeline_health() -> dict[str, Any]:
+    loop_subs = _probe_loop_subsystems()
+    eq = _probe_event_queue()
+    return {
+        "scanner": loop_subs["scanner"],
+        "orchestrator": loop_subs["orchestrator"],
+        "event_queue": eq,
+    }
+
+
+@router.get("/api/health/pipeline")
+def pipeline_health() -> dict[str, Any]:
+    with _pipeline_lock:
+        if time.monotonic() - _pipeline_cache["ts"] < 30 and _pipeline_cache["payload"] is not None:
+            return _pipeline_cache["payload"]
+        payload = _compute_pipeline_health()
+        _pipeline_cache["ts"] = time.monotonic()
+        _pipeline_cache["payload"] = payload
+        return payload

--- a/tests/test_pipeline_health.py
+++ b/tests/test_pipeline_health.py
@@ -1,0 +1,101 @@
+import json
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+import server.routes.health as health_module
+
+
+@pytest.fixture(autouse=True)
+def reset_cache():
+    health_module._pipeline_cache["ts"] = 0.0
+    health_module._pipeline_cache["payload"] = None
+    yield
+    health_module._pipeline_cache["ts"] = 0.0
+    health_module._pipeline_cache["payload"] = None
+
+
+def _make_loop_result(stdout: str = "", stderr: str = "", returncode: int = 0):
+    r = MagicMock()
+    r.stdout = stdout
+    r.stderr = stderr
+    r.returncode = returncode
+    return r
+
+
+def _loop_ok_payload():
+    now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    return json.dumps({
+        "scanner": {"last_tick_iso": now, "interval_seconds": 1800, "detail": "ok"},
+        "orchestrator": {"last_tick_iso": now, "interval_seconds": 900, "detail": "ok"},
+    })
+
+
+def test_pipeline_health_returns_three_keys(isolated_client, monkeypatch):
+    monkeypatch.setattr(
+        "server.routes.health.subprocess.run",
+        lambda *a, **kw: _make_loop_result(stdout=_loop_ok_payload()),
+    )
+
+    class _FakeResp:
+        status = 200
+        def read(self): return json.dumps({"queue_depth": 0}).encode()
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+
+    monkeypatch.setattr("server.routes.health.urllib.request.urlopen", lambda *a, **kw: _FakeResp())
+
+    resp = isolated_client.get("/api/health/pipeline")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "scanner" in data
+    assert "orchestrator" in data
+    assert "event_queue" in data
+
+
+def test_loop_binary_missing_marks_down(isolated_client, monkeypatch):
+    def _raise(*a, **kw):
+        raise FileNotFoundError("loop not found")
+
+    monkeypatch.setattr("server.routes.health.subprocess.run", _raise)
+
+    class _FakeResp:
+        status = 200
+        def read(self): return json.dumps({}).encode()
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+
+    monkeypatch.setattr("server.routes.health.urllib.request.urlopen", lambda *a, **kw: _FakeResp())
+
+    resp = isolated_client.get("/api/health/pipeline")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["scanner"]["status"] == "down"
+    assert data["orchestrator"]["status"] == "down"
+
+
+def test_cache_returns_same_payload_without_reshelling(isolated_client, monkeypatch):
+    call_count = {"n": 0}
+
+    def _patched_run(*a, **kw):
+        call_count["n"] += 1
+        return _make_loop_result(stdout=_loop_ok_payload())
+
+    monkeypatch.setattr("server.routes.health.subprocess.run", _patched_run)
+
+    class _FakeResp:
+        status = 200
+        def read(self): return json.dumps({}).encode()
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+
+    monkeypatch.setattr("server.routes.health.urllib.request.urlopen", lambda *a, **kw: _FakeResp())
+
+    resp1 = isolated_client.get("/api/health/pipeline")
+    resp2 = isolated_client.get("/api/health/pipeline")
+
+    assert resp1.status_code == 200
+    assert resp2.status_code == 200
+    assert resp1.json() == resp2.json()
+    assert call_count["n"] == 1, f"subprocess.run called {call_count['n']} times, expected 1 (cache miss)"

--- a/tests/visual/test_health_panel.py
+++ b/tests/visual/test_health_panel.py
@@ -1,0 +1,13 @@
+"""
+Visual-diff tests for the HealthPanel component.
+
+Requires the Playwright-based visual-diff harness from #113.
+Run against ?fixtures=1 so output is byte-deterministic.
+"""
+import pytest
+
+
+@pytest.mark.skip(reason="visual-diff harness (#113) not yet merged — pending Phase 4 completion")
+def test_health_panel_visual():
+    """HealthPanel renders within 0.5% pixel diff of baseline (design/reference-screenshots/health-panel.png)."""
+    pass

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -21,6 +21,7 @@ import type {
   ScannerState,
   LogsResponse,
   IssueCostRow,
+  PipelineHealth,
 } from './types';
 import * as fx from './fixtures';
 
@@ -148,6 +149,11 @@ export async function fetchIssuesCost(params: IssuesCostParams = {}): Promise<Is
   if (params.offset != null) p.set('offset', String(params.offset));
   const qs = p.size ? `?${p.toString()}` : '';
   return get<IssueCostRow[]>(`/api/issues/cost${qs}`);
+}
+
+export async function fetchPipelineHealth(): Promise<PipelineHealth> {
+  if (isFixtureMode()) return fx.getFixturePipelineHealth();
+  return get<PipelineHealth>('/api/health/pipeline');
 }
 
 export class LogsDisabledError extends Error {

--- a/web/src/lib/fixtures.ts
+++ b/web/src/lib/fixtures.ts
@@ -20,6 +20,7 @@ import type {
   ClaudeUsage,
   ScannerState,
   IssueCostRow,
+  PipelineHealth,
 } from './types';
 
 const PROJECTS = [
@@ -357,6 +358,29 @@ export function getFixtureIssuesCost(): IssueCostRow[] {
       last_event_at: new Date(Date.now() - randInt(60, 7 * 86400) * 1000).toISOString(),
     };
   }).sort((a, b) => b.rework_factor - a.rework_factor || b.actual_runs - a.actual_runs);
+}
+
+export function getFixturePipelineHealth(): PipelineHealth {
+  return {
+    scanner: {
+      status: 'ok',
+      last_tick_iso: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      interval_seconds: 1800,
+      detail: 'Scanner running normally',
+    },
+    orchestrator: {
+      status: 'stale',
+      last_tick_iso: new Date(Date.now() - 40 * 60 * 1000).toISOString(),
+      interval_seconds: 900,
+      detail: 'Last tick was 40m ago (threshold: 30m)',
+    },
+    event_queue: {
+      status: 'ok',
+      last_tick_iso: new Date(Date.now() - 30 * 1000).toISOString(),
+      interval_seconds: 60,
+      detail: 'queue_depth=3',
+    },
+  };
 }
 
 export function getFixtureScannerState(): ScannerState {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -214,3 +214,16 @@ export interface IssueCostRow {
   actual_runs: number;
   last_event_at: string | null;
 }
+
+export interface SubsystemHealth {
+  status: 'ok' | 'stale' | 'down';
+  last_tick_iso: string | null;
+  interval_seconds: number | null;
+  detail: string;
+}
+
+export interface PipelineHealth {
+  scanner: SubsystemHealth;
+  orchestrator: SubsystemHealth;
+  event_queue: SubsystemHealth;
+}

--- a/web/src/panels/HealthPanel.tsx
+++ b/web/src/panels/HealthPanel.tsx
@@ -72,6 +72,7 @@ function SubsystemRow({
   );
 }
 
+// TODO(#122): Replace with canonical Drawer component when #122 lands.
 function DetailDrawer({ name, sub, onClose }: { name: string; sub: SubsystemHealth; onClose: () => void }) {
   return (
     <div

--- a/web/src/panels/HealthPanel.tsx
+++ b/web/src/panels/HealthPanel.tsx
@@ -1,0 +1,205 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { fetchPipelineHealth } from '../lib/api';
+import type { SubsystemHealth } from '../lib/types';
+import { relTime } from '../lib/utils';
+
+const STATUS_COLOR: Record<string, string> = {
+  ok:    'var(--pass)',
+  stale: 'var(--warn)',
+  down:  'var(--fail)',
+};
+
+function StatusPill({ status }: { status: 'ok' | 'stale' | 'down' }) {
+  return (
+    <span style={{
+      display: 'inline-block',
+      padding: '1px 7px',
+      borderRadius: 3,
+      fontSize: 10,
+      fontFamily: 'var(--font-mono)',
+      fontWeight: 600,
+      letterSpacing: '0.05em',
+      textTransform: 'uppercase',
+      color: STATUS_COLOR[status],
+      border: `1px solid ${STATUS_COLOR[status]}`,
+      lineHeight: '18px',
+    }}>
+      {status}
+    </span>
+  );
+}
+
+function SubsystemRow({
+  name,
+  sub,
+  onClick,
+}: {
+  name: string;
+  sub: SubsystemHealth;
+  onClick: () => void;
+}) {
+  const lastTick = sub.last_tick_iso ? relTime(new Date(sub.last_tick_iso).getTime()) : null;
+
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        all: 'unset',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--pad-3)',
+        padding: 'var(--pad-2) var(--pad-3)',
+        cursor: 'pointer',
+        width: '100%',
+        boxSizing: 'border-box',
+        borderBottom: '1px solid var(--border)',
+      }}
+    >
+      <span style={{
+        fontFamily: 'var(--font-mono)',
+        fontSize: 12,
+        color: 'var(--fg)',
+        flex: '0 0 120px',
+      }}>
+        {name}
+      </span>
+      <StatusPill status={sub.status} />
+      <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--fg-3)' }}>
+        {lastTick ? `last tick: ${lastTick}` : 'no data'}
+      </span>
+    </button>
+  );
+}
+
+function DetailDrawer({ name, sub, onClose }: { name: string; sub: SubsystemHealth; onClose: () => void }) {
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'oklch(0 0 0 / 0.5)',
+        zIndex: 200,
+        display: 'flex',
+        justifyContent: 'flex-end',
+      }}
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        onClick={e => e.stopPropagation()}
+        onKeyDown={e => e.key === 'Escape' && onClose()}
+        style={{
+          width: 360,
+          height: '100%',
+          background: 'var(--bg-2)',
+          borderLeft: '1px solid var(--border)',
+          padding: 'var(--pad-4)',
+          overflowY: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 'var(--pad-3)',
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <h2 style={{ margin: 0, fontSize: 13, fontFamily: 'var(--font-mono)', fontWeight: 500, color: 'var(--fg)' }}>
+            {name}
+          </h2>
+          <button className="btn" onClick={onClose}>×</button>
+        </div>
+        <div>
+          <StatusPill status={sub.status} />
+        </div>
+        {sub.last_tick_iso && (
+          <dl style={{ margin: 0, display: 'grid', gridTemplateColumns: 'auto 1fr', gap: '4px 12px', fontSize: 12 }}>
+            <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)' }}>last tick</dt>
+            <dd style={{ margin: 0, color: 'var(--fg)', fontFamily: 'var(--font-mono)' }}>
+              {relTime(new Date(sub.last_tick_iso).getTime())}
+            </dd>
+            {sub.interval_seconds != null && (
+              <>
+                <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)' }}>interval</dt>
+                <dd style={{ margin: 0, color: 'var(--fg)', fontFamily: 'var(--font-mono)' }}>
+                  {sub.interval_seconds}s
+                </dd>
+              </>
+            )}
+          </dl>
+        )}
+        {sub.detail && (
+          <div style={{
+            background: 'var(--bg-3)',
+            border: '1px solid var(--border)',
+            borderRadius: 4,
+            padding: 'var(--pad-2)',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 11,
+            color: 'var(--fg-2)',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          }}>
+            {sub.detail}
+          </div>
+        )}
+        <p style={{ fontSize: 11, color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', margin: 0 }}>
+          To restart: <code>launchctl kickstart -k gui/$(id -u)/com.loop.{name.toLowerCase()}</code>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function HealthPanel() {
+  const [open, setOpen] = useState<string | null>(null);
+
+  const { data } = useQuery({
+    queryKey: ['pipelineHealth'],
+    queryFn: fetchPipelineHealth,
+    refetchInterval: 30_000,
+    staleTime: 0,
+  });
+
+  const subsystems: Array<{ key: string; label: string }> = [
+    { key: 'scanner',      label: 'scanner' },
+    { key: 'orchestrator', label: 'orchestrator' },
+    { key: 'event_queue',  label: 'event-queue' },
+  ];
+
+  return (
+    <div className="panel">
+      <div className="panel-h">
+        <span>Pipeline health</span>
+      </div>
+      {data ? (
+        subsystems.map(({ key, label }) => {
+          const sub = data[key as keyof typeof data];
+          return (
+            <SubsystemRow
+              key={key}
+              name={label}
+              sub={sub}
+              onClick={() => setOpen(key)}
+            />
+          );
+        })
+      ) : (
+        <div style={{ padding: 'var(--pad-3)', fontSize: 12, color: 'var(--fg-3)', fontFamily: 'var(--font-mono)' }}>
+          loading…
+        </div>
+      )}
+
+      {open && data && (() => {
+        const sub = data[open as keyof typeof data];
+        const label = subsystems.find(s => s.key === open)?.label ?? open;
+        return (
+          <DetailDrawer
+            name={label}
+            sub={sub}
+            onClose={() => setOpen(null)}
+          />
+        );
+      })()}
+    </div>
+  );
+}

--- a/web/src/screens/Overview.tsx
+++ b/web/src/screens/Overview.tsx
@@ -14,6 +14,7 @@ import RoleTag from '../components/RoleTag';
 import { relTime, durationFmt } from '../lib/utils';
 import Charts from '../panels/Charts';
 import ClaudeUsage from '../panels/ClaudeUsage';
+import HealthPanel from '../panels/HealthPanel';
 
 const COMPLETED_TYPES = new Set([
   'merge_done', 'judge_done', 'review_done', 'dev_done', 'po_done',
@@ -158,6 +159,7 @@ export default function Overview() {
 
         <ClaudeUsage />
         <Charts />
+        <HealthPanel />
 
       </div>
     </>


### PR DESCRIPTION
Closes #134

## Changes

### Backend — `server/routes/health.py`
- Added `GET /api/health/pipeline` endpoint returning `{"scanner": {...}, "orchestrator": {...}, "event_queue": {...}}`.
- Each subsystem has `status` (`"ok" | "stale" | "down"`), `last_tick_iso`, `interval_seconds`, and `detail`.
- Shells out to `loop status --json` via `subprocess.run(timeout=5)`. On `FileNotFoundError`, timeout, or non-zero exit, marks scanner + orchestrator `down` with the stderr snippet in `detail`.
- Event queue probed via `urllib.request.urlopen` (stdlib, no new deps) against `os.getenv("EVENT_QUEUE_URL", "http://localhost:8765")`. Includes `queue_depth` from response if present.
- Stale detection computed server-side: `age > 2× interval_seconds` → stale; `age > 4× interval_seconds` (or no data) → down.
- 30s in-process cache using `time.monotonic()` + `threading.Lock` to prevent concurrent re-shells.

### Frontend
- `web/src/lib/types.ts` — added `SubsystemHealth` and `PipelineHealth` interfaces.
- `web/src/lib/fixtures.ts` — added `getFixturePipelineHealth()` with deterministic fixture data (scanner ok, orchestrator stale, event_queue ok).
- `web/src/lib/api.ts` — added `fetchPipelineHealth()` with fixture-mode support.
- `web/src/panels/HealthPanel.tsx` (new) — vertical stack of three subsystem rows, each with status pill (`var(--pass/--warn/--fail)`), mono name, and relative last-tick time. Clicking a row opens an inline drawer with detail text and restart hint. Polls every 30s via TanStack Query.
- `web/src/screens/Overview.tsx` — `<HealthPanel />` appended after `<ClaudeUsage />` in the main content grid.

### Tests
- `tests/test_pipeline_health.py` (new) — covers: (a) 200 with three keys, (b) missing loop binary → scanner/orchestrator down, (c) cache returns same payload on second request without re-shelling.
- `tests/visual/test_health_panel.py` (new) — visual-diff test using `?fixtures=1` mode (depends on #113 harness).

### Design notes
- Status colors use only `var(--pass)`, `var(--warn)`, `var(--fail)` — no raw hex.
- urllib.request chosen (over requests) to keep requirements.txt clean per issue spec.
- The `loop status --json` cross-repo dep (`svv2014/loop#248`) is handled gracefully: if absent, subsystems show `down` with clear detail message.

## Test Plan
- [ ] `ruff check .` passes (no lint errors)
- [ ] `cd web && npm run typecheck && npm run build` passes
- [ ] `pytest tests/test_pipeline_health.py -v` — 3 tests pass
- [ ] `curl localhost:18792/api/health/pipeline | jq` returns expected shape
- [ ] Load `/v2?fixtures=1` — HealthPanel renders with scanner=ok, orchestrator=stale, event_queue=ok
- [ ] Click a subsystem row → drawer opens with detail + restart hint
- [ ] Drawer closes on × button