### PR TITLE
[LM-196] make project and role required in ReportPayload — fix silent data loss on POST /api/report

### DIFF
--- a/server/models.py
+++ b/server/models.py
@@ -16,8 +16,8 @@ class ReportPayload(BaseModel):
     core_version: Optional[str] = None
     timestamp: Optional[str] = None
 
-    project: Optional[str] = None
-    role: Optional[str] = None
+    project: str
+    role: str
     model: Optional[str] = None
     event_type: Optional[str] = None
     event: Optional[str] = None        # alias for event_type (v1.0 schema)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -95,6 +95,40 @@ def test_loop_id_null_when_absent(isolated_client):
     assert row[0] is None
 
 
+def test_missing_project_returns_422(isolated_client):
+    resp = isolated_client.post("/api/report", json={
+        "role": "builder",
+        "event_type": "started",
+    })
+    assert resp.status_code == 422
+
+
+def test_missing_role_returns_422(isolated_client):
+    resp = isolated_client.post("/api/report", json={
+        "project": "proj-a",
+        "event_type": "started",
+    })
+    assert resp.status_code == 422
+
+
+def test_full_payload_accepted_and_persisted(isolated_client):
+    import time
+    resp = isolated_client.post("/api/report", json={
+        "project": "proj-full",
+        "role": "builder",
+        "event_type": "started",
+    })
+    assert resp.status_code == 202
+    assert resp.json()["status"] == "accepted"
+    time.sleep(0.05)  # background task
+    conn = sqlite3.connect(server.db.DB_PATH)
+    count = conn.execute(
+        "SELECT COUNT(*) FROM events WHERE project='proj-full'"
+    ).fetchone()[0]
+    conn.close()
+    assert count == 1
+
+
 def test_concurrent_reports_both_persisted(shared_client):
     """Concurrent POST /api/report writes must both persist (WAL + busy_timeout)."""
     import threading


### PR DESCRIPTION
Closes #196

## Changes

- **`server/models.py`**: Changed `project` and `role` from `Optional[str] = None` to `str` (required, no default). FastAPI now rejects requests missing either field with HTTP 422 before any background task is scheduled, eliminating the silent data-loss path where SQLite's NOT NULL constraint was silently swallowing the error.
- **`tests/test_ingest.py`**: Added three new test cases:
  - `test_missing_project_returns_422` — POST without `project` → 422
  - `test_missing_role_returns_422` — POST without `role` → 422
  - `test_full_payload_accepted_and_persisted` — full payload → 202 and row inserted in `events`

No other files were modified. No new dependencies.

## Test Plan

- `pytest tests/test_ingest.py -v` — all 12 tests pass (9 existing + 3 new)
- `ruff check .` — no lint errors