### PR TITLE
[LM-110] Per-ticket timeline view — API + frontend + event_audit

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -29,6 +29,7 @@ from server.routes import (  # noqa: E402
     runs,
     scanner_state,
     stats,
+    timeline,
 )
 
 app.include_router(health.router)
@@ -43,6 +44,7 @@ app.include_router(claude_usage.router)
 app.include_router(issues_cost.router)
 app.include_router(logs.router)
 app.include_router(scanner_state.router)
+app.include_router(timeline.router)
 
 if os.path.isdir("static/dist"):
     app.mount("/v2", StaticFiles(directory="static/dist", html=True), name="dist")

--- a/server/db.py
+++ b/server/db.py
@@ -83,6 +83,21 @@ MIGRATIONS = [
         "ALTER TABLE pipeline_runs ADD COLUMN issue_lifetime_seconds INTEGER; "
         "ALTER TABLE pipeline_runs ADD COLUMN pr_lifetime_seconds INTEGER",
     ),
+    (
+        "0004_event_audit",
+        """
+        CREATE TABLE IF NOT EXISTS event_audit (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            project TEXT NOT NULL,
+            issue_number INTEGER NOT NULL,
+            pr_number INTEGER,
+            ts TEXT NOT NULL,
+            type TEXT NOT NULL,
+            payload TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_event_audit_ticket ON event_audit (project, issue_number)
+        """,
+    ),
 ]
 
 
@@ -98,6 +113,10 @@ def _migration_already_applied(conn: sqlite3.Connection, version_id: str) -> boo
     if version_id == "0003_add_pipeline_run_cols":
         cols = {r[1] for r in conn.execute("PRAGMA table_info(pipeline_runs)")}
         return "issue_lifetime_seconds" in cols
+    if version_id == "0004_event_audit":
+        return bool(conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='event_audit'"
+        ).fetchone())
     return False
 
 

--- a/server/routes/timeline.py
+++ b/server/routes/timeline.py
@@ -1,0 +1,48 @@
+import json
+import sqlite3
+
+from fastapi import APIRouter, Depends
+
+from server.db import db_dep
+
+router = APIRouter()
+
+
+@router.get("/api/timeline")
+def timeline(
+    slug: str,
+    num: int,
+    include_skips: bool = False,
+    conn: sqlite3.Connection = Depends(db_dep),
+):
+    where_clauses = ["project = ?", "issue_number = ?"]
+    params: list = [slug, num]
+
+    if not include_skips:
+        where_clauses.append(
+            "NOT (type = 'reconcile_check' AND json_extract(payload, '$.decision') = 'skip')"
+        )
+
+    where_sql = "WHERE " + " AND ".join(where_clauses)
+
+    rows = conn.execute(
+        f"""
+        SELECT id, ts, type, payload, pr_number
+        FROM event_audit
+        {where_sql}
+        ORDER BY ts ASC, id ASC
+        """,
+        params,
+    ).fetchall()
+
+    events = []
+    for r in rows:
+        entry = dict(r)
+        if entry["payload"]:
+            try:
+                entry["payload"] = json.loads(entry["payload"])
+            except (json.JSONDecodeError, TypeError):
+                pass
+        events.append(entry)
+
+    return {"events": events}

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,0 +1,93 @@
+import json
+import sqlite3
+
+import server.db
+
+
+def _insert_audit(
+    db_path: str, project: str, issue_number: int, ts: str, type_: str,
+    payload: dict | None = None, pr_number: int | None = None,
+):
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO event_audit (project, issue_number, pr_number, ts, type, payload) VALUES (?, ?, ?, ?, ?, ?)",
+        (project, issue_number, pr_number, ts, type_, json.dumps(payload) if payload is not None else None),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_timeline_happy_path(isolated_client):
+    db = server.db.DB_PATH
+    _insert_audit(db, "myproj", 42, "2026-01-01T10:00:00Z", "label_change", {"from": "open", "to": "in-progress"})
+    _insert_audit(db, "myproj", 42, "2026-01-01T11:00:00Z", "handler_run", {"handler": "dev"})
+    _insert_audit(db, "myproj", 42, "2026-01-01T12:00:00Z", "merge", None)
+
+    resp = isolated_client.get("/api/timeline?slug=myproj&num=42")
+    assert resp.status_code == 200
+
+    data = resp.json()
+    assert "events" in data
+    events = data["events"]
+    assert len(events) == 3
+    assert events[0]["type"] == "label_change"
+    assert events[1]["type"] == "handler_run"
+    assert events[2]["type"] == "merge"
+    # ascending order by ts
+    assert events[0]["ts"] < events[1]["ts"] < events[2]["ts"]
+    # payload deserialized
+    assert events[0]["payload"] == {"from": "open", "to": "in-progress"}
+    assert events[2]["payload"] is None
+
+
+def test_timeline_empty(isolated_client):
+    resp = isolated_client.get("/api/timeline?slug=no-such-project&num=999")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data == {"events": []}
+
+
+def test_timeline_skip_filter_default(isolated_client):
+    """reconcile_check with decision=skip is hidden by default."""
+    db = server.db.DB_PATH
+    _insert_audit(db, "proj-skip", 1, "2026-01-01T09:00:00Z", "label_change")
+    _insert_audit(db, "proj-skip", 1, "2026-01-01T09:01:00Z", "reconcile_check",
+                  {"decision": "skip", "reason": "workflow-aware"})
+    _insert_audit(db, "proj-skip", 1, "2026-01-01T09:02:00Z", "reconcile_check", {"decision": "run"})
+
+    resp = isolated_client.get("/api/timeline?slug=proj-skip&num=1")
+    assert resp.status_code == 200
+    events = resp.json()["events"]
+    types = [e["type"] for e in events]
+    # skip is filtered, run is kept
+    assert types.count("label_change") == 1
+    assert types.count("reconcile_check") == 1
+    assert events[1]["payload"]["decision"] == "run"
+
+
+def test_timeline_include_skips(isolated_client):
+    """include_skips=true reveals reconcile_check decision=skip events."""
+    db = server.db.DB_PATH
+    _insert_audit(db, "proj-skips2", 2, "2026-01-01T08:00:00Z", "reconcile_check", {"decision": "skip"})
+    _insert_audit(db, "proj-skips2", 2, "2026-01-01T08:01:00Z", "reconcile_check", {"decision": "run"})
+
+    resp = isolated_client.get("/api/timeline?slug=proj-skips2&num=2&include_skips=true")
+    assert resp.status_code == 200
+    events = resp.json()["events"]
+    assert len(events) == 2
+    decisions = [e["payload"]["decision"] for e in events]
+    assert "skip" in decisions
+    assert "run" in decisions
+
+
+def test_timeline_isolates_by_project(isolated_client):
+    """Events from a different project are not returned."""
+    db = server.db.DB_PATH
+    _insert_audit(db, "proj-a", 10, "2026-01-01T07:00:00Z", "merge")
+    _insert_audit(db, "proj-b", 10, "2026-01-01T07:01:00Z", "handler_run")
+
+    resp = isolated_client.get("/api/timeline?slug=proj-a&num=10")
+    assert resp.status_code == 200
+    events = resp.json()["events"]
+    assert len(events) == 1
+    assert events[0]["type"] == "merge"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import Overview from './screens/Overview';
 import Logs from './screens/Logs';
 import ProjectDetail from './screens/ProjectDetail';
 import Queue from './screens/Queue';
+import Timeline from './screens/Timeline';
 import WorkerDetail from './screens/WorkerDetail';
 import Cost from './screens/Cost';
 import { useHashRoute } from './router';
@@ -22,13 +23,14 @@ const SCREEN_KEYS: Record<string, string> = {
 };
 
 export default function App() {
-  const { screen: hashScreen, projectId: hashProjectId, navigateTo } = useHashRoute();
+  const { screen: hashScreen, projectId: hashProjectId, issueNum: hashIssueNum, navigateTo } = useHashRoute();
 
   // Derive UI screen from hash. 'project' is a sub-state of 'projects' nav item.
   const [navScreen, setNavScreen] = useState<string>(
-    hashScreen === 'project' ? 'projects' : hashScreen,
+    hashScreen === 'project' ? 'projects' : hashScreen === 'timeline' ? 'projects' : hashScreen,
   );
   const [projectId, setProjectId] = useState<string | null>(hashProjectId);
+  const [issueNum, setIssueNum] = useState<number | null>(hashIssueNum);
   const [allProjectIds, setAllProjectIds] = useState<string[]>([]);
 
   // Fetch all known project IDs from /api/status for the project switcher
@@ -44,18 +46,25 @@ export default function App() {
 
   // When the hash changes externally (back/forward), sync local state
   useEffect(() => {
-    if (hashScreen === 'project' && hashProjectId) {
+    if (hashScreen === 'timeline' && hashProjectId && hashIssueNum != null) {
       setNavScreen('projects');
       setProjectId(hashProjectId);
-    } else if (hashScreen !== 'project') {
+      setIssueNum(hashIssueNum);
+    } else if (hashScreen === 'project' && hashProjectId) {
+      setNavScreen('projects');
+      setProjectId(hashProjectId);
+      setIssueNum(null);
+    } else if (hashScreen !== 'project' && hashScreen !== 'timeline') {
       setNavScreen(hashScreen);
+      setIssueNum(null);
     }
-  }, [hashScreen, hashProjectId]);
+  }, [hashScreen, hashProjectId, hashIssueNum]);
 
   function handleNavChange(s: string) {
     setNavScreen(s);
     if (s !== 'projects') {
       setProjectId(null);
+      setIssueNum(null);
       if (s !== 'cost') {
         navigateTo(s as 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs');
       }
@@ -64,16 +73,34 @@ export default function App() {
 
   function handleProjectChange(id: string) {
     setProjectId(id);
+    setIssueNum(null);
     navigateTo('project', id);
   }
 
   function handleBack() {
     setProjectId(null);
+    setIssueNum(null);
     navigateTo('overview');
     setNavScreen('overview');
   }
 
-  const isProjectDetail = navScreen === 'projects' && projectId != null;
+  function handleTimelineOpen(slug: string, num: number) {
+    setProjectId(slug);
+    setIssueNum(num);
+    navigateTo('timeline', slug, num);
+  }
+
+  function handleTimelineBack() {
+    if (projectId) {
+      setIssueNum(null);
+      navigateTo('project', projectId);
+    } else {
+      handleBack();
+    }
+  }
+
+  const isTimeline = navScreen === 'projects' && projectId != null && issueNum != null;
+  const isProjectDetail = navScreen === 'projects' && projectId != null && issueNum == null;
 
   const activeQuery = useQuery({
     queryKey: ['active'],
@@ -108,14 +135,21 @@ export default function App() {
     <div className="app">
       <Logo />
       <TopBar events={events} online={online} version={version} />
-      <NavRail screen={isProjectDetail ? 'projects' : navScreen} setScreen={handleNavChange} />
+      <NavRail screen={(isProjectDetail || isTimeline) ? 'projects' : navScreen} setScreen={handleNavChange} />
       <main className="main">
-        {isProjectDetail && projectId != null ? (
+        {isTimeline && projectId != null && issueNum != null ? (
+          <Timeline
+            projectId={projectId}
+            issueNum={issueNum}
+            onBack={handleTimelineBack}
+          />
+        ) : isProjectDetail && projectId != null ? (
           <ProjectDetail
             projectId={projectId}
             allProjectIds={allProjectIds.length > 0 ? allProjectIds : [projectId]}
             onBack={handleBack}
             onProjectChange={handleProjectChange}
+            onTimelineOpen={handleTimelineOpen}
           />
         ) : navScreen === 'overview' ? (
           <Overview />

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -203,6 +203,18 @@ export interface LogsResponse {
   lines: LogLine[];
 }
 
+export interface TimelineEvent {
+  id: number;
+  ts: string;
+  type: string;
+  payload: Record<string, unknown> | null;
+  pr_number: number | null;
+}
+
+export interface TimelineResponse {
+  events: TimelineEvent[];
+}
+
 export interface IssueCostRow {
   project: string;
   issue_number: number;

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -1,22 +1,31 @@
 import { useCallback, useEffect, useState } from 'react';
 
-export type Screen = 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs';
+export type Screen = 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs' | 'timeline';
 
 export interface HashRoute {
   screen: Screen;
   projectId: string | null;
+  issueNum: number | null;
 }
 
 function parseHash(hash: string): HashRoute {
-  // Format: #project=<id>
+  // #timeline=<slug>&num=<N>
+  const tm = hash.match(/^#timeline=([^&]+)&num=(\d+)$/);
+  if (tm) {
+    return { screen: 'timeline', projectId: decodeURIComponent(tm[1]), issueNum: parseInt(tm[2], 10) };
+  }
+  // #project=<id>
   const m = hash.match(/^#project=(.+)$/);
   if (m) {
-    return { screen: 'project', projectId: decodeURIComponent(m[1]) };
+    return { screen: 'project', projectId: decodeURIComponent(m[1]), issueNum: null };
   }
-  return { screen: 'overview', projectId: null };
+  return { screen: 'overview', projectId: null, issueNum: null };
 }
 
-function buildHash(screen: Screen, projectId: string | null): string {
+function buildHash(screen: Screen, projectId: string | null, issueNum: number | null = null): string {
+  if (screen === 'timeline' && projectId && issueNum != null) {
+    return `#timeline=${encodeURIComponent(projectId)}&num=${issueNum}`;
+  }
   if (screen === 'project' && projectId) {
     return `#project=${encodeURIComponent(projectId)}`;
   }
@@ -32,10 +41,10 @@ export function useHashRoute() {
     return () => window.removeEventListener('hashchange', handler);
   }, []);
 
-  const navigateTo = useCallback((screen: Screen, projectId: string | null = null) => {
-    const hash = buildHash(screen, projectId);
+  const navigateTo = useCallback((screen: Screen, projectId: string | null = null, issueNum: number | null = null) => {
+    const hash = buildHash(screen, projectId, issueNum);
     history.replaceState(null, '', window.location.pathname + window.location.search + hash);
-    setRoute({ screen, projectId });
+    setRoute({ screen, projectId, issueNum });
   }, []);
 
   return { ...route, navigateTo };

--- a/web/src/screens/ProjectDetail.tsx
+++ b/web/src/screens/ProjectDetail.tsx
@@ -15,6 +15,7 @@ interface ProjectDetailProps {
   allProjectIds: string[];
   onBack: () => void;
   onProjectChange: (id: string) => void;
+  onTimelineOpen: (slug: string, num: number) => void;
 }
 
 const ROLE_COLORS: Record<string, string> = {
@@ -58,7 +59,7 @@ function fmtDuration(secs: number | null): string {
   return m ? `${h}h ${m}m` : `${h}h`;
 }
 
-export default function ProjectDetail({ projectId, allProjectIds, onBack, onProjectChange }: ProjectDetailProps) {
+export default function ProjectDetail({ projectId, allProjectIds, onBack, onProjectChange, onTimelineOpen }: ProjectDetailProps) {
   const [runs, setRuns] = useState<PipelineRun[]>([]);
   const [prs, setPrs] = useState<PRMonitorEntry[]>([]);
   const [feed, setFeed] = useState<FeedItem[]>([]);
@@ -226,7 +227,15 @@ export default function ProjectDetail({ projectId, allProjectIds, onBack, onProj
                 )}
                 {issues.map(i => (
                   <tr key={i.num}>
-                    <td className="mono" style={{ color: 'var(--fg)' }}>#{i.num}</td>
+                    <td className="mono" style={{ color: 'var(--fg)' }}>
+                      <button
+                        className="btn"
+                        style={{ padding: '1px 5px', fontSize: 11 }}
+                        onClick={() => onTimelineOpen(projectId, i.num)}
+                      >
+                        #{i.num}
+                      </button>
+                    </td>
                     <td>
                       <span className="tag" style={{
                         color: i.status === 'merged'  ? 'var(--role-merge)'

--- a/web/src/screens/Timeline.tsx
+++ b/web/src/screens/Timeline.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useState } from 'react';
+import type { TimelineEvent, TimelineResponse } from '../lib/types';
+
+interface TimelineProps {
+  projectId: string;
+  issueNum: number;
+  onBack: () => void;
+}
+
+const TYPE_BADGE: Record<string, { label: string; color: string }> = {
+  label_change:    { label: 'label',     color: 'var(--role-po)' },
+  reconcile_check: { label: 'reconcile', color: 'var(--fg-3)' },
+  handler_run:     { label: 'handler',   color: 'var(--role-dev)' },
+  merge:           { label: 'merge',     color: 'var(--role-merge)' },
+  pr_opened:       { label: 'pr',        color: 'var(--role-reviewer)' },
+  qa_run:          { label: 'qa',        color: 'var(--role-qa)' },
+};
+
+function typeBadge(type: string): { label: string; color: string } {
+  return TYPE_BADGE[type] ?? { label: type, color: 'var(--fg-2)' };
+}
+
+function fmtTs(ts: string): string {
+  try {
+    const d = new Date(ts.includes('T') ? ts : ts + 'Z');
+    return d.toLocaleString(undefined, {
+      month: 'short', day: 'numeric',
+      hour: '2-digit', minute: '2-digit', second: '2-digit',
+    });
+  } catch {
+    return ts;
+  }
+}
+
+export default function Timeline({ projectId, issueNum, onBack }: TimelineProps) {
+  const [events, setEvents] = useState<TimelineEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [includeSkips, setIncludeSkips] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(false);
+    const qs = `slug=${encodeURIComponent(projectId)}&num=${issueNum}&include_skips=${includeSkips}`;
+    fetch(`/api/timeline?${qs}`)
+      .then(r => r.ok ? r.json() : Promise.reject(r.status))
+      .then((data: TimelineResponse) => { setEvents(data.events); setLoading(false); })
+      .catch(() => { setError(true); setLoading(false); });
+  }, [projectId, issueNum, includeSkips]);
+
+  return (
+    <div data-testid="timeline">
+      {/* Header */}
+      <div className="screen-h" style={{ display: 'flex', alignItems: 'center', gap: 'var(--pad-3)', padding: 'var(--pad-2) var(--pad-4)' }}>
+        <button className="btn" onClick={onBack}>← Back</button>
+        <h1 style={{ flex: 1, margin: 0, fontFamily: 'var(--font-mono)', fontSize: 13, fontWeight: 500, letterSpacing: '0.04em' }}>
+          <span className="muted">timeline /</span> {projectId} <span className="muted">·</span> #{issueNum}
+        </h1>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, cursor: 'pointer', color: 'var(--fg-2)' }}>
+          <input
+            type="checkbox"
+            checked={includeSkips}
+            onChange={e => setIncludeSkips(e.target.checked)}
+          />
+          show reconcile skips
+        </label>
+      </div>
+
+      {/* Body */}
+      <div style={{ padding: 'var(--pad-4)' }}>
+        {loading && (
+          <div className="muted" style={{ fontSize: 12 }}>Loading…</div>
+        )}
+        {error && (
+          <div style={{ color: 'var(--fail)', fontSize: 12 }}>Failed to load timeline.</div>
+        )}
+        {!loading && !error && events.length === 0 && (
+          <div className="muted" style={{ fontSize: 12, textAlign: 'center', padding: 'var(--pad-4)' }}>
+            No events recorded for this ticket.
+          </div>
+        )}
+        {!loading && !error && events.length > 0 && (
+          <div style={{ position: 'relative', paddingLeft: 24 }}>
+            {/* Vertical connector line */}
+            <div style={{
+              position: 'absolute', left: 7, top: 8, bottom: 8,
+              width: 2, background: 'var(--border)',
+            }} />
+
+            {events.map((ev, idx) => {
+              const badge = typeBadge(ev.type);
+              return (
+                <div key={ev.id} style={{ position: 'relative', marginBottom: idx < events.length - 1 ? 20 : 0 }}>
+                  {/* Dot */}
+                  <div style={{
+                    position: 'absolute', left: -20, top: 3,
+                    width: 8, height: 8,
+                    borderRadius: '50%',
+                    background: badge.color,
+                    border: '2px solid var(--bg)',
+                  }} />
+
+                  <div className="panel" style={{ padding: 'var(--pad-2) var(--pad-3)' }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: ev.payload ? 6 : 0 }}>
+                      <span className="tag" style={{ color: badge.color, borderColor: badge.color, fontSize: 10 }}>
+                        {badge.label}
+                      </span>
+                      <span className="mono muted" style={{ fontSize: 11 }}>{fmtTs(ev.ts)}</span>
+                      {ev.pr_number != null && (
+                        <span className="muted" style={{ fontSize: 11 }}>PR #{ev.pr_number}</span>
+                      )}
+                    </div>
+
+                    {ev.payload && (
+                      <pre style={{
+                        margin: 0,
+                        fontSize: 11,
+                        fontFamily: 'var(--font-mono)',
+                        color: 'var(--fg-2)',
+                        whiteSpace: 'pre-wrap',
+                        wordBreak: 'break-all',
+                      }}>
+                        {JSON.stringify(ev.payload, null, 2)}
+                      </pre>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #110

## Changes

**Backend:**
- `server/db.py`: Added migration `0004_event_audit` creating the `event_audit` table (`id, project, issue_number, pr_number, ts, type, payload`) with an index on `(project, issue_number)`. Note: this PR includes the table schema since dependency #109 is still open.
- `server/routes/timeline.py`: New `GET /api/timeline?slug=X&num=N` route. Reads from `event_audit`, returns `{ events: [...] }` ordered by `ts ASC`. `reconcile_check` events with `payload.decision = 'skip'` are filtered by default; pass `include_skips=true` to reveal them.
- `server/app.py`: Registered `timeline` router.

**Frontend:**
- `web/src/router.tsx`: Added `'timeline'` to `Screen` type; added `issueNum` field to `HashRoute`; parse/build `#timeline=<slug>&num=<N>` hash pattern.
- `web/src/screens/Timeline.tsx`: Vertical timeline component with type badges (label_change, reconcile_check, handler_run, merge, etc.); unknown types render with neutral badge. Toggle checkbox to show/hide reconcile skips. Empty state message when no events exist.
- `web/src/App.tsx`: Handle `isTimeline` state; render `<Timeline>` when `projectId + issueNum` are set; pass `onTimelineOpen` to `ProjectDetail`.
- `web/src/screens/ProjectDetail.tsx`: Issue number column in "Recent issues" table is now a button that opens the timeline for that ticket.
- `web/src/lib/types.ts`: Added `TimelineEvent` and `TimelineResponse` interfaces.

**Tests:**
- `tests/test_timeline.py`: 5 tests covering happy path, empty result, skip-filter default behaviour, `include_skips=true`, and project isolation.

## Test Plan
- `ruff check .` — passes
- `npm run typecheck && npm run build` — passes
- `pytest tests/test_timeline.py -v` — 5/5 pass
- Navigate to a project in the dashboard → click an issue number → timeline page opens
- Toggle "show reconcile skips" checkbox → skipped reconcile_check events appear/disappear
- Visit a project+issue with no audit events → "No events recorded for this ticket" is shown