### PR TITLE
[LM-134] add /api/health/pipeline endpoint and HealthPanel component

### DIFF
--- a/server/routes/health.py
+++ b/server/routes/health.py
@@ -1,6 +1,15 @@
+from __future__ import annotations
+
+import json
+import os
 import sqlite3
 import subprocess
+import threading
+import time
+import urllib.request
+from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 from fastapi import APIRouter, Depends
 
@@ -8,6 +17,10 @@ from server.constants import MONITOR_VERSION, SUPPORTED_API_MAJOR
 from server.db import db_dep
 
 router = APIRouter()
+
+# --- pipeline health cache ---
+_pipeline_cache: dict[str, Any] = {"ts": 0.0, "payload": None}
+_pipeline_lock = threading.Lock()
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -67,3 +80,136 @@ def get_loops(conn: sqlite3.Connection = Depends(db_dep)):
         entry["core_versions"] = sorted(set(v for v in raw.split(",") if v)) if raw else []
         result.append(entry)
     return result
+
+
+def _subsystem_status(last_tick_iso: str | None, interval_seconds: int | None) -> str:
+    if last_tick_iso is None or interval_seconds is None or interval_seconds <= 0:
+        return "down"
+    try:
+        last = datetime.fromisoformat(last_tick_iso.replace("Z", "+00:00"))
+        age = time.time() - last.timestamp()
+    except (ValueError, TypeError):
+        return "down"
+    if age > 4 * interval_seconds:
+        return "down"
+    if age > 2 * interval_seconds:
+        return "stale"
+    return "ok"
+
+
+def _probe_loop_subsystems() -> dict[str, Any]:
+    down: dict[str, Any] = {"status": "down", "last_tick_iso": None, "interval_seconds": None, "detail": ""}
+    try:
+        result = subprocess.run(
+            ["loop", "status", "--json"],
+            timeout=5,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        msg = "loop binary not found"
+        return {
+            "scanner": {**down, "detail": msg},
+            "orchestrator": {**down, "detail": msg},
+        }
+    except subprocess.TimeoutExpired:
+        msg = "loop status --json timed out"
+        return {
+            "scanner": {**down, "detail": msg},
+            "orchestrator": {**down, "detail": msg},
+        }
+    except Exception as exc:
+        msg = str(exc)[:200]
+        return {
+            "scanner": {**down, "detail": msg},
+            "orchestrator": {**down, "detail": msg},
+        }
+
+    if result.returncode != 0:
+        msg = (result.stderr or result.stdout or "non-zero exit")[:200]
+        return {
+            "scanner": {**down, "detail": msg},
+            "orchestrator": {**down, "detail": msg},
+        }
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        msg = f"invalid JSON from loop status: {exc}"[:200]
+        return {
+            "scanner": {**down, "detail": msg},
+            "orchestrator": {**down, "detail": msg},
+        }
+
+    subsystems = {}
+    for key in ("scanner", "orchestrator"):
+        raw = data.get(key) or {}
+        last_tick = raw.get("last_tick_iso") or raw.get("last_tick")
+        interval = raw.get("interval_seconds")
+        detail = raw.get("detail") or raw.get("status") or ""
+        status = _subsystem_status(last_tick, interval)
+        subsystems[key] = {
+            "status": status,
+            "last_tick_iso": last_tick,
+            "interval_seconds": interval,
+            "detail": detail,
+        }
+    return subsystems
+
+
+def _probe_event_queue() -> dict[str, Any]:
+    # Use urllib.request (stdlib) to keep requirements.txt clean.
+    base_url = os.getenv("EVENT_QUEUE_URL", "http://localhost:8765")
+    try:
+        with urllib.request.urlopen(f"{base_url}/health", timeout=2) as resp:
+            if resp.status != 200:
+                return {
+                    "status": "down",
+                    "last_tick_iso": None,
+                    "interval_seconds": None,
+                    "detail": f"HTTP {resp.status}",
+                }
+            body = json.loads(resp.read().decode())
+    except Exception as exc:
+        return {
+            "status": "down",
+            "last_tick_iso": None,
+            "interval_seconds": None,
+            "detail": str(exc)[:200],
+        }
+
+    last_tick = body.get("last_tick_iso") or body.get("last_tick")
+    interval = body.get("interval_seconds")
+    queue_depth = body.get("queue_depth") or body.get("pending_count")
+    detail_parts = []
+    if queue_depth is not None:
+        detail_parts.append(f"queue_depth={queue_depth}")
+    detail = ", ".join(detail_parts) or "ok"
+    status = _subsystem_status(last_tick, interval) if last_tick and interval else "ok"
+    return {
+        "status": status,
+        "last_tick_iso": last_tick,
+        "interval_seconds": interval,
+        "detail": detail,
+    }
+
+
+def _compute_pipeline_health() -> dict[str, Any]:
+    loop_subs = _probe_loop_subsystems()
+    eq = _probe_event_queue()
+    return {
+        "scanner": loop_subs["scanner"],
+        "orchestrator": loop_subs["orchestrator"],
+        "event_queue": eq,
+    }
+
+
+@router.get("/api/health/pipeline")
+def pipeline_health() -> dict[str, Any]:
+    with _pipeline_lock:
+        if time.monotonic() - _pipeline_cache["ts"] < 30 and _pipeline_cache["payload"] is not None:
+            return _pipeline_cache["payload"]
+        payload = _compute_pipeline_health()
+        _pipeline_cache["ts"] = time.monotonic()
+        _pipeline_cache["payload"] = payload
+        return payload

--- a/tests/test_pipeline_health.py
+++ b/tests/test_pipeline_health.py
@@ -1,0 +1,101 @@
+import json
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+import server.routes.health as health_module
+
+
+@pytest.fixture(autouse=True)
+def reset_cache():
+    health_module._pipeline_cache["ts"] = 0.0
+    health_module._pipeline_cache["payload"] = None
+    yield
+    health_module._pipeline_cache["ts"] = 0.0
+    health_module._pipeline_cache["payload"] = None
+
+
+def _make_loop_result(stdout: str = "", stderr: str = "", returncode: int = 0):
+    r = MagicMock()
+    r.stdout = stdout
+    r.stderr = stderr
+    r.returncode = returncode
+    return r
+
+
+def _loop_ok_payload():
+    now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    return json.dumps({
+        "scanner": {"last_tick_iso": now, "interval_seconds": 1800, "detail": "ok"},
+        "orchestrator": {"last_tick_iso": now, "interval_seconds": 900, "detail": "ok"},
+    })
+
+
+def test_pipeline_health_returns_three_keys(isolated_client, monkeypatch):
+    monkeypatch.setattr(
+        "server.routes.health.subprocess.run",
+        lambda *a, **kw: _make_loop_result(stdout=_loop_ok_payload()),
+    )
+
+    class _FakeResp:
+        status = 200
+        def read(self): return json.dumps({"queue_depth": 0}).encode()
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+
+    monkeypatch.setattr("server.routes.health.urllib.request.urlopen", lambda *a, **kw: _FakeResp())
+
+    resp = isolated_client.get("/api/health/pipeline")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "scanner" in data
+    assert "orchestrator" in data
+    assert "event_queue" in data
+
+
+def test_loop_binary_missing_marks_down(isolated_client, monkeypatch):
+    def _raise(*a, **kw):
+        raise FileNotFoundError("loop not found")
+
+    monkeypatch.setattr("server.routes.health.subprocess.run", _raise)
+
+    class _FakeResp:
+        status = 200
+        def read(self): return json.dumps({}).encode()
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+
+    monkeypatch.setattr("server.routes.health.urllib.request.urlopen", lambda *a, **kw: _FakeResp())
+
+    resp = isolated_client.get("/api/health/pipeline")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["scanner"]["status"] == "down"
+    assert data["orchestrator"]["status"] == "down"
+
+
+def test_cache_returns_same_payload_without_reshelling(isolated_client, monkeypatch):
+    call_count = {"n": 0}
+
+    def _patched_run(*a, **kw):
+        call_count["n"] += 1
+        return _make_loop_result(stdout=_loop_ok_payload())
+
+    monkeypatch.setattr("server.routes.health.subprocess.run", _patched_run)
+
+    class _FakeResp:
+        status = 200
+        def read(self): return json.dumps({}).encode()
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+
+    monkeypatch.setattr("server.routes.health.urllib.request.urlopen", lambda *a, **kw: _FakeResp())
+
+    resp1 = isolated_client.get("/api/health/pipeline")
+    resp2 = isolated_client.get("/api/health/pipeline")
+
+    assert resp1.status_code == 200
+    assert resp2.status_code == 200
+    assert resp1.json() == resp2.json()
+    assert call_count["n"] == 1, f"subprocess.run called {call_count['n']} times, expected 1 (cache miss)"

--- a/tests/test_pipeline_health_qa.py
+++ b/tests/test_pipeline_health_qa.py
@@ -1,0 +1,200 @@
+"""QA-driven tests for PR #193 — _subsystem_status boundary cases and event-queue degradation.
+
+Covers gaps not exercised by the PR's own test_pipeline_health.py:
+- Direct unit tests of _subsystem_status (ok / stale / down thresholds, invalid input)
+- Endpoint returns 'stale' and 'down' when loop reports aged last_tick_iso values
+- Event-queue non-200 HTTP response marks event_queue as 'down'
+"""
+import json
+import time
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+import server.routes.health as health_module
+from server.routes.health import _subsystem_status
+
+
+@pytest.fixture(autouse=True)
+def reset_cache():
+    health_module._pipeline_cache["ts"] = 0.0
+    health_module._pipeline_cache["payload"] = None
+    yield
+    health_module._pipeline_cache["ts"] = 0.0
+    health_module._pipeline_cache["payload"] = None
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests for _subsystem_status
+# ---------------------------------------------------------------------------
+
+def test_subsystem_status_none_last_tick_is_down():
+    assert _subsystem_status(None, 1800) == "down"
+
+
+def test_subsystem_status_none_interval_is_down():
+    now = datetime.now(timezone.utc).isoformat()
+    assert _subsystem_status(now, None) == "down"
+
+
+def test_subsystem_status_zero_interval_is_down():
+    now = datetime.now(timezone.utc).isoformat()
+    assert _subsystem_status(now, 0) == "down"
+
+
+def test_subsystem_status_negative_interval_is_down():
+    now = datetime.now(timezone.utc).isoformat()
+    assert _subsystem_status(now, -60) == "down"
+
+
+def test_subsystem_status_invalid_iso_is_down():
+    assert _subsystem_status("not-a-date", 1800) == "down"
+
+
+def test_subsystem_status_fresh_tick_is_ok():
+    now = datetime.now(timezone.utc).isoformat()
+    assert _subsystem_status(now, 1800) == "ok"
+
+
+def test_subsystem_status_age_just_under_2x_is_ok():
+    interval = 100
+    age = interval * 2 - 1
+    old = datetime.fromtimestamp(time.time() - age, tz=timezone.utc).isoformat()
+    assert _subsystem_status(old, interval) == "ok"
+
+
+def test_subsystem_status_age_just_over_2x_is_stale():
+    interval = 100
+    age = interval * 2 + 1
+    old = datetime.fromtimestamp(time.time() - age, tz=timezone.utc).isoformat()
+    assert _subsystem_status(old, interval) == "stale"
+
+
+def test_subsystem_status_age_just_under_4x_is_stale():
+    interval = 100
+    age = interval * 4 - 1
+    old = datetime.fromtimestamp(time.time() - age, tz=timezone.utc).isoformat()
+    assert _subsystem_status(old, interval) == "stale"
+
+
+def test_subsystem_status_age_just_over_4x_is_down():
+    interval = 100
+    age = interval * 4 + 1
+    old = datetime.fromtimestamp(time.time() - age, tz=timezone.utc).isoformat()
+    assert _subsystem_status(old, interval) == "down"
+
+
+def test_subsystem_status_accepts_Z_suffix():
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert _subsystem_status(now, 1800) == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Endpoint integration: stale / down status from aged loop ticks
+# ---------------------------------------------------------------------------
+
+def _make_loop_result(stdout="", stderr="", returncode=0):
+    r = MagicMock()
+    r.stdout = stdout
+    r.stderr = stderr
+    r.returncode = returncode
+    return r
+
+
+class _FakeOkResp:
+    status = 200
+    def read(self): return json.dumps({}).encode()
+    def __enter__(self): return self
+    def __exit__(self, *a): pass
+
+
+def _aged_payload(scanner_age_s: int, orch_age_s: int) -> str:
+    scanner_tick = datetime.fromtimestamp(time.time() - scanner_age_s, tz=timezone.utc).isoformat()
+    orch_tick = datetime.fromtimestamp(time.time() - orch_age_s, tz=timezone.utc).isoformat()
+    return json.dumps({
+        "scanner":      {"last_tick_iso": scanner_tick, "interval_seconds": 1800, "detail": ""},
+        "orchestrator": {"last_tick_iso": orch_tick,    "interval_seconds": 900,  "detail": ""},
+    })
+
+
+def test_endpoint_returns_stale_when_scanner_tick_is_old(isolated_client, monkeypatch):
+    # age = 2×interval + 60 → stale; within 4×interval so not down
+    scanner_age = 1800 * 2 + 60
+    orch_age = 10
+    monkeypatch.setattr(
+        "server.routes.health.subprocess.run",
+        lambda *a, **kw: _make_loop_result(stdout=_aged_payload(scanner_age, orch_age)),
+    )
+    monkeypatch.setattr("server.routes.health.urllib.request.urlopen", lambda *a, **kw: _FakeOkResp())
+
+    resp = isolated_client.get("/api/health/pipeline")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["scanner"]["status"] == "stale"
+    assert data["orchestrator"]["status"] == "ok"
+
+
+def test_endpoint_returns_down_when_scanner_tick_very_old(isolated_client, monkeypatch):
+    # age > 4×interval → down
+    scanner_age = 1800 * 4 + 60
+    orch_age = 10
+    monkeypatch.setattr(
+        "server.routes.health.subprocess.run",
+        lambda *a, **kw: _make_loop_result(stdout=_aged_payload(scanner_age, orch_age)),
+    )
+    monkeypatch.setattr("server.routes.health.urllib.request.urlopen", lambda *a, **kw: _FakeOkResp())
+
+    resp = isolated_client.get("/api/health/pipeline")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["scanner"]["status"] == "down"
+    assert data["orchestrator"]["status"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Event-queue degradation: non-200 and exception paths
+# ---------------------------------------------------------------------------
+
+class _FakeNon200Resp:
+    status = 503
+    def read(self): return b""
+    def __enter__(self): return self
+    def __exit__(self, *a): pass
+
+
+def test_event_queue_non200_marks_down(isolated_client, monkeypatch):
+    monkeypatch.setattr(
+        "server.routes.health.subprocess.run",
+        lambda *a, **kw: _make_loop_result(stdout=json.dumps({
+            "scanner":      {"last_tick_iso": datetime.now(timezone.utc).isoformat(), "interval_seconds": 1800, "detail": ""},
+            "orchestrator": {"last_tick_iso": datetime.now(timezone.utc).isoformat(), "interval_seconds": 900,  "detail": ""},
+        })),
+    )
+    monkeypatch.setattr("server.routes.health.urllib.request.urlopen", lambda *a, **kw: _FakeNon200Resp())
+
+    resp = isolated_client.get("/api/health/pipeline")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["event_queue"]["status"] == "down"
+    assert "503" in data["event_queue"]["detail"]
+
+
+def test_event_queue_connection_error_marks_down(isolated_client, monkeypatch):
+    def _raise(*a, **kw):
+        raise OSError("Connection refused")
+
+    monkeypatch.setattr(
+        "server.routes.health.subprocess.run",
+        lambda *a, **kw: _make_loop_result(stdout=json.dumps({
+            "scanner":      {"last_tick_iso": datetime.now(timezone.utc).isoformat(), "interval_seconds": 1800, "detail": ""},
+            "orchestrator": {"last_tick_iso": datetime.now(timezone.utc).isoformat(), "interval_seconds": 900,  "detail": ""},
+        })),
+    )
+    monkeypatch.setattr("server.routes.health.urllib.request.urlopen", _raise)
+
+    resp = isolated_client.get("/api/health/pipeline")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["event_queue"]["status"] == "down"
+    assert "Connection refused" in data["event_queue"]["detail"]

--- a/tests/visual/test_health_panel.py
+++ b/tests/visual/test_health_panel.py
@@ -1,0 +1,13 @@
+"""
+Visual-diff tests for the HealthPanel component.
+
+Requires the Playwright-based visual-diff harness from #113.
+Run against ?fixtures=1 so output is byte-deterministic.
+"""
+import pytest
+
+
+@pytest.mark.skip(reason="visual-diff harness (#113) not yet merged — pending Phase 4 completion")
+def test_health_panel_visual():
+    """HealthPanel renders within 0.5% pixel diff of baseline (design/reference-screenshots/health-panel.png)."""
+    pass

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -21,6 +21,7 @@ import type {
   ScannerState,
   LogsResponse,
   IssueCostRow,
+  PipelineHealth,
 } from './types';
 import * as fx from './fixtures';
 
@@ -148,6 +149,11 @@ export async function fetchIssuesCost(params: IssuesCostParams = {}): Promise<Is
   if (params.offset != null) p.set('offset', String(params.offset));
   const qs = p.size ? `?${p.toString()}` : '';
   return get<IssueCostRow[]>(`/api/issues/cost${qs}`);
+}
+
+export async function fetchPipelineHealth(): Promise<PipelineHealth> {
+  if (isFixtureMode()) return fx.getFixturePipelineHealth();
+  return get<PipelineHealth>('/api/health/pipeline');
 }
 
 export class LogsDisabledError extends Error {

--- a/web/src/lib/fixtures.ts
+++ b/web/src/lib/fixtures.ts
@@ -20,6 +20,7 @@ import type {
   ClaudeUsage,
   ScannerState,
   IssueCostRow,
+  PipelineHealth,
 } from './types';
 
 const PROJECTS = [
@@ -357,6 +358,29 @@ export function getFixtureIssuesCost(): IssueCostRow[] {
       last_event_at: new Date(Date.now() - randInt(60, 7 * 86400) * 1000).toISOString(),
     };
   }).sort((a, b) => b.rework_factor - a.rework_factor || b.actual_runs - a.actual_runs);
+}
+
+export function getFixturePipelineHealth(): PipelineHealth {
+  return {
+    scanner: {
+      status: 'ok',
+      last_tick_iso: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      interval_seconds: 1800,
+      detail: 'Scanner running normally',
+    },
+    orchestrator: {
+      status: 'stale',
+      last_tick_iso: new Date(Date.now() - 40 * 60 * 1000).toISOString(),
+      interval_seconds: 900,
+      detail: 'Last tick was 40m ago (threshold: 30m)',
+    },
+    event_queue: {
+      status: 'ok',
+      last_tick_iso: new Date(Date.now() - 30 * 1000).toISOString(),
+      interval_seconds: 60,
+      detail: 'queue_depth=3',
+    },
+  };
 }
 
 export function getFixtureScannerState(): ScannerState {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -214,3 +214,16 @@ export interface IssueCostRow {
   actual_runs: number;
   last_event_at: string | null;
 }
+
+export interface SubsystemHealth {
+  status: 'ok' | 'stale' | 'down';
+  last_tick_iso: string | null;
+  interval_seconds: number | null;
+  detail: string;
+}
+
+export interface PipelineHealth {
+  scanner: SubsystemHealth;
+  orchestrator: SubsystemHealth;
+  event_queue: SubsystemHealth;
+}

--- a/web/src/panels/HealthPanel.tsx
+++ b/web/src/panels/HealthPanel.tsx
@@ -1,0 +1,205 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { fetchPipelineHealth } from '../lib/api';
+import type { SubsystemHealth } from '../lib/types';
+import { relTime } from '../lib/utils';
+
+const STATUS_COLOR: Record<string, string> = {
+  ok:    'var(--pass)',
+  stale: 'var(--warn)',
+  down:  'var(--fail)',
+};
+
+function StatusPill({ status }: { status: 'ok' | 'stale' | 'down' }) {
+  return (
+    <span style={{
+      display: 'inline-block',
+      padding: '1px 7px',
+      borderRadius: 3,
+      fontSize: 10,
+      fontFamily: 'var(--font-mono)',
+      fontWeight: 600,
+      letterSpacing: '0.05em',
+      textTransform: 'uppercase',
+      color: STATUS_COLOR[status],
+      border: `1px solid ${STATUS_COLOR[status]}`,
+      lineHeight: '18px',
+    }}>
+      {status}
+    </span>
+  );
+}
+
+function SubsystemRow({
+  name,
+  sub,
+  onClick,
+}: {
+  name: string;
+  sub: SubsystemHealth;
+  onClick: () => void;
+}) {
+  const lastTick = sub.last_tick_iso ? relTime(new Date(sub.last_tick_iso).getTime()) : null;
+
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        all: 'unset',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--pad-3)',
+        padding: 'var(--pad-2) var(--pad-3)',
+        cursor: 'pointer',
+        width: '100%',
+        boxSizing: 'border-box',
+        borderBottom: '1px solid var(--border)',
+      }}
+    >
+      <span style={{
+        fontFamily: 'var(--font-mono)',
+        fontSize: 12,
+        color: 'var(--fg)',
+        flex: '0 0 120px',
+      }}>
+        {name}
+      </span>
+      <StatusPill status={sub.status} />
+      <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--fg-3)' }}>
+        {lastTick ? `last tick: ${lastTick}` : 'no data'}
+      </span>
+    </button>
+  );
+}
+
+function DetailDrawer({ name, sub, onClose }: { name: string; sub: SubsystemHealth; onClose: () => void }) {
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'oklch(0 0 0 / 0.5)',
+        zIndex: 200,
+        display: 'flex',
+        justifyContent: 'flex-end',
+      }}
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        onClick={e => e.stopPropagation()}
+        onKeyDown={e => e.key === 'Escape' && onClose()}
+        style={{
+          width: 360,
+          height: '100%',
+          background: 'var(--bg-2)',
+          borderLeft: '1px solid var(--border)',
+          padding: 'var(--pad-4)',
+          overflowY: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 'var(--pad-3)',
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <h2 style={{ margin: 0, fontSize: 13, fontFamily: 'var(--font-mono)', fontWeight: 500, color: 'var(--fg)' }}>
+            {name}
+          </h2>
+          <button className="btn" onClick={onClose}>×</button>
+        </div>
+        <div>
+          <StatusPill status={sub.status} />
+        </div>
+        {sub.last_tick_iso && (
+          <dl style={{ margin: 0, display: 'grid', gridTemplateColumns: 'auto 1fr', gap: '4px 12px', fontSize: 12 }}>
+            <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)' }}>last tick</dt>
+            <dd style={{ margin: 0, color: 'var(--fg)', fontFamily: 'var(--font-mono)' }}>
+              {relTime(new Date(sub.last_tick_iso).getTime())}
+            </dd>
+            {sub.interval_seconds != null && (
+              <>
+                <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)' }}>interval</dt>
+                <dd style={{ margin: 0, color: 'var(--fg)', fontFamily: 'var(--font-mono)' }}>
+                  {sub.interval_seconds}s
+                </dd>
+              </>
+            )}
+          </dl>
+        )}
+        {sub.detail && (
+          <div style={{
+            background: 'var(--bg-3)',
+            border: '1px solid var(--border)',
+            borderRadius: 4,
+            padding: 'var(--pad-2)',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 11,
+            color: 'var(--fg-2)',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          }}>
+            {sub.detail}
+          </div>
+        )}
+        <p style={{ fontSize: 11, color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', margin: 0 }}>
+          To restart: <code>launchctl kickstart -k gui/$(id -u)/com.loop.{name.toLowerCase()}</code>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function HealthPanel() {
+  const [open, setOpen] = useState<string | null>(null);
+
+  const { data } = useQuery({
+    queryKey: ['pipelineHealth'],
+    queryFn: fetchPipelineHealth,
+    refetchInterval: 30_000,
+    staleTime: 0,
+  });
+
+  const subsystems: Array<{ key: string; label: string }> = [
+    { key: 'scanner',      label: 'scanner' },
+    { key: 'orchestrator', label: 'orchestrator' },
+    { key: 'event_queue',  label: 'event-queue' },
+  ];
+
+  return (
+    <div className="panel">
+      <div className="panel-h">
+        <span>Pipeline health</span>
+      </div>
+      {data ? (
+        subsystems.map(({ key, label }) => {
+          const sub = data[key as keyof typeof data];
+          return (
+            <SubsystemRow
+              key={key}
+              name={label}
+              sub={sub}
+              onClick={() => setOpen(key)}
+            />
+          );
+        })
+      ) : (
+        <div style={{ padding: 'var(--pad-3)', fontSize: 12, color: 'var(--fg-3)', fontFamily: 'var(--font-mono)' }}>
+          loading…
+        </div>
+      )}
+
+      {open && data && (() => {
+        const sub = data[open as keyof typeof data];
+        const label = subsystems.find(s => s.key === open)?.label ?? open;
+        return (
+          <DetailDrawer
+            name={label}
+            sub={sub}
+            onClose={() => setOpen(null)}
+          />
+        );
+      })()}
+    </div>
+  );
+}

--- a/web/src/screens/Overview.tsx
+++ b/web/src/screens/Overview.tsx
@@ -14,6 +14,7 @@ import RoleTag from '../components/RoleTag';
 import { relTime, durationFmt } from '../lib/utils';
 import Charts from '../panels/Charts';
 import ClaudeUsage from '../panels/ClaudeUsage';
+import HealthPanel from '../panels/HealthPanel';
 
 const COMPLETED_TYPES = new Set([
   'merge_done', 'judge_done', 'review_done', 'dev_done', 'po_done',
@@ -158,6 +159,7 @@ export default function Overview() {
 
         <ClaudeUsage />
         <Charts />
+        <HealthPanel />
 
       </div>
     </>


### PR DESCRIPTION
Closes #134

## Changes

### Backend (`server/routes/health.py`)
- Added `GET /api/health/pipeline` endpoint returning `{scanner, orchestrator, event_queue}` objects, each with `status`, `last_tick_iso`, `interval_seconds`, and `detail`.
- Shells out to `loop status --json` via `subprocess.run([...], timeout=5)` for scanner + orchestrator; on `FileNotFoundError`, timeout, or non-zero exit the subsystems are marked `down` with the stderr snippet in `detail`.
- Event queue probed via `urllib.request.urlopen` (stdlib only, no new deps) at `EVENT_QUEUE_URL` env var (default `http://localhost:8765`).
- 30-second in-process cache using `time.monotonic()` + `threading.Lock`.
- Server-side stale detection: `> 2×interval` → `stale`, `> 4×interval` (or no data) → `down`.

### Frontend
- `web/src/lib/types.ts` — added `SubsystemHealth` and `PipelineHealth` interfaces.
- `web/src/lib/fixtures.ts` — added `getFixturePipelineHealth()` with deterministic fixture data (scanner=ok, orchestrator=stale, event_queue=ok).
- `web/src/lib/api.ts` — added `fetchPipelineHealth()` mirroring existing fetch patterns; respects `?fixtures=1` mode.
- `web/src/panels/HealthPanel.tsx` — new panel: vertical stack of three subsystem rows with status pills using `var(--pass)`, `var(--warn)`, `var(--fail)` tokens only. Click row opens inline detail drawer with last-tick age, interval, detail text, and restart hint. Polls every 30s via TanStack Query.
- `web/src/screens/Overview.tsx` — `<HealthPanel />` mounted after `<Charts />`.

### Tests
- `tests/test_pipeline_health.py` — three tests: (a) endpoint returns 200 with all three keys, (b) missing `loop` binary marks scanner+orchestrator `down`, (c) cache serves same payload on second call without re-shelling (`subprocess.run` called exactly once). Uses `monkeypatch` on `subprocess.run` and `urllib.request.urlopen`.
- `tests/visual/test_health_panel.py` — placeholder marked `@pytest.mark.skip` pending visual-diff harness from #113.
- `design/reference-screenshots/health-panel.png` — placeholder; to be replaced with real capture once #113 harness is available.

### Note on `loop status --json`
If `svv2014/loop#248` has not shipped yet, the endpoint degrades gracefully: scanner and orchestrator show `status: "down"` with `detail: "loop binary not found"`. No partial feature — it's safe to deploy regardless of whether the CLI dep is available.

## Test Plan
- `ruff check .` — passes
- `tsc --noEmit` — passes
- `npm run build` — passes
- `pytest tests/test_pipeline_health.py -v` — 3/3 pass