### PR TITLE
[LM-109] add /api/anomalies SQL endpoint for anomaly detection

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -18,6 +18,7 @@ app = FastAPI(title="Loop Monitor", lifespan=lifespan)
 
 from server.routes import (  # noqa: E402
     action_queue,
+    anomalies,
     board,
     claude_usage,
     config,
@@ -35,6 +36,7 @@ from server.routes import (  # noqa: E402
 
 app.include_router(health.router)
 app.include_router(ingest.router)
+app.include_router(anomalies.router)
 app.include_router(board.router)
 app.include_router(feed.router)
 app.include_router(runs.router)

--- a/server/routes/anomalies.py
+++ b/server/routes/anomalies.py
@@ -1,0 +1,52 @@
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse
+
+from server.db import db_dep
+
+router = APIRouter()
+
+
+@router.get("/api/anomalies")
+def get_anomalies(
+    project: Optional[str] = Query(default=None),
+    window_hours: Optional[str] = Query(default=None),
+    threshold: Optional[str] = Query(default=None),
+    conn: sqlite3.Connection = Depends(db_dep),
+):
+    # Validate required params
+    params = [("project", project), ("window_hours", window_hours), ("threshold", threshold)]
+    missing = [p for p, v in params if v is None]
+    if missing:
+        return JSONResponse(status_code=400, content={"error": f"Missing required parameters: {', '.join(missing)}"})
+
+    # Validate numeric params
+    try:
+        window_hours_f = float(window_hours)
+    except (ValueError, TypeError):
+        return JSONResponse(status_code=400, content={"error": "window_hours must be numeric"})
+
+    try:
+        threshold_i = int(threshold)
+    except (ValueError, TypeError):
+        return JSONResponse(status_code=400, content={"error": "threshold must be an integer"})
+
+    since = (datetime.now(timezone.utc) - timedelta(hours=window_hours_f)).isoformat()
+    rows = conn.execute(
+        """
+        SELECT issue_number, COUNT(*) AS touches
+        FROM events
+        WHERE project = :project
+          AND event_type IN ('label_transition', 'reconcile_check')
+          AND created_at > :since
+          AND issue_number IS NOT NULL
+        GROUP BY issue_number
+        HAVING COUNT(*) >= :threshold
+        ORDER BY touches DESC
+        """,
+        {"project": project, "since": since, "threshold": threshold_i},
+    ).fetchall()
+    return [{"issue_number": r["issue_number"], "touches": r["touches"]} for r in rows]

--- a/tests/test_anomalies.py
+++ b/tests/test_anomalies.py
@@ -1,0 +1,145 @@
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+import server.db
+
+
+def _insert_event(conn, project, event_type, issue_number, created_at):
+    conn.execute(
+        """
+        INSERT INTO events (project, role, event_type, issue_number, created_at)
+        VALUES (?, 'dev', ?, ?, ?)
+        """,
+        (project, event_type, issue_number, created_at),
+    )
+    conn.commit()
+
+
+def _now_iso():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _hours_ago_iso(hours):
+    return (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
+
+
+# ── (a) no events → empty list ────────────────────────────────────────────────
+
+def test_no_events_returns_empty(isolated_client):
+    resp = isolated_client.get("/api/anomalies?project=myproject&window_hours=24&threshold=2")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+# ── (b) one issue over threshold → returned ───────────────────────────────────
+
+def test_issue_over_threshold_returned(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    for _ in range(3):
+        _insert_event(conn, "proj", "label_transition", 42, _now_iso())
+    conn.close()
+
+    resp = isolated_client.get("/api/anomalies?project=proj&window_hours=24&threshold=2")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["issue_number"] == 42
+    assert data[0]["touches"] == 3
+
+
+# ── (c) one issue below threshold → not returned ──────────────────────────────
+
+def test_issue_below_threshold_excluded(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _insert_event(conn, "proj", "label_transition", 99, _now_iso())
+    conn.close()
+
+    resp = isolated_client.get("/api/anomalies?project=proj&window_hours=24&threshold=3")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert all(item["issue_number"] != 99 for item in data)
+
+
+# ── (d) events outside the window → not counted ───────────────────────────────
+
+def test_events_outside_window_not_counted(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    old_ts = _hours_ago_iso(48)
+    for _ in range(5):
+        _insert_event(conn, "proj-old", "label_transition", 7, old_ts)
+    conn.close()
+
+    resp = isolated_client.get("/api/anomalies?project=proj-old&window_hours=24&threshold=2")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+# ── (e) wrong event_type → not counted ────────────────────────────────────────
+
+def test_wrong_event_type_not_counted(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    for _ in range(5):
+        _insert_event(conn, "proj-et", "dev_done", 55, _now_iso())
+    conn.close()
+
+    resp = isolated_client.get("/api/anomalies?project=proj-et&window_hours=24&threshold=2")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+# ── unknown project → empty list (no error) ───────────────────────────────────
+
+def test_unknown_project_returns_empty(isolated_client):
+    resp = isolated_client.get("/api/anomalies?project=no-such-project&window_hours=24&threshold=1")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+# ── 400 for missing params ────────────────────────────────────────────────────
+
+def test_missing_all_params_returns_400(isolated_client):
+    resp = isolated_client.get("/api/anomalies")
+    assert resp.status_code == 400
+
+
+def test_missing_project_returns_400(isolated_client):
+    resp = isolated_client.get("/api/anomalies?window_hours=24&threshold=2")
+    assert resp.status_code == 400
+
+
+def test_missing_window_hours_returns_400(isolated_client):
+    resp = isolated_client.get("/api/anomalies?project=p&threshold=2")
+    assert resp.status_code == 400
+
+
+def test_missing_threshold_returns_400(isolated_client):
+    resp = isolated_client.get("/api/anomalies?project=p&window_hours=24")
+    assert resp.status_code == 400
+
+
+# ── 400 for non-numeric params ────────────────────────────────────────────────
+
+def test_non_numeric_window_hours_returns_400(isolated_client):
+    resp = isolated_client.get("/api/anomalies?project=p&window_hours=abc&threshold=2")
+    assert resp.status_code == 400
+
+
+def test_non_numeric_threshold_returns_400(isolated_client):
+    resp = isolated_client.get("/api/anomalies?project=p&window_hours=24&threshold=xyz")
+    assert resp.status_code == 400
+
+
+# ── both event types counted ─────────────────────────────────────────────────
+
+def test_both_event_types_counted(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _insert_event(conn, "proj-both", "label_transition", 10, _now_iso())
+    _insert_event(conn, "proj-both", "reconcile_check", 10, _now_iso())
+    conn.close()
+
+    resp = isolated_client.get("/api/anomalies?project=proj-both&window_hours=24&threshold=2")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["issue_number"] == 10
+    assert data[0]["touches"] == 2


### PR DESCRIPTION
Closes #109

## Changes

### loop-monitor (this PR)
- `server/routes/anomalies.py` — new `GET /api/anomalies` endpoint that queries the `events` table for issues with high `label_transition`/`reconcile_check` event counts within a rolling time window
- `server/app.py` — registers the new anomalies router
- `tests/test_anomalies.py` — pytest coverage: no-events, over-threshold, below-threshold, outside-window, wrong-event-type, missing/invalid params

### loop (separate PR needed)
The reconciler changes (`scanner/reconciler.sh` + `tests/anomaly-detector.bats`) are out of scope for this PR and will be handled in the loop repo. See issue #109 for the full cross-repo scope.

## Endpoint
`GET /api/anomalies?project=<slug>&window_hours=<N>&threshold=<M>`
- Returns `[{"issue_number": int, "touches": int}, ...]` sorted by touches desc
- 200 + empty array when no anomalies or unknown project
- 400 for missing or non-numeric params

## Test Plan
- Run `pytest tests/test_anomalies.py -v` — all 13 cases pass
- Manually: `curl "http://localhost:8000/api/anomalies?project=test&window_hours=24&threshold=2"` → `[]`
- Confirm 400 on missing params: `curl -v "http://localhost:8000/api/anomalies"` → 400