### PR TITLE
[LM-135] Phase 6.2 · Failure inspector (per-ticket error context)

### DIFF
--- a/server/helpers/github.py
+++ b/server/helpers/github.py
@@ -1,0 +1,118 @@
+"""GitHub API helpers — thin wrappers around the `gh` CLI."""
+
+import json
+import subprocess
+import time
+
+# In-memory cache: (project, kind, number) -> (payload, expires_at)
+_FAILURE_CACHE: dict[tuple[str, str, int], tuple[dict, float]] = {}
+_CACHE_TTL = 60  # seconds
+
+FAILURE_CONTEXT_START = "<!-- failure-context -->"
+FAILURE_CONTEXT_END = "<!-- /failure-context -->"
+
+
+def _parse_failure_comment(body: str) -> dict:
+    """Extract structured fields from a failure-context comment body.
+
+    Returns a dict with all FailureContext fields; excerpt is None if the
+    marker is absent or malformed.
+    """
+    result: dict = {
+        "excerpt": None,
+        "model": None,
+        "run_id": None,
+        "retry_count": 0,
+        "timestamp": None,
+        "github_comment_url": None,
+        "log_path": None,
+    }
+    start = body.find(FAILURE_CONTEXT_START)
+    if start == -1:
+        return result
+    end = body.find(FAILURE_CONTEXT_END, start)
+    if end == -1:
+        return result
+    block = body[start + len(FAILURE_CONTEXT_START):end].strip()
+    if not block:
+        return result
+    try:
+        data = json.loads(block)
+    except (json.JSONDecodeError, ValueError):
+        return result
+    result["excerpt"] = data.get("excerpt") or None
+    result["model"] = data.get("model") or None
+    result["run_id"] = data.get("run_id") or None
+    result["retry_count"] = int(data.get("retry_count") or 0)
+    result["timestamp"] = data.get("timestamp") or None
+    result["log_path"] = data.get("log_path") or None
+    return result
+
+
+def fetch_failure_context(
+    repo: str,
+    kind: str,
+    number: int,
+    project: str,
+    cache_key: tuple[str, str, int],
+) -> dict:
+    """Return the most recent failure-context comment for a GH issue/PR.
+
+    Falls back to an empty payload (excerpt=None) on any error.
+    Caches results for 60 seconds to stay within GH rate limits.
+    """
+    now = time.monotonic()
+    cached = _FAILURE_CACHE.get(cache_key)
+    if cached and now < cached[1]:
+        return cached[0]
+
+    entity = "issues" if kind == "issue" else "pulls"
+    payload = _empty_payload()
+
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repo}/{entity}/{number}/comments",
+             "--jq", "[.[] | {body: .body, url: .html_url, created_at: .created_at}]"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:
+        _FAILURE_CACHE[cache_key] = (payload, now + _CACHE_TTL)
+        return payload
+
+    if result.returncode != 0:
+        _FAILURE_CACHE[cache_key] = (payload, now + _CACHE_TTL)
+        return payload
+
+    try:
+        comments = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError):
+        _FAILURE_CACHE[cache_key] = (payload, now + _CACHE_TTL)
+        return payload
+
+    # Walk from most-recent to find the first comment with the marker
+    for comment in reversed(comments):
+        body = comment.get("body") or ""
+        if FAILURE_CONTEXT_START in body:
+            parsed = _parse_failure_comment(body)
+            parsed["github_comment_url"] = comment.get("url") or None
+            if parsed["timestamp"] is None:
+                parsed["timestamp"] = comment.get("created_at") or None
+            _FAILURE_CACHE[cache_key] = (parsed, now + _CACHE_TTL)
+            return parsed
+
+    _FAILURE_CACHE[cache_key] = (payload, now + _CACHE_TTL)
+    return payload
+
+
+def _empty_payload() -> dict:
+    return {
+        "excerpt": None,
+        "model": None,
+        "run_id": None,
+        "retry_count": 0,
+        "timestamp": None,
+        "github_comment_url": None,
+        "log_path": None,
+    }

--- a/server/routes/action_queue.py
+++ b/server/routes/action_queue.py
@@ -3,10 +3,11 @@ import sqlite3
 from datetime import datetime, timezone
 from typing import Optional
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 
 from server.constants import PROJECTS
 from server.db import db_dep
+from server.helpers.github import fetch_failure_context
 from server.helpers.timeline import parse_ts
 
 router = APIRouter()
@@ -138,3 +139,27 @@ def action_queue(conn: sqlite3.Connection = Depends(db_dep)):
         })
     result.sort(key=lambda x: x["age_seconds"], reverse=True)
     return result
+
+
+@router.get("/api/action_queue/{project}/{kind}/{number}/failure")
+def action_queue_failure(project: str, kind: str, number: int):
+    """Most-recent failure-context comment for a ticket.
+
+    Returns 200 with excerpt=null when no failure comment exists.
+    Returns 400 for invalid kind values.
+    """
+    if kind not in ("issue", "pr"):
+        raise HTTPException(status_code=400, detail="kind must be 'issue' or 'pr'")
+    repo = PROJECTS.get(project)
+    if repo is None:
+        return {
+            "excerpt": None,
+            "model": None,
+            "run_id": None,
+            "retry_count": 0,
+            "timestamp": None,
+            "github_comment_url": None,
+            "log_path": None,
+        }
+    cache_key = (project, kind, number)
+    return fetch_failure_context(repo=repo, kind=kind, number=number, project=project, cache_key=cache_key)

--- a/tests/test_action_queue.py
+++ b/tests/test_action_queue.py
@@ -1,7 +1,10 @@
+import json
 import sqlite3
+from unittest.mock import MagicMock, patch
 
 import server
 import server.db
+import server.helpers.github as gh_helper
 
 
 def test_action_queue_empty(isolated_client):
@@ -157,3 +160,107 @@ def test_action_queue_threshold_seconds_field(isolated_client, monkeypatch):
     assert stuck_item is not None
     assert stuck_item["reason"] == "stuck_label"
     assert stuck_item["threshold_seconds"] is None
+
+
+# ── Failure-context endpoint ──────────────────────────────────────────────────
+
+_COMMENT_WITH_MARKER = json.dumps({
+    "excerpt": "ModuleNotFoundError: No module named 'boba_orchestrator'",
+    "model": "claude-opus-4-5",
+    "run_id": "run-abc123",
+    "retry_count": 2,
+    "timestamp": "2026-05-02T14:30:00Z",
+    "log_path": "/var/log/loop/boba-orchestrator.log",
+})
+
+_GH_COMMENT_BODY = (
+    "PO failed 2x.\n"
+    "<!-- failure-context -->\n"
+    + _COMMENT_WITH_MARKER + "\n"
+    "<!-- /failure-context -->\n"
+)
+
+
+def _make_gh_response(comments: list[dict]) -> str:
+    return json.dumps(comments)
+
+
+def test_failure_endpoint_no_comment(isolated_client, monkeypatch):
+    """Returns 200 with excerpt=null when no failure-context comment exists."""
+    gh_helper._FAILURE_CACHE.clear()
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = _make_gh_response([
+        {"body": "Just a regular comment", "url": "https://gh/c/1", "created_at": "2026-05-01T10:00:00Z"},
+    ])
+
+    with patch("server.helpers.github.subprocess.run", return_value=mock_result):
+        resp = isolated_client.get("/api/action_queue/loop/issue/42/failure")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["excerpt"] is None
+    assert data["retry_count"] == 0
+    assert data["model"] is None
+
+
+def test_failure_endpoint_with_marker(isolated_client, monkeypatch):
+    """Returns parsed payload when a failure-context comment exists."""
+    gh_helper._FAILURE_CACHE.clear()
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = _make_gh_response([
+        {"body": "some old comment", "url": "https://gh/c/1", "created_at": "2026-05-01T10:00:00Z"},
+        {"body": _GH_COMMENT_BODY, "url": "https://gh/c/2", "created_at": "2026-05-02T14:30:00Z"},
+    ])
+
+    with patch("server.helpers.github.subprocess.run", return_value=mock_result):
+        resp = isolated_client.get("/api/action_queue/loop/issue/42/failure")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["excerpt"] == "ModuleNotFoundError: No module named 'boba_orchestrator'"
+    assert data["model"] == "claude-opus-4-5"
+    assert data["run_id"] == "run-abc123"
+    assert data["retry_count"] == 2
+    assert data["timestamp"] == "2026-05-02T14:30:00Z"
+    assert data["log_path"] == "/var/log/loop/boba-orchestrator.log"
+    assert data["github_comment_url"] == "https://gh/c/2"
+
+
+def test_failure_endpoint_malformed_json_in_marker(isolated_client):
+    """Returns excerpt=null when the marker block contains invalid JSON."""
+    gh_helper._FAILURE_CACHE.clear()
+
+    bad_body = "<!-- failure-context -->\nnot-valid-json\n<!-- /failure-context -->"
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = _make_gh_response([
+        {"body": bad_body, "url": "https://gh/c/3", "created_at": "2026-05-02T15:00:00Z"},
+    ])
+
+    with patch("server.helpers.github.subprocess.run", return_value=mock_result):
+        resp = isolated_client.get("/api/action_queue/loop/issue/99/failure")
+
+    assert resp.status_code == 200
+    assert resp.json()["excerpt"] is None
+
+
+def test_failure_endpoint_unknown_project(isolated_client):
+    """Returns empty payload (no GH call) for an unknown project slug."""
+    gh_helper._FAILURE_CACHE.clear()
+
+    with patch("server.helpers.github.subprocess.run") as mock_run:
+        resp = isolated_client.get("/api/action_queue/nonexistent-project/issue/1/failure")
+
+    assert resp.status_code == 200
+    assert resp.json()["excerpt"] is None
+    mock_run.assert_not_called()
+
+
+def test_failure_endpoint_invalid_kind(isolated_client):
+    """Returns 400 for kind values other than 'issue' or 'pr'."""
+    resp = isolated_client.get("/api/action_queue/loop/comment/42/failure")
+    assert resp.status_code == 400

--- a/web/src/components/FailureInspector.tsx
+++ b/web/src/components/FailureInspector.tsx
@@ -1,0 +1,243 @@
+import { useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { fetchFailureContext } from '../lib/api';
+import type { FailureContext } from '../lib/types';
+
+interface Props {
+  project: string;
+  kind: string;
+  number: number;
+  title: string;
+  githubUrl: string | null;
+  onClose: () => void;
+}
+
+async function copyToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  ta.style.position = 'fixed';
+  ta.style.opacity = '0';
+  document.body.appendChild(ta);
+  ta.focus();
+  ta.select();
+  document.execCommand('copy');
+  document.body.removeChild(ta);
+}
+
+const DT_STYLE: React.CSSProperties = {
+  color: 'var(--fg-3)',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 10,
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  alignSelf: 'center',
+};
+
+export default function FailureInspector({ project, kind, number, title, githubUrl, onClose }: Props) {
+  const [copied, setCopied] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['failure', project, kind, number],
+    queryFn: () => fetchFailureContext(project, kind, number),
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+  });
+
+  function handleOverlayClick(e: React.MouseEvent<HTMLDivElement>) {
+    if (e.target === overlayRef.current) onClose();
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Escape') onClose();
+  }
+
+  async function handleCopy() {
+    if (!data?.excerpt) return;
+    await copyToClipboard(data.excerpt);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <div
+      ref={overlayRef}
+      onClick={handleOverlayClick}
+      onKeyDown={handleKeyDown}
+      tabIndex={-1}
+      aria-modal="true"
+      role="dialog"
+      aria-label="Failure inspector"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'oklch(0 0 0 / 0.5)',
+        zIndex: 200,
+        display: 'flex',
+        justifyContent: 'flex-end',
+      }}
+    >
+      <div
+        onClick={e => e.stopPropagation()}
+        style={{
+          width: 400,
+          height: '100%',
+          background: 'var(--bg-2)',
+          borderLeft: '1px solid var(--border)',
+          padding: 'var(--pad-4)',
+          overflowY: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 'var(--pad-3)',
+        }}
+      >
+        {/* Header */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <h2 style={{ margin: 0, fontSize: 13, fontFamily: 'var(--font-mono)', fontWeight: 500, color: 'var(--fg)' }}>
+            {title || `${kind} #${number}`}
+          </h2>
+          <button className="btn" onClick={onClose} aria-label="Close">×</button>
+        </div>
+
+        {/* Metadata */}
+        <dl style={{ margin: 0, display: 'grid', gridTemplateColumns: 'auto 1fr', gap: '6px var(--pad-3)', fontSize: 12 }}>
+          <dt style={DT_STYLE}>Project</dt>
+          <dd style={{ margin: 0 }}>{project}</dd>
+          <dt style={DT_STYLE}>Item</dt>
+          <dd style={{ margin: 0 }} className="mono">{kind} #{number}</dd>
+        </dl>
+
+        <hr style={{ border: 'none', borderTop: '1px solid var(--border)', margin: 0 }} />
+
+        {/* Failure context */}
+        {isLoading ? (
+          <div className="muted" style={{ fontSize: 12 }}>Loading failure context…</div>
+        ) : !data || data.excerpt === null ? (
+          <EmptyState logPath={data?.log_path ?? null} />
+        ) : (
+          <FailureDetail data={{ ...data, excerpt: data.excerpt }} copied={copied} onCopy={handleCopy} />
+        )}
+
+        {/* GitHub link */}
+        {githubUrl && (
+          <a
+            href={githubUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="btn primary"
+            style={{ display: 'inline-block', textAlign: 'center', textDecoration: 'none' }}
+          >
+            View on GitHub
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ logPath }: { logPath: string | null }) {
+  return (
+    <div style={{ fontSize: 12, color: 'var(--fg-3)' }}>
+      {logPath
+        ? <>No failure context yet — see log file at <span className="mono" style={{ color: 'var(--fg-2)' }}>{logPath}</span></>
+        : 'No failure context available.'}
+    </div>
+  );
+}
+
+interface FailureDetailProps {
+  data: FailureContext & { excerpt: string };
+  copied: boolean;
+  onCopy: () => void;
+}
+
+function FailureDetail({ data, copied, onCopy }: FailureDetailProps) {
+  return (
+    <>
+      {/* Excerpt */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--pad-2)' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span style={{ fontSize: 10, fontFamily: 'var(--font-mono)', textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--fg-3)' }}>
+            Error Excerpt
+          </span>
+          <button
+            className="btn"
+            onClick={onCopy}
+            style={{ fontSize: 11 }}
+          >
+            {copied ? 'Copied!' : 'Copy'}
+          </button>
+        </div>
+        <pre
+          style={{
+            margin: 0,
+            padding: 'var(--pad-3)',
+            background: 'var(--bg-1)',
+            border: '1px solid var(--border)',
+            borderRadius: 2,
+            fontFamily: 'var(--font-mono)',
+            fontSize: 11,
+            color: 'var(--fg-fail, var(--fg))',
+            overflowY: 'auto',
+            maxHeight: '50vh',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-all',
+          }}
+        >
+          {data.excerpt}
+        </pre>
+      </div>
+
+      {/* Metadata grid */}
+      <dl style={{ margin: 0, display: 'grid', gridTemplateColumns: 'auto 1fr', gap: '6px var(--pad-3)', fontSize: 12 }}>
+        {data.retry_count > 0 && (
+          <>
+            <dt style={DT_STYLE}>Retries</dt>
+            <dd style={{ margin: 0 }} className="num">{data.retry_count}</dd>
+          </>
+        )}
+        {data.model && (
+          <>
+            <dt style={DT_STYLE}>Model</dt>
+            <dd style={{ margin: 0 }} className="mono">{data.model}</dd>
+          </>
+        )}
+        {data.run_id && (
+          <>
+            <dt style={DT_STYLE}>Run ID</dt>
+            <dd style={{ margin: 0 }} className="mono">{data.run_id}</dd>
+          </>
+        )}
+        {data.timestamp && (
+          <>
+            <dt style={DT_STYLE}>Time</dt>
+            <dd style={{ margin: 0 }} className="mono">{data.timestamp}</dd>
+          </>
+        )}
+        {data.log_path && (
+          <>
+            <dt style={DT_STYLE}>Log path</dt>
+            <dd style={{ margin: 0, wordBreak: 'break-all' }} className="mono">{data.log_path}</dd>
+          </>
+        )}
+      </dl>
+
+      {/* Link to failure comment */}
+      {data.github_comment_url && (
+        <a
+          href={data.github_comment_url}
+          target="_blank"
+          rel="noreferrer"
+          className="btn"
+          style={{ display: 'inline-block', textAlign: 'center', textDecoration: 'none', fontSize: 12 }}
+        >
+          View failure comment on GitHub
+        </a>
+      )}
+    </>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -21,6 +21,7 @@ import type {
   ScannerState,
   LogsResponse,
   IssueCostRow,
+  FailureContext,
 } from './types';
 import * as fx from './fixtures';
 
@@ -148,6 +149,16 @@ export async function fetchIssuesCost(params: IssuesCostParams = {}): Promise<Is
   if (params.offset != null) p.set('offset', String(params.offset));
   const qs = p.size ? `?${p.toString()}` : '';
   return get<IssueCostRow[]>(`/api/issues/cost${qs}`);
+}
+
+export async function fetchFailureContext(
+  project: string,
+  kind: string,
+  number: number,
+): Promise<FailureContext> {
+  return get<FailureContext>(
+    `/api/action_queue/${encodeURIComponent(project)}/${encodeURIComponent(kind)}/${number}/failure`,
+  );
 }
 
 export class LogsDisabledError extends Error {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -203,6 +203,16 @@ export interface LogsResponse {
   lines: LogLine[];
 }
 
+export interface FailureContext {
+  excerpt: string | null;
+  model: string | null;
+  run_id: string | null;
+  retry_count: number;
+  timestamp: string | null;
+  github_comment_url: string | null;
+  log_path: string | null;
+}
+
 export interface IssueCostRow {
   project: string;
   issue_number: number;

--- a/web/src/screens/Queue.tsx
+++ b/web/src/screens/Queue.tsx
@@ -2,6 +2,11 @@ import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchActionQueue } from '../lib/api';
 import type { QueueItem } from '../lib/types';
+import FailureInspector from '../components/FailureInspector';
+
+function isFailureItem(item: QueueItem): boolean {
+  return item.stage === 'needs-clarification' || item.reason === 'qa_fail_repeated';
+}
 
 export type SortCol = 'project' | 'item' | 'stage' | 'age_seconds' | 'reason';
 export type SortDir = 'asc' | 'desc';
@@ -288,7 +293,18 @@ export default function Queue() {
         )}
       </section>
 
-      {selected && <InlineDrawer item={selected} onClose={() => setSelected(null)} />}
+      {selected && isFailureItem(selected) ? (
+        <FailureInspector
+          project={selected.project}
+          kind={selected.kind}
+          number={selected.number}
+          title={selected.title}
+          githubUrl={selected.github_url}
+          onClose={() => setSelected(null)}
+        />
+      ) : selected ? (
+        <InlineDrawer item={selected} onClose={() => setSelected(null)} />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
Closes #135

## Motivation

On 2026-05-02, 12 tickets failed PO due to a \`ModuleNotFoundError\` in boba-orchestrator. The GH comments only read "PO failed 2x — see log", making root-cause investigation require ~30 minutes of grepping a 16 MB log. This PR surfaces that context inline.

## Changes

### Server
- **`server/helpers/github.py`** (new) — fetches the latest GH comments for a ticket via the \`gh\` CLI (exit-code-tolerant, mirrors the pattern in \`health.py\`), parses the \`<!-- failure-context -->…<!-- /failure-context -->\` block as JSON using literal-substring extraction (no regex on user content). Results are cached 60 s in memory keyed by \`(project, kind, number)\` to stay within GH rate limits.
- **`server/routes/action_queue.py`** — adds `GET /api/action_queue/{project}/{kind}/{number}/failure`. Returns 200 with \`{excerpt, model, run_id, retry_count, timestamp, github_comment_url, log_path}\`. \`excerpt\` is \`null\` when no failure comment exists (not 404). Returns 400 for invalid \`kind\` values; returns empty payload for unknown project slugs without calling the GH API.

### Tests
- **`tests/test_action_queue.py`** — 5 new tests: no failure comment → empty payload; comment with valid marker → parsed fields; malformed JSON in marker → \`excerpt: null\`; unknown project → empty, no subprocess call; invalid kind → 400. All 15 tests pass.

### React
- **`web/src/lib/types.ts`** — adds \`FailureContext\` interface.
- **`web/src/lib/api.ts`** — adds \`fetchFailureContext(project, kind, number)\`.
- **`web/src/components/FailureInspector.tsx`** (new) — drawer component using the existing inline-drawer chrome pattern. Calls \`useQuery\` with \`staleTime: Infinity, refetchOnWindowFocus: false\`. Shows: scrollable monospaced excerpt (max-height 50 vh, full text reachable), retry count, model, run ID, timestamp, log path (read-only), copy-to-clipboard (\`navigator.clipboard\` with \`execCommand\` fallback), link to GH comment. Empty state when \`excerpt\` is null. Styled with design-token variables only.
- **`web/src/screens/Queue.tsx`** — row-click opens \`FailureInspector\` when \`stage === 'needs-clarification'\` or \`reason === 'qa_fail_repeated'\`; all other rows continue to use the existing \`InlineDrawer\`.

## Test Plan
- `ruff check .` → clean
- `pytest tests/test_action_queue.py -v` → 15/15 pass
- `cd web && npm run typecheck` → no errors
- `cd web && npm run build` → builds cleanly
- `cd web && npm test` → 29/29 pass
- Click a `needs-clarification` row in the Queue screen → FailureInspector drawer opens
- Click any other row → existing InlineDrawer opens
- Empty state renders when no failure-context comment exists
- Long excerpts scroll within the drawer without pushing it off-screen
- Copy button copies the full excerpt to clipboard