### PR TITLE
Use project repo map for issue metadata lookups

### DIFF
--- a/server/routes/issues_cost.py
+++ b/server/routes/issues_cost.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends
 
+from server.constants import PROJECTS
 from server.db import db_dep
 
 router = APIRouter()
@@ -29,11 +30,16 @@ def _fetch_gh_meta(project: str, issue_number: int) -> dict:
             return data
 
     default: dict = {"title": "", "state": "unknown", "priority": None, "body": "", "merged": False}
+    repo = PROJECTS.get(project)
+    if repo is None:
+        _gh_cache[key] = (now + _GH_TTL, default)
+        return default
+
     try:
         result = subprocess.run(
             [
                 "gh", "api",
-                f"repos/svv2014/{project}/issues/{issue_number}",
+                f"repos/{repo}/issues/{issue_number}",
                 "--jq",
                 "{title, state, body, labels: [.labels[].name], pull_request}",
             ],

--- a/tests/test_issues_cost.py
+++ b/tests/test_issues_cost.py
@@ -1,4 +1,5 @@
 import sqlite3
+import subprocess
 from datetime import datetime, timedelta, timezone
 
 from fastapi.testclient import TestClient
@@ -124,6 +125,45 @@ def test_gh_api_unavailable(tmp_path, monkeypatch):
     assert row is not None
     assert row["priority"] is None
     assert row["title"] == ""
+
+
+def test_fetch_gh_meta_uses_project_repo_mapping(monkeypatch):
+    issues_cost_module._gh_cache.clear()
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=(
+                '{"title":"Mapped","state":"open","body":"",'
+                '"labels":["p1-high"],"pull_request":{"merged_at":null}}'
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(issues_cost_module.subprocess, "run", _run)
+
+    meta = issues_cost_module._fetch_gh_meta("ntc", 198)
+
+    assert calls[0][0][2] == "repos/svv2014/NanoTraderCopilot/issues/198"
+    assert meta["title"] == "Mapped"
+    assert meta["priority"] == "p1-high"
+    assert meta["merged"] is False
+
+
+def test_fetch_gh_meta_unknown_project_returns_default_without_call(monkeypatch):
+    issues_cost_module._gh_cache.clear()
+
+    def _run(*args, **kwargs):
+        raise AssertionError("subprocess.run should not be called for unknown projects")
+
+    monkeypatch.setattr(issues_cost_module.subprocess, "run", _run)
+
+    meta = issues_cost_module._fetch_gh_meta("unknown-project", 198)
+
+    assert meta == {"title": "", "state": "unknown", "priority": None, "body": "", "merged": False}
 
 
 # (f) since filter excludes events older than the cutoff


### PR DESCRIPTION
## Requested
Issue #198 reports that `_fetch_gh_meta` hardcodes the `svv2014` owner instead of using the existing `PROJECTS` map.

## Implemented
- Resolve the full `owner/repo` path from `PROJECTS.get(project)`.
- Return and cache the existing default stub for unknown project slugs without calling `gh api`.
- Added regression coverage for mapped project lookup and unknown project handling.

## Not covered
No changes to issue cost calculations beyond the GitHub metadata lookup path.

## Validated
- `.venv/bin/pytest tests/test_issues_cost.py`
- `.venv/bin/ruff check server/routes/issues_cost.py tests/test_issues_cost.py`
- `git diff --check`

The pytest run emitted an existing Pydantic v2 deprecation warning unrelated to this change.