### PR TITLE
[LM-197] fix ROLES reviewer → review so review stage in_flight/cap are correct

### DIFF
--- a/server/routes/scanner_state.py
+++ b/server/routes/scanner_state.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter
 
 router = APIRouter()
 
-ROLES = ["po", "dev", "qa", "reviewer", "merge"]
+ROLES = ["po", "dev", "qa", "review", "merge"]
 
 # Matches loop's current retry policy; update here if loop ever exposes the limit
 RETRY_MAX = 2

--- a/tests/test_scanner_state.py
+++ b/tests/test_scanner_state.py
@@ -112,7 +112,7 @@ class TestScannerLogCapParsing:
             "[2026-05-09 10:00:00] [scanner] loop-po-handler max=4 (per-tick emit cap)\n"
             "[2026-05-09 10:00:00] [scanner] loop-dev-handler max=4 (per-tick emit cap)\n"
             "[2026-05-09 10:00:00] [scanner] loop-qa-handler max=4 (per-tick emit cap)\n"
-            "[2026-05-09 10:00:00] [scanner] loop-reviewer-handler max=4 (per-tick emit cap)\n"
+            "[2026-05-09 10:00:00] [scanner] loop-review-handler max=4 (per-tick emit cap)\n"
             "[2026-05-09 10:00:00] [scanner] loop-merge-handler max=4 (per-tick emit cap)\n"
         )
 
@@ -186,3 +186,35 @@ class TestHelperCountInflight:
 
         monkeypatch.setattr("server.routes.scanner_state.subprocess.run", raise_err)
         assert ss_module._count_inflight("dev") == 0
+
+    def test_review_role_uses_review_handler(self, monkeypatch):
+        calls = []
+
+        def capture(*a, **kw):
+            calls.append(a[0])
+            return _make_subprocess_mock(stdout="1234\n", returncode=0)
+
+        monkeypatch.setattr("server.routes.scanner_state.subprocess.run", capture)
+        result = ss_module._count_inflight("review")
+        assert result == 1
+        assert calls[0] == ["pgrep", "-f", "loop-review-handler"]
+
+
+class TestReviewCapParsing:
+    """_read_caps picks up loop-review-handler cap lines (not loop-reviewer-handler)."""
+
+    def test_review_handler_cap_parsed(self, tmp_path):
+        log = tmp_path / "loop-scanner.log"
+        log.write_text(
+            "[2026-05-09 10:00:00] [scanner] loop-review-handler max=3 (per-tick emit cap)\n"
+        )
+        caps = ss_module._read_caps(log)
+        assert caps["review"] == 3
+
+    def test_reviewer_handler_not_matched(self, tmp_path):
+        log = tmp_path / "loop-scanner.log"
+        log.write_text(
+            "[2026-05-09 10:00:00] [scanner] loop-reviewer-handler max=3 (per-tick emit cap)\n"
+        )
+        caps = ss_module._read_caps(log)
+        assert caps["review"] is None

--- a/web/src/lib/fixtures.ts
+++ b/web/src/lib/fixtures.ts
@@ -365,7 +365,7 @@ export function getFixtureScannerState(): ScannerState {
       po:       { in_flight: 1, cap: 4 },
       dev:      { in_flight: 2, cap: 4 },
       qa:       { in_flight: 0, cap: 4 },
-      reviewer: { in_flight: 1, cap: 4 },
+      review: { in_flight: 1, cap: 4 },
       merge:    { in_flight: 0, cap: 2 },
     },
     retries: [

--- a/web/src/panels/ScannerState.tsx
+++ b/web/src/panels/ScannerState.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchScannerState } from '../lib/api';
 import type { RetryRow } from '../lib/types';
 
-const ROLES = ['po', 'dev', 'qa', 'reviewer', 'merge'] as const;
+const ROLES = ['po', 'dev', 'qa', 'review', 'merge'] as const;
 
 interface Props {
   projectId: string;


### PR DESCRIPTION
Closes #197

## Changes

- **`server/routes/scanner_state.py`**: Changed `"reviewer"` → `"review"` in `ROLES`. This makes `f"loop-{role}-handler"` produce `loop-review-handler`, matching the actual process name in `ALLOWED_HANDLERS` (logs.py). Previously `loop-reviewer-handler` never matched pgrep or log lines so `in_flight` was always 0 and `cap` always null for the review stage.

- **`web/src/panels/ScannerState.tsx`**: Updated the frontend `ROLES` array from `'reviewer'` → `'review'` so it reads `stages["review"]` from the API response (consistent with the backend fix).

- **`web/src/lib/fixtures.ts`**: Updated fixture data key from `reviewer` → `review` to match the corrected API shape.

- **`tests/test_scanner_state.py`**: 
  - Fixed existing cap-parsing test log line from `loop-reviewer-handler` → `loop-review-handler`.
  - Added `test_review_role_uses_review_handler`: verifies `_count_inflight("review")` calls pgrep with `loop-review-handler`.
  - Added `TestReviewCapParsing` class with two tests: confirms `loop-review-handler` lines are parsed and `loop-reviewer-handler` lines are not.

## Test Plan
- All 14 unit/integration tests in `tests/test_scanner_state.py` pass.
- TypeScript typecheck passes (`npm run typecheck`).
- Frontend build passes (`npm run build`).
- `ruff check .` passes.
- Cross-check: every ROLES entry produces a name matching ALLOWED_HANDLERS — `po`, `dev`, `qa`, `review`, `merge` all align.