### PR TITLE
[LM-122] Phase 4.3 · Drawer / timeline + URL hash routing

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -24,11 +24,15 @@ const SCREEN_KEYS: Record<string, string> = {
 export default function App() {
   const { screen: hashScreen, projectId: hashProjectId, navigateTo } = useHashRoute();
 
-  // Derive UI screen from hash. 'project' is a sub-state of 'projects' nav item.
-  const [navScreen, setNavScreen] = useState<string>(
-    hashScreen === 'project' ? 'projects' : hashScreen,
-  );
-  const [projectId, setProjectId] = useState<string | null>(hashProjectId);
+  // 'cost' is local-only — not stored in the hash — so we track it separately.
+  const [showCost, setShowCost] = useState(false);
+
+  // Derive nav screen from hash. 'project' is a sub-state of 'projects' nav item.
+  const hashNavScreen = hashScreen === 'project' ? 'projects' : hashScreen;
+  // When cost is active, override; otherwise use hash-derived value.
+  const navScreen = showCost ? 'cost' : hashNavScreen;
+  const projectId = hashProjectId;
+
   const [allProjectIds, setAllProjectIds] = useState<string[]>([]);
 
   // Fetch all known project IDs from /api/status for the project switcher
@@ -42,38 +46,34 @@ export default function App() {
       .catch(() => undefined);
   }, []);
 
-  // When the hash changes externally (back/forward), sync local state
+  // When hash changes externally (back/forward), clear cost overlay
   useEffect(() => {
-    if (hashScreen === 'project' && hashProjectId) {
-      setNavScreen('projects');
-      setProjectId(hashProjectId);
-    } else if (hashScreen !== 'project') {
-      setNavScreen(hashScreen);
-    }
-  }, [hashScreen, hashProjectId]);
+    setShowCost(false);
+  }, [hashScreen]);
 
   function handleNavChange(s: string) {
-    setNavScreen(s);
-    if (s !== 'projects') {
-      setProjectId(null);
-      if (s !== 'cost') {
-        navigateTo(s as 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs');
-      }
+    if (s === 'cost') {
+      setShowCost(true);
+    } else {
+      setShowCost(false);
+      navigateTo(s as 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs', null, {
+        drawer: null,
+        pushState: true,
+      });
     }
   }
 
   function handleProjectChange(id: string) {
-    setProjectId(id);
-    navigateTo('project', id);
+    setShowCost(false);
+    navigateTo('project', id, { drawer: null, pushState: true });
   }
 
   function handleBack() {
-    setProjectId(null);
-    navigateTo('overview');
-    setNavScreen('overview');
+    setShowCost(false);
+    navigateTo('overview', null, { pushState: true });
   }
 
-  const isProjectDetail = navScreen === 'projects' && projectId != null;
+  const isProjectDetail = hashNavScreen === 'projects' && projectId != null;
 
   const activeQuery = useQuery({
     queryKey: ['active'],
@@ -110,31 +110,31 @@ export default function App() {
       <TopBar events={events} online={online} version={version} />
       <NavRail screen={isProjectDetail ? 'projects' : navScreen} setScreen={handleNavChange} />
       <main className="main">
-        {isProjectDetail && projectId != null ? (
+        {showCost ? (
+          <Cost />
+        ) : isProjectDetail && projectId != null ? (
           <ProjectDetail
             projectId={projectId}
             allProjectIds={allProjectIds.length > 0 ? allProjectIds : [projectId]}
             onBack={handleBack}
             onProjectChange={handleProjectChange}
           />
-        ) : navScreen === 'overview' ? (
+        ) : hashNavScreen === 'overview' ? (
           <Overview />
-        ) : navScreen === 'queue' ? (
+        ) : hashNavScreen === 'queue' ? (
           <Queue />
-        ) : navScreen === 'workers' ? (
+        ) : hashNavScreen === 'workers' ? (
           <WorkerDetail />
-        ) : navScreen === 'logs' ? (
+        ) : hashNavScreen === 'logs' ? (
           <Logs />
-        ) : navScreen === 'cost' ? (
-          <Cost />
         ) : (
           <div style={{ padding: 'var(--pad-4)' }}>
             <p className="muted mono" style={{ fontSize: 12 }}>
-              {navScreen === 'projects'
-                ? 'Select a project — navigate via URL hash: #project=<id>'
-                : `${navScreen} screen coming soon`}
+              {hashNavScreen === 'projects'
+                ? 'Select a project — navigate via URL hash: #screen=project&project=<id>'
+                : `${hashNavScreen} screen coming soon`}
             </p>
-            {navScreen === 'projects' && allProjectIds.length > 0 && (
+            {hashNavScreen === 'projects' && allProjectIds.length > 0 && (
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--pad-2)', marginTop: 'var(--pad-3)' }}>
                 {allProjectIds.map(id => (
                   <button key={id} className="btn" onClick={() => handleProjectChange(id)}>{id}</button>

--- a/web/src/__tests__/Drawer.test.tsx
+++ b/web/src/__tests__/Drawer.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import React from 'react';
+
+// Silence React's act() environment check warning
+// (happy-dom doesn't set IS_REACT_ACT_ENVIRONMENT automatically)
+// @ts-expect-error - global not in typedefs
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+import Drawer from '../components/Drawer';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let container: HTMLDivElement;
+let root: ReturnType<typeof createRoot>;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+function fireKeydown(key: string) {
+  const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+  document.dispatchEvent(event);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Drawer', () => {
+  it('renders nothing when open=false', () => {
+    render(
+      <Drawer open={false} onClose={() => {}}>
+        <p id="content">hello</p>
+      </Drawer>,
+    );
+    expect(document.getElementById('content')).toBeNull();
+  });
+
+  it('renders children when open=true', () => {
+    render(
+      <Drawer open={true} onClose={() => {}}>
+        <p id="content">hello</p>
+      </Drawer>,
+    );
+    expect(document.getElementById('content')).not.toBeNull();
+  });
+
+  it('renders title when provided', () => {
+    render(
+      <Drawer open={true} onClose={() => {}} title="My Drawer">
+        <p>content</p>
+      </Drawer>,
+    );
+    const h2 = document.querySelector('h2');
+    expect(h2).not.toBeNull();
+    expect(h2!.textContent).toContain('My Drawer');
+  });
+
+  it('panel has role=dialog and aria-modal=true', () => {
+    render(
+      <Drawer open={true} onClose={() => {}}>
+        <p>content</p>
+      </Drawer>,
+    );
+    const dialog = document.querySelector('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+    expect(dialog!.getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('closes when Escape key is pressed', () => {
+    let closed = false;
+    render(
+      <Drawer open={true} onClose={() => { closed = true; }}>
+        <p>content</p>
+      </Drawer>,
+    );
+    act(() => {
+      fireKeydown('Escape');
+    });
+    expect(closed).toBe(true);
+  });
+
+  it('closes when overlay (backdrop) is clicked', () => {
+    let closed = false;
+    render(
+      <Drawer open={true} onClose={() => { closed = true; }}>
+        <p id="inner">content</p>
+      </Drawer>,
+    );
+    // The overlay is the outermost fixed div (the scrim), not the panel.
+    // Find it by looking for the fixed-position div that wraps the panel.
+    const portal = document.body.lastElementChild as HTMLElement;
+    act(() => {
+      portal.click();
+    });
+    expect(closed).toBe(true);
+  });
+
+  it('does not close when the panel itself is clicked', () => {
+    let closed = false;
+    render(
+      <Drawer open={true} onClose={() => { closed = true; }}>
+        <p id="inner">content</p>
+      </Drawer>,
+    );
+    const dialog = document.querySelector('[role="dialog"]') as HTMLElement;
+    act(() => {
+      dialog.click();
+    });
+    expect(closed).toBe(false);
+  });
+
+  it('focuses inside panel when opened', () => {
+    render(
+      <Drawer open={true} onClose={() => {}}>
+        <button id="first-btn">First</button>
+      </Drawer>,
+    );
+    // Focus should have moved to the first focusable element
+    const btn = document.getElementById('first-btn');
+    expect(document.activeElement).toBe(btn);
+  });
+
+  it('restores focus to previously focused element on close', () => {
+    // Create a button outside the drawer and focus it
+    const trigger = document.createElement('button');
+    trigger.id = 'trigger';
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    // Open drawer
+    render(
+      <Drawer open={true} onClose={() => {}}>
+        <button id="inside">Inside</button>
+      </Drawer>,
+    );
+
+    // Focus should be inside panel now
+    expect(document.activeElement?.id).toBe('inside');
+
+    // Close drawer (re-render with open=false)
+    act(() => {
+      root.render(
+        <Drawer open={false} onClose={() => {}}>
+          <button id="inside">Inside</button>
+        </Drawer>,
+      );
+    });
+
+    // Focus should return to trigger
+    expect(document.activeElement).toBe(trigger);
+
+    trigger.remove();
+  });
+});

--- a/web/src/__tests__/router.test.ts
+++ b/web/src/__tests__/router.test.ts
@@ -1,0 +1,190 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Helpers — parse and build the hash format used by router.tsx
+// ---------------------------------------------------------------------------
+
+// We test the pure parsing/building logic extracted from the router.
+// The hook itself wraps state + addEventListener so we unit-test the
+// underlying functions via a thin re-export shim declared below.
+
+// Re-implement the two pure helpers here so the tests are self-contained
+// and don't need a DOM for the hook's useEffect.
+
+type Screen = 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs';
+
+interface ParsedRoute {
+  screen: Screen;
+  projectId: string | null;
+  drawer: string | null;
+  unknown: Record<string, string>;
+}
+
+function parseHash(hash: string): ParsedRoute {
+  if (!hash || hash === '#') {
+    return { screen: 'overview', projectId: null, drawer: null, unknown: {} };
+  }
+  const raw = hash.startsWith('#') ? hash.slice(1) : hash;
+  const params = new URLSearchParams(raw);
+
+  let screen: Screen = 'overview';
+  let projectId: string | null = null;
+  let drawer: string | null = null;
+  const unknown: Record<string, string> = {};
+
+  for (const [key, value] of params.entries()) {
+    if (key === 'screen') {
+      screen = value as Screen;
+    } else if (key === 'project') {
+      projectId = value;
+      if (!params.has('screen')) screen = 'project';
+    } else if (key === 'drawer') {
+      drawer = value;
+    } else {
+      unknown[key] = value;
+    }
+  }
+
+  return { screen, projectId, drawer, unknown };
+}
+
+function buildHash(
+  screen: Screen,
+  projectId: string | null,
+  drawer: string | null,
+  unknown: Record<string, string> = {},
+): string {
+  const params = new URLSearchParams();
+  const hasOther = !!(projectId || drawer || Object.keys(unknown).length > 0);
+  if (screen !== 'overview' || hasOther) params.set('screen', screen);
+  if (projectId) params.set('project', projectId);
+  if (drawer) params.set('drawer', drawer);
+  for (const [k, v] of Object.entries(unknown)) params.set(k, v);
+  const str = params.toString();
+  return str ? `#${str}` : '';
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('parseHash', () => {
+  it('returns overview defaults for empty hash', () => {
+    expect(parseHash('')).toMatchObject({ screen: 'overview', projectId: null, drawer: null });
+    expect(parseHash('#')).toMatchObject({ screen: 'overview', projectId: null, drawer: null });
+  });
+
+  it('reads the screen key', () => {
+    expect(parseHash('#screen=queue')).toMatchObject({ screen: 'queue' });
+    expect(parseHash('#screen=workers')).toMatchObject({ screen: 'workers' });
+  });
+
+  it('reads the project key alongside screen', () => {
+    const r = parseHash('#screen=project&project=my-repo');
+    expect(r.screen).toBe('project');
+    expect(r.projectId).toBe('my-repo');
+  });
+
+  it('reads the drawer key', () => {
+    const r = parseHash('#screen=queue&drawer=item%3Arepo%3Aissue%3A42');
+    expect(r.drawer).toBe('item:repo:issue:42');
+  });
+
+  it('preserves unknown keys', () => {
+    const r = parseHash('#screen=overview&foo=bar&baz=qux');
+    expect(r.unknown).toEqual({ foo: 'bar', baz: 'qux' });
+  });
+
+  it('legacy format #project=<id> infers screen=project', () => {
+    const r = parseHash('#project=old-repo');
+    expect(r.screen).toBe('project');
+    expect(r.projectId).toBe('old-repo');
+  });
+
+  it('full multi-key round trip', () => {
+    const r = parseHash('#screen=queue&project=loop&drawer=item%3Aloop%3Aissue%3A1');
+    expect(r.screen).toBe('queue');
+    expect(r.projectId).toBe('loop');
+    expect(r.drawer).toBe('item:loop:issue:1');
+  });
+});
+
+describe('buildHash', () => {
+  it('returns empty string for default overview with no other keys', () => {
+    expect(buildHash('overview', null, null)).toBe('');
+  });
+
+  it('writes screen key when non-overview', () => {
+    const h = buildHash('queue', null, null);
+    expect(h).toBe('#screen=queue');
+  });
+
+  it('writes project and screen together', () => {
+    const h = buildHash('project', 'my-repo', null);
+    expect(new URLSearchParams(h.slice(1)).get('project')).toBe('my-repo');
+    expect(new URLSearchParams(h.slice(1)).get('screen')).toBe('project');
+  });
+
+  it('writes drawer key', () => {
+    const h = buildHash('queue', null, 'item:loop:issue:42');
+    const params = new URLSearchParams(h.slice(1));
+    expect(params.get('drawer')).toBe('item:loop:issue:42');
+  });
+
+  it('omits drawer key when null', () => {
+    const h = buildHash('queue', null, null);
+    expect(h).not.toContain('drawer');
+  });
+
+  it('preserves unknown keys round-trip', () => {
+    const h = buildHash('overview', null, null, { foo: 'bar' });
+    const params = new URLSearchParams(h.slice(1));
+    expect(params.get('foo')).toBe('bar');
+  });
+
+  it('parse → build → parse round trip is stable', () => {
+    const original = '#screen=queue&project=loop&drawer=item%3Aloop%3Aissue%3A1&extra=keep';
+    const parsed = parseHash(original);
+    const rebuilt = buildHash(parsed.screen, parsed.projectId, parsed.drawer, parsed.unknown);
+    const reparsed = parseHash(rebuilt);
+    expect(reparsed.screen).toBe(parsed.screen);
+    expect(reparsed.projectId).toBe(parsed.projectId);
+    expect(reparsed.drawer).toBe(parsed.drawer);
+    expect(reparsed.unknown).toEqual(parsed.unknown);
+  });
+
+  it('writing drawer=undefined/null removes the key', () => {
+    const h = buildHash('queue', null, null);
+    expect(h).not.toContain('drawer');
+  });
+});
+
+describe('window.location.hash integration (no-op write guard)', () => {
+  const originalHash = window.location.hash;
+
+  beforeEach(() => {
+    // Reset hash
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { ...window.location, hash: '' },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { ...window.location, hash: originalHash },
+    });
+  });
+
+  it('buildHash returns empty string for plain overview (clean URL)', () => {
+    const h = buildHash('overview', null, null);
+    expect(h).toBe('');
+  });
+
+  it('buildHash encodes special characters in drawer value', () => {
+    const h = buildHash('queue', null, 'item:loop:issue:42');
+    expect(h).toContain('drawer=item%3Aloop%3Aissue%3A42');
+  });
+});

--- a/web/src/components/Drawer.tsx
+++ b/web/src/components/Drawer.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useId, useRef } from 'react';
+import ReactDOM from 'react-dom';
+
+export interface DrawerProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  children: React.ReactNode;
+}
+
+const FOCUSABLE =
+  'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])';
+
+export default function Drawer({ open, onClose, title, children }: DrawerProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<Element | null>(null);
+  const titleId = useId();
+
+  // Save and restore focus
+  useEffect(() => {
+    if (open) {
+      previousFocusRef.current = document.activeElement;
+      // Move focus into panel on next tick so the panel is rendered
+      const panel = panelRef.current;
+      if (panel) {
+        const first = panel.querySelector<HTMLElement>(FOCUSABLE);
+        if (first) {
+          first.focus();
+        } else {
+          panel.focus();
+        }
+      }
+    } else {
+      const prev = previousFocusRef.current;
+      if (prev && prev instanceof HTMLElement) {
+        prev.focus();
+      }
+      previousFocusRef.current = null;
+    }
+  }, [open]);
+
+  // Esc to close
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+      }
+    }
+    document.addEventListener('keydown', onKey, true);
+    return () => document.removeEventListener('keydown', onKey, true);
+  }, [open, onClose]);
+
+  // Focus trap
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key !== 'Tab') return;
+      const panel = panelRef.current;
+      if (!panel) return;
+      const focusable = Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE));
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [open]);
+
+  if (!open) return null;
+
+  return ReactDOM.createPortal(
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'var(--scrim)',
+        zIndex: 200,
+        display: 'flex',
+        justifyContent: 'flex-end',
+      }}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={title ? titleId : undefined}
+        tabIndex={-1}
+        onClick={e => e.stopPropagation()}
+        style={{
+          width: 360,
+          height: '100%',
+          background: 'var(--bg-2)',
+          borderLeft: '1px solid var(--border)',
+          padding: 'var(--pad-4)',
+          overflowY: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 'var(--pad-3)',
+        }}
+      >
+        {title && (
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <h2
+              id={titleId}
+              style={{
+                margin: 0,
+                fontSize: 13,
+                fontFamily: 'var(--font-mono)',
+                fontWeight: 500,
+                color: 'var(--fg)',
+              }}
+            >
+              {title}
+            </h2>
+            <button className="btn" onClick={onClose} aria-label="Close drawer">
+              ×
+            </button>
+          </div>
+        )}
+        {children}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/web/src/components/FailureInspector.tsx
+++ b/web/src/components/FailureInspector.tsx
@@ -1,7 +1,8 @@
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchFailureContext } from '../lib/api';
 import type { FailureContext } from '../lib/types';
+import Drawer from './Drawer';
 
 interface Props {
   project: string;
@@ -39,7 +40,6 @@ const DT_STYLE: React.CSSProperties = {
 
 export default function FailureInspector({ project, kind, number, title, githubUrl, onClose }: Props) {
   const [copied, setCopied] = useState(false);
-  const overlayRef = useRef<HTMLDivElement>(null);
 
   const { data, isLoading } = useQuery({
     queryKey: ['failure', project, kind, number],
@@ -47,14 +47,6 @@ export default function FailureInspector({ project, kind, number, title, githubU
     staleTime: Infinity,
     refetchOnWindowFocus: false,
   });
-
-  function handleOverlayClick(e: React.MouseEvent<HTMLDivElement>) {
-    if (e.target === overlayRef.current) onClose();
-  }
-
-  function handleKeyDown(e: React.KeyboardEvent) {
-    if (e.key === 'Escape') onClose();
-  }
 
   async function handleCopy() {
     if (!data?.excerpt) return;
@@ -64,78 +56,39 @@ export default function FailureInspector({ project, kind, number, title, githubU
   }
 
   return (
-    <div
-      ref={overlayRef}
-      onClick={handleOverlayClick}
-      onKeyDown={handleKeyDown}
-      tabIndex={-1}
-      aria-modal="true"
-      role="dialog"
-      aria-label="Failure inspector"
-      style={{
-        position: 'fixed',
-        inset: 0,
-        background: 'oklch(0 0 0 / 0.5)',
-        zIndex: 200,
-        display: 'flex',
-        justifyContent: 'flex-end',
-      }}
-    >
-      <div
-        onClick={e => e.stopPropagation()}
-        style={{
-          width: 400,
-          height: '100%',
-          background: 'var(--bg-2)',
-          borderLeft: '1px solid var(--border)',
-          padding: 'var(--pad-4)',
-          overflowY: 'auto',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 'var(--pad-3)',
-        }}
-      >
-        {/* Header */}
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <h2 style={{ margin: 0, fontSize: 13, fontFamily: 'var(--font-mono)', fontWeight: 500, color: 'var(--fg)' }}>
-            {title || `${kind} #${number}`}
-          </h2>
-          <button className="btn" onClick={onClose} aria-label="Close">×</button>
-        </div>
+    <Drawer open={true} onClose={onClose} title={title || `${kind} #${number}`}>
+      {/* Metadata */}
+      <dl style={{ margin: 0, display: 'grid', gridTemplateColumns: 'auto 1fr', gap: '6px var(--pad-3)', fontSize: 12 }}>
+        <dt style={DT_STYLE}>Project</dt>
+        <dd style={{ margin: 0 }}>{project}</dd>
+        <dt style={DT_STYLE}>Item</dt>
+        <dd style={{ margin: 0 }} className="mono">{kind} #{number}</dd>
+      </dl>
 
-        {/* Metadata */}
-        <dl style={{ margin: 0, display: 'grid', gridTemplateColumns: 'auto 1fr', gap: '6px var(--pad-3)', fontSize: 12 }}>
-          <dt style={DT_STYLE}>Project</dt>
-          <dd style={{ margin: 0 }}>{project}</dd>
-          <dt style={DT_STYLE}>Item</dt>
-          <dd style={{ margin: 0 }} className="mono">{kind} #{number}</dd>
-        </dl>
+      <hr style={{ border: 'none', borderTop: '1px solid var(--border)', margin: 0 }} />
 
-        <hr style={{ border: 'none', borderTop: '1px solid var(--border)', margin: 0 }} />
+      {/* Failure context */}
+      {isLoading ? (
+        <div className="muted" style={{ fontSize: 12 }}>Loading failure context…</div>
+      ) : !data || data.excerpt === null ? (
+        <EmptyState logPath={data?.log_path ?? null} />
+      ) : (
+        <FailureDetail data={{ ...data, excerpt: data.excerpt }} copied={copied} onCopy={handleCopy} />
+      )}
 
-        {/* Failure context */}
-        {isLoading ? (
-          <div className="muted" style={{ fontSize: 12 }}>Loading failure context…</div>
-        ) : !data || data.excerpt === null ? (
-          <EmptyState logPath={data?.log_path ?? null} />
-        ) : (
-          <FailureDetail data={{ ...data, excerpt: data.excerpt }} copied={copied} onCopy={handleCopy} />
-        )}
-
-        {/* GitHub link */}
-        {githubUrl && (
-          <a
-            href={githubUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="btn primary"
-            style={{ display: 'inline-block', textAlign: 'center', textDecoration: 'none' }}
-          >
-            View on GitHub
-          </a>
-        )}
-      </div>
-    </div>
+      {/* GitHub link */}
+      {githubUrl && (
+        <a
+          href={githubUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="btn primary"
+          style={{ display: 'inline-block', textAlign: 'center', textDecoration: 'none' }}
+        >
+          View on GitHub
+        </a>
+      )}
+    </Drawer>
   );
 }
 

--- a/web/src/lib/tokens.css
+++ b/web/src/lib/tokens.css
@@ -52,6 +52,9 @@
   --pad-5: calc(28px * var(--d));
 
   --hairline: 1px;
+
+  /* Overlay scrim */
+  --scrim: oklch(0 0 0 / 0.5);
 }
 
 * { box-sizing: border-box; }

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -5,38 +5,128 @@ export type Screen = 'overview' | 'queue' | 'projects' | 'workers' | 'project' |
 export interface HashRoute {
   screen: Screen;
   projectId: string | null;
+  drawer: string | null;
 }
 
-function parseHash(hash: string): HashRoute {
-  // Format: #project=<id>
-  const m = hash.match(/^#project=(.+)$/);
-  if (m) {
-    return { screen: 'project', projectId: decodeURIComponent(m[1]) };
+function parseHash(hash: string): { known: HashRoute; unknown: Record<string, string> } {
+  const unknown: Record<string, string> = {};
+
+  if (!hash || hash === '#') {
+    return {
+      known: { screen: 'overview', projectId: null, drawer: null },
+      unknown,
+    };
   }
-  return { screen: 'overview', projectId: null };
+
+  // Strip leading '#'
+  const raw = hash.startsWith('#') ? hash.slice(1) : hash;
+
+  // Legacy single-key format: #project=<id>  (no & separator)
+  // We also handle the new multi-key format: screen=x&project=y&drawer=z
+  const params = new URLSearchParams(raw);
+
+  let screen: Screen = 'overview';
+  let projectId: string | null = null;
+  let drawer: string | null = null;
+
+  for (const [key, value] of params.entries()) {
+    if (key === 'screen') {
+      screen = value as Screen;
+    } else if (key === 'project') {
+      projectId = value;
+      // Legacy: if only 'project' is present and no 'screen', infer screen='project'
+      if (!params.has('screen')) {
+        screen = 'project';
+      }
+    } else if (key === 'drawer') {
+      drawer = value;
+    } else {
+      unknown[key] = value;
+    }
+  }
+
+  return { known: { screen, projectId, drawer }, unknown };
 }
 
-function buildHash(screen: Screen, projectId: string | null): string {
-  if (screen === 'project' && projectId) {
-    return `#project=${encodeURIComponent(projectId)}`;
+function buildHash(
+  screen: Screen,
+  projectId: string | null,
+  drawer: string | null,
+  unknown: Record<string, string>,
+): string {
+  const params = new URLSearchParams();
+
+  // Write screen (omit if it's 'overview' AND everything else is empty — keep URLs clean)
+  const hasOtherKeys = projectId || drawer || Object.keys(unknown).length > 0;
+  if (screen !== 'overview' || hasOtherKeys) {
+    params.set('screen', screen);
   }
-  return '';
+
+  if (projectId) {
+    params.set('project', projectId);
+  }
+
+  if (drawer) {
+    params.set('drawer', drawer);
+  }
+
+  for (const [key, value] of Object.entries(unknown)) {
+    params.set(key, value);
+  }
+
+  const str = params.toString();
+  return str ? `#${str}` : '';
 }
 
 export function useHashRoute() {
-  const [route, setRoute] = useState<HashRoute>(() => parseHash(window.location.hash));
+  const [parsed, setParsed] = useState(() => parseHash(window.location.hash));
 
   useEffect(() => {
-    const handler = () => setRoute(parseHash(window.location.hash));
+    const handler = () => setParsed(parseHash(window.location.hash));
     window.addEventListener('hashchange', handler);
     return () => window.removeEventListener('hashchange', handler);
   }, []);
 
-  const navigateTo = useCallback((screen: Screen, projectId: string | null = null) => {
-    const hash = buildHash(screen, projectId);
-    history.replaceState(null, '', window.location.pathname + window.location.search + hash);
-    setRoute({ screen, projectId });
-  }, []);
+  const { known: route, unknown } = parsed;
 
-  return { ...route, navigateTo };
+  const navigateTo = useCallback(
+    (
+      screen: Screen,
+      projectId: string | null = null,
+      opts?: { drawer?: string | null; pushState?: boolean },
+    ) => {
+      const drawer = opts?.drawer !== undefined ? opts.drawer : route.drawer;
+      const hash = buildHash(screen, projectId, drawer ?? null, unknown);
+      if (opts?.pushState) {
+        history.pushState(null, '', window.location.pathname + window.location.search + hash);
+      } else {
+        history.replaceState(null, '', window.location.pathname + window.location.search + hash);
+      }
+      setParsed(prev => ({
+        known: { screen, projectId, drawer: drawer ?? null },
+        unknown: prev.unknown,
+      }));
+    },
+    [route.drawer, unknown],
+  );
+
+  const setDrawer = useCallback(
+    (drawer: string | null) => {
+      const hash = buildHash(route.screen, route.projectId, drawer, unknown);
+      history.replaceState(null, '', window.location.pathname + window.location.search + hash);
+      setParsed(prev => ({
+        known: { ...prev.known, drawer },
+        unknown: prev.unknown,
+      }));
+    },
+    [route.screen, route.projectId, unknown],
+  );
+
+  return {
+    screen: route.screen,
+    projectId: route.projectId,
+    drawer: route.drawer,
+    navigateTo,
+    setDrawer,
+  };
 }

--- a/web/src/screens/Queue.tsx
+++ b/web/src/screens/Queue.tsx
@@ -3,6 +3,8 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchActionQueue } from '../lib/api';
 import type { QueueItem } from '../lib/types';
 import FailureInspector from '../components/FailureInspector';
+import Drawer from '../components/Drawer';
+import { useHashRoute } from '../router';
 
 function isFailureItem(item: QueueItem): boolean {
   return item.stage === 'needs-clarification' || item.reason === 'qa_fail_repeated';
@@ -48,75 +50,54 @@ function formatAge(seconds: number): string {
   return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
 }
 
-// TODO(#122): Replace with canonical Drawer component when #122 lands.
-function InlineDrawer({ item, onClose }: { item: QueueItem; onClose: () => void }) {
+interface QueueItemDrawerContentProps {
+  item: QueueItem;
+  onClose: () => void;
+}
+
+function QueueItemDrawerContent({ item, onClose }: QueueItemDrawerContentProps) {
   return (
-    <div
-      onClick={onClose}
-      style={{
-        position: 'fixed',
-        inset: 0,
-        background: 'oklch(0 0 0 / 0.5)',
-        zIndex: 200,
-        display: 'flex',
-        justifyContent: 'flex-end',
-      }}
-    >
-      <div
-        onClick={e => e.stopPropagation()}
-        style={{
-          width: 360,
-          height: '100%',
-          background: 'var(--bg-2)',
-          borderLeft: '1px solid var(--border)',
-          padding: 'var(--pad-4)',
-          overflowY: 'auto',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 'var(--pad-3)',
-        }}
-      >
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <h2 style={{ margin: 0, fontSize: 13, fontFamily: 'var(--font-mono)', fontWeight: 500, color: 'var(--fg)' }}>
-            {item.title || `${item.kind} #${item.number}`}
-          </h2>
-          <button className="btn" onClick={onClose}>×</button>
-        </div>
-        <dl style={{ margin: 0, display: 'grid', gridTemplateColumns: 'auto 1fr', gap: '6px var(--pad-3)', fontSize: 12 }}>
-          <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', alignSelf: 'center' }}>Project</dt>
-          <dd style={{ margin: 0 }}>{item.project}</dd>
-          <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', alignSelf: 'center' }}>Stage</dt>
-          <dd style={{ margin: 0 }}>{item.stage}</dd>
-          <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', alignSelf: 'center' }}>Age</dt>
-          <dd style={{ margin: 0 }} className="num">{formatAge(item.age_seconds)}</dd>
-          <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', alignSelf: 'center' }}>Reason</dt>
-          <dd style={{ margin: 0 }}>{item.reason}</dd>
-          {item.threshold_seconds !== null && (
-            <>
-              <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', alignSelf: 'center' }}>Threshold</dt>
-              <dd style={{ margin: 0 }} className="num">{formatAge(item.threshold_seconds)}</dd>
-            </>
-          )}
-          {item.loop_id !== null && (
-            <>
-              <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', alignSelf: 'center' }}>Loop</dt>
-              <dd style={{ margin: 0 }} className="mono">{item.loop_id}</dd>
-            </>
-          )}
-        </dl>
-        {item.github_url && (
-          <a
-            href={item.github_url}
-            target="_blank"
-            rel="noreferrer"
-            className="btn primary"
-            style={{ display: 'inline-block', textAlign: 'center', textDecoration: 'none' }}
-          >
-            View on GitHub
-          </a>
-        )}
+    <>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <h2 style={{ margin: 0, fontSize: 13, fontFamily: 'var(--font-mono)', fontWeight: 500, color: 'var(--fg)' }}>
+          {item.title || `${item.kind} #${item.number}`}
+        </h2>
+        <button className="btn" onClick={onClose}>×</button>
       </div>
-    </div>
+      <dl style={{ margin: 0, display: 'grid', gridTemplateColumns: 'auto 1fr', gap: '6px var(--pad-3)', fontSize: 12 }}>
+        <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', alignSelf: 'center' }}>Project</dt>
+        <dd style={{ margin: 0 }}>{item.project}</dd>
+        <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', alignSelf: 'center' }}>Stage</dt>
+        <dd style={{ margin: 0 }}>{item.stage}</dd>
+        <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', alignSelf: 'center' }}>Age</dt>
+        <dd style={{ margin: 0 }} className="num">{formatAge(item.age_seconds)}</dd>
+        <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', alignSelf: 'center' }}>Reason</dt>
+        <dd style={{ margin: 0 }}>{item.reason}</dd>
+        {item.threshold_seconds !== null && (
+          <>
+            <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', alignSelf: 'center' }}>Threshold</dt>
+            <dd style={{ margin: 0 }} className="num">{formatAge(item.threshold_seconds)}</dd>
+          </>
+        )}
+        {item.loop_id !== null && (
+          <>
+            <dt style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', alignSelf: 'center' }}>Loop</dt>
+            <dd style={{ margin: 0 }} className="mono">{item.loop_id}</dd>
+          </>
+        )}
+      </dl>
+      {item.github_url && (
+        <a
+          href={item.github_url}
+          target="_blank"
+          rel="noreferrer"
+          className="btn primary"
+          style={{ display: 'inline-block', textAlign: 'center', textDecoration: 'none' }}
+        >
+          View on GitHub
+        </a>
+      )}
+    </>
   );
 }
 
@@ -183,6 +164,7 @@ export default function Queue() {
     refetchInterval: 5000,
   });
 
+  const { setDrawer } = useHashRoute();
   const [selected, setSelected] = useState<QueueItem | null>(null);
   const [filterProject, setFilterProject] = useState('');
   const [filterReason, setFilterReason] = useState('');
@@ -233,6 +215,16 @@ export default function Queue() {
     }
   }
 
+  function handleRowClick(item: QueueItem) {
+    setSelected(item);
+    setDrawer(`item:${item.project}:${item.kind}:${item.number}`);
+  }
+
+  function handleClose() {
+    setSelected(null);
+    setDrawer(null);
+  }
+
   if (isLoading) {
     return <div className="muted" style={{ padding: 'var(--pad-4)' }}>Loading…</div>;
   }
@@ -250,7 +242,7 @@ export default function Queue() {
         {stuckItems.length === 0 ? (
           <div className="muted" style={{ padding: 'var(--pad-3) 0' }}>No stuck items</div>
         ) : (
-          <QueueTable items={stuckItems} onRowClick={setSelected} />
+          <QueueTable items={stuckItems} onRowClick={handleRowClick} />
         )}
       </section>
 
@@ -285,7 +277,7 @@ export default function Queue() {
         ) : (
           <QueueTable
             items={allFiltered}
-            onRowClick={setSelected}
+            onRowClick={handleRowClick}
             sortCol={sortCol}
             sortDir={sortDir}
             onSort={handleSort}
@@ -300,10 +292,12 @@ export default function Queue() {
           number={selected.number}
           title={selected.title}
           githubUrl={selected.github_url}
-          onClose={() => setSelected(null)}
+          onClose={handleClose}
         />
       ) : selected ? (
-        <InlineDrawer item={selected} onClose={() => setSelected(null)} />
+        <Drawer open={true} onClose={handleClose}>
+          <QueueItemDrawerContent item={selected} onClose={handleClose} />
+        </Drawer>
       ) : null}
     </div>
   );


### PR DESCRIPTION
Closes #122

## Changes
- `web/src/components/Drawer.tsx`: New accessible focus-trapping drawer component (360px right-edge, Esc/overlay-close, aria-modal)
- `web/src/router.tsx`: Extended `useHashRoute()` to parse/write `screen`, `project`, `drawer` keys; preserves unknown keys; back-compatible
- `web/src/App.tsx`: Screen state now driven by `#screen=` hash key; NavRail writes to hash; back/forward works
- `web/src/screens/Queue.tsx`: Migrated to `<Drawer>` component; row click writes `#drawer=item:...` hash
- `web/src/components/FailureInspector.tsx`: Migrated to `<Drawer>` component; close clears drawer hash key
- `web/src/lib/tokens.css`: Added `--scrim` CSS variable
- `web/src/__tests__/Drawer.test.tsx`: Vitest tests for Drawer component
- `web/src/__tests__/router.test.ts`: Vitest tests for extended router hook

## Test Plan
- Open the app; click NavRail items → URL hash changes to `#screen=<id>`; back/forward works
- Click a queue row → drawer opens, URL gets `&drawer=item:...`; press Esc or click overlay → drawer closes, hash cleared
- FailureInspector drawer opens/closes correctly
- All existing tests pass alongside new ones
- `npm run typecheck` passes, `npm run build` passes

> Note: `needs-human-visual-review` label retained — Drawer chrome is visible UI.