### PR TITLE
[LM-137] Token-spend dashboard — per-role / project / day breakdown

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -29,6 +29,7 @@ from server.routes import (  # noqa: E402
     runs,
     scanner_state,
     stats,
+    token_spend,
 )
 
 app.include_router(health.router)
@@ -43,6 +44,7 @@ app.include_router(claude_usage.router)
 app.include_router(issues_cost.router)
 app.include_router(logs.router)
 app.include_router(scanner_state.router)
+app.include_router(token_spend.router)
 
 if os.path.isdir("static/dist"):
     app.mount("/v2", StaticFiles(directory="static/dist", html=True), name="dist")

--- a/server/routes/token_spend.py
+++ b/server/routes/token_spend.py
@@ -1,0 +1,88 @@
+import os
+import sqlite3
+from datetime import date, timedelta
+
+from fastapi import APIRouter, Depends
+
+from server.db import db_dep
+
+router = APIRouter()
+
+
+def _tokens_per_event() -> int:
+    try:
+        return max(1, int(os.environ.get("LOOPMON_TOKENS_PER_EVENT", "5000")))
+    except ValueError:
+        return 5000
+
+
+def _input_ratio() -> float:
+    try:
+        r = float(os.environ.get("LOOPMON_INPUT_RATIO", "0.8"))
+        return max(0.0, min(1.0, r))
+    except ValueError:
+        return 0.8
+
+
+def _cost_per_1m(key: str, default: float) -> float:
+    try:
+        return float(os.environ.get(key, str(default)))
+    except ValueError:
+        return default
+
+
+@router.get("/api/token_spend")
+def get_token_spend(conn: sqlite3.Connection = Depends(db_dep)) -> dict:
+    today = date.today()
+    since = today - timedelta(days=29)  # 30 days so frontend can show today/7d/30d
+
+    rows = conn.execute(
+        """
+        SELECT
+            date(created_at) AS day,
+            role,
+            project,
+            COALESCE(model, '') AS model,
+            COUNT(*) AS n
+        FROM events
+        WHERE date(created_at) >= ?
+        GROUP BY day, role, project, model
+        ORDER BY day DESC, n DESC
+        """,
+        (since.isoformat(),),
+    ).fetchall()
+
+    tpe = _tokens_per_event()
+    ir = _input_ratio()
+    c_in = _cost_per_1m("LOOPMON_COST_PER_1M_INPUT", 3.0)
+    c_out = _cost_per_1m("LOOPMON_COST_PER_1M_OUTPUT", 15.0)
+
+    result = []
+    for row in rows:
+        n = row["n"]
+        total = n * tpe
+        inp = int(total * ir)
+        out = total - inp
+        cost = (inp / 1_000_000 * c_in) + (out / 1_000_000 * c_out)
+        result.append(
+            {
+                "date": row["day"],
+                "role": row["role"],
+                "project": row["project"],
+                "model": row["model"],
+                "event_count": n,
+                "input_tokens": inp,
+                "output_tokens": out,
+                "cost_usd": round(cost, 6),
+            }
+        )
+
+    return {
+        "rows": result,
+        "config": {
+            "tokens_per_event": tpe,
+            "input_ratio": ir,
+            "cost_per_1m_input": c_in,
+            "cost_per_1m_output": c_out,
+        },
+    }

--- a/tests/test_token_spend.py
+++ b/tests/test_token_spend.py
@@ -1,0 +1,140 @@
+import os
+import sqlite3
+
+from fastapi.testclient import TestClient
+
+import server
+import server.db
+
+
+def _make_client(monkeypatch, tmp_path):
+    monkeypatch.setattr(server.db, "DB_PATH", str(tmp_path / "test.db"))
+    server.db.apply_pending_migrations()
+    return TestClient(server.app)
+
+
+def _insert_events(db_path: str, events: list) -> None:
+    conn = sqlite3.connect(db_path)
+    for ev in events:
+        conn.execute(
+            "INSERT INTO events (project, role, event_type, issue_number, created_at) VALUES (?,?,?,?,?)",
+            (ev["project"], ev["role"], ev["event_type"], ev["issue_number"], ev["created_at"]),
+        )
+    conn.commit()
+    conn.close()
+
+
+def test_empty_db_returns_empty_rows(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    resp = client.get("/api/token_spend")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["rows"] == []
+    assert "config" in data
+
+
+def test_returns_correct_structure(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-a", "role": "dev", "event_type": "dev_start",
+         "issue_number": 1, "created_at": "2026-05-13T10:00:00+00:00"},
+    ])
+    resp = client.get("/api/token_spend")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["rows"]) == 1
+    row = data["rows"][0]
+    assert row["role"] == "dev"
+    assert row["project"] == "proj-a"
+    assert row["event_count"] == 1
+    assert "input_tokens" in row
+    assert "output_tokens" in row
+    assert "cost_usd" in row
+    assert "date" in row
+
+
+def test_token_calculation_defaults(tmp_path, monkeypatch):
+    # 1 event, default 5000 tpe, 0.8 input ratio, $3/1M in, $15/1M out
+    monkeypatch.delenv("LOOPMON_TOKENS_PER_EVENT", raising=False)
+    monkeypatch.delenv("LOOPMON_INPUT_RATIO", raising=False)
+    monkeypatch.delenv("LOOPMON_COST_PER_1M_INPUT", raising=False)
+    monkeypatch.delenv("LOOPMON_COST_PER_1M_OUTPUT", raising=False)
+    client = _make_client(monkeypatch, tmp_path)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-a", "role": "qa", "event_type": "qa_start",
+         "issue_number": 1, "created_at": "2026-05-13T10:00:00+00:00"},
+    ])
+    resp = client.get("/api/token_spend")
+    row = resp.json()["rows"][0]
+    assert row["input_tokens"] == 4000   # 5000 * 0.8
+    assert row["output_tokens"] == 1000  # 5000 * 0.2
+    expected_cost = (4000 / 1_000_000 * 3.0) + (1000 / 1_000_000 * 15.0)
+    assert abs(row["cost_usd"] - expected_cost) < 1e-8
+
+
+def test_configurable_tokens_per_event(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOOPMON_TOKENS_PER_EVENT", "10000")
+    monkeypatch.delenv("LOOPMON_INPUT_RATIO", raising=False)
+    monkeypatch.delenv("LOOPMON_COST_PER_1M_INPUT", raising=False)
+    monkeypatch.delenv("LOOPMON_COST_PER_1M_OUTPUT", raising=False)
+    client = _make_client(monkeypatch, tmp_path)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-a", "role": "po", "event_type": "po_start",
+         "issue_number": 1, "created_at": "2026-05-13T10:00:00+00:00"},
+    ])
+    resp = client.get("/api/token_spend")
+    row = resp.json()["rows"][0]
+    assert row["input_tokens"] == 8000   # 10000 * 0.8
+    assert row["output_tokens"] == 2000  # 10000 * 0.2
+    cfg = resp.json()["config"]
+    assert cfg["tokens_per_event"] == 10000
+
+
+def test_configurable_cost_env_vars(tmp_path, monkeypatch):
+    monkeypatch.delenv("LOOPMON_TOKENS_PER_EVENT", raising=False)
+    monkeypatch.delenv("LOOPMON_INPUT_RATIO", raising=False)
+    monkeypatch.setenv("LOOPMON_COST_PER_1M_INPUT", "6.0")
+    monkeypatch.setenv("LOOPMON_COST_PER_1M_OUTPUT", "30.0")
+    client = _make_client(monkeypatch, tmp_path)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-b", "role": "dev", "event_type": "dev_start",
+         "issue_number": 2, "created_at": "2026-05-13T10:00:00+00:00"},
+    ])
+    resp = client.get("/api/token_spend")
+    cfg = resp.json()["config"]
+    assert cfg["cost_per_1m_input"] == 6.0
+    assert cfg["cost_per_1m_output"] == 30.0
+    row = resp.json()["rows"][0]
+    expected_cost = (4000 / 1_000_000 * 6.0) + (1000 / 1_000_000 * 30.0)
+    assert abs(row["cost_usd"] - expected_cost) < 1e-8
+
+
+def test_per_role_grouping(tmp_path, monkeypatch):
+    monkeypatch.delenv("LOOPMON_TOKENS_PER_EVENT", raising=False)
+    client = _make_client(monkeypatch, tmp_path)
+    for role in ("po", "dev", "qa"):
+        _insert_events(server.db.DB_PATH, [
+            {"project": "proj-a", "role": role, "event_type": f"{role}_start",
+             "issue_number": 1, "created_at": "2026-05-13T10:00:00+00:00"},
+        ])
+    resp = client.get("/api/token_spend")
+    rows = resp.json()["rows"]
+    roles_returned = {r["role"] for r in rows}
+    assert {"po", "dev", "qa"} == roles_returned
+
+
+def test_only_returns_last_30_days(tmp_path, monkeypatch):
+    monkeypatch.delenv("LOOPMON_TOKENS_PER_EVENT", raising=False)
+    client = _make_client(monkeypatch, tmp_path)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-a", "role": "dev", "event_type": "dev_start",
+         "issue_number": 1, "created_at": "2025-01-01T10:00:00+00:00"},  # old
+        {"project": "proj-a", "role": "qa", "event_type": "qa_start",
+         "issue_number": 2, "created_at": "2026-05-13T10:00:00+00:00"},  # recent
+    ])
+    resp = client.get("/api/token_spend")
+    rows = resp.json()["rows"]
+    assert all(r["date"] >= "2026-04-13" for r in rows)
+    roles = {r["role"] for r in rows}
+    assert "dev" not in roles  # old event excluded
+    assert "qa" in roles

--- a/tests/test_token_spend.py
+++ b/tests/test_token_spend.py
@@ -1,4 +1,3 @@
-import os
 import sqlite3
 
 from fastapi.testclient import TestClient

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -22,6 +22,7 @@ import type {
   LogsResponse,
   IssueCostRow,
   FailureContext,
+  TokenSpend,
 } from './types';
 import * as fx from './fixtures';
 
@@ -149,6 +150,11 @@ export async function fetchIssuesCost(params: IssuesCostParams = {}): Promise<Is
   if (params.offset != null) p.set('offset', String(params.offset));
   const qs = p.size ? `?${p.toString()}` : '';
   return get<IssueCostRow[]>(`/api/issues/cost${qs}`);
+}
+
+export async function fetchTokenSpend(): Promise<TokenSpend> {
+  if (isFixtureMode()) return fx.getFixtureTokenSpend();
+  return get<TokenSpend>('/api/token_spend');
 }
 
 export async function fetchFailureContext(

--- a/web/src/lib/fixtures.ts
+++ b/web/src/lib/fixtures.ts
@@ -20,6 +20,8 @@ import type {
   ClaudeUsage,
   ScannerState,
   IssueCostRow,
+  TokenSpend,
+  TokenSpendRow,
 } from './types';
 
 const PROJECTS = [
@@ -335,6 +337,45 @@ export function getFixtureClaudeUsage(): ClaudeUsage {
 // Full history for use by transforms (same data that would come from /api/history)
 export function getFixtureHistoryAll(): RawEvent[] {
   return HISTORY;
+}
+
+export function getFixtureTokenSpend(): TokenSpend {
+  resetSeed();
+  const CLAUDE_AGENTS = AGENTS.filter(a => a.agent === 'claude');
+  const rows: TokenSpendRow[] = [];
+  const now = Date.now();
+  for (let d = 29; d >= 0; d--) {
+    const dt = new Date(now - d * 86400_000);
+    const dateStr = dt.toISOString().slice(0, 10);
+    for (const role of ROLES) {
+      const p = pick(PROJECTS);
+      const ag = pick(CLAUDE_AGENTS);
+      const n = randInt(1, 15);
+      const tpe = 5000;
+      const inp = Math.floor(n * tpe * 0.8);
+      const out = n * tpe - inp;
+      const cost = parseFloat(((inp / 1_000_000 * 3.0) + (out / 1_000_000 * 15.0)).toFixed(6));
+      rows.push({
+        date: dateStr,
+        role,
+        project: p.id,
+        model: ag.model,
+        event_count: n,
+        input_tokens: inp,
+        output_tokens: out,
+        cost_usd: cost,
+      });
+    }
+  }
+  return {
+    rows,
+    config: {
+      tokens_per_event: 5000,
+      input_ratio: 0.8,
+      cost_per_1m_input: 3.0,
+      cost_per_1m_output: 15.0,
+    },
+  };
 }
 
 export function getFixtureIssuesCost(): IssueCostRow[] {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -213,6 +213,29 @@ export interface FailureContext {
   log_path: string | null;
 }
 
+export interface TokenSpendRow {
+  date: string;
+  role: string;
+  project: string;
+  model: string;
+  event_count: number;
+  input_tokens: number;
+  output_tokens: number;
+  cost_usd: number;
+}
+
+export interface TokenSpendConfig {
+  tokens_per_event: number;
+  input_ratio: number;
+  cost_per_1m_input: number;
+  cost_per_1m_output: number;
+}
+
+export interface TokenSpend {
+  rows: TokenSpendRow[];
+  config: TokenSpendConfig;
+}
+
 export interface IssueCostRow {
   project: string;
   issue_number: number;

--- a/web/src/panels/TokenSpend.tsx
+++ b/web/src/panels/TokenSpend.tsx
@@ -152,8 +152,10 @@ export default function TokenSpend() {
           Estimated · {cfg.tokens_per_event.toLocaleString()} tokens/event
           · ${cfg.cost_per_1m_input}/1M in · ${cfg.cost_per_1m_output}/1M out
           · configure via <span className="mono">LOOPMON_TOKENS_PER_EVENT</span>,{' '}
+          <span className="mono">LOOPMON_INPUT_RATIO</span>,{' '}
           <span className="mono">LOOPMON_COST_PER_1M_INPUT</span>,{' '}
           <span className="mono">LOOPMON_COST_PER_1M_OUTPUT</span>
+          {' '}· counts are event-based estimates and will differ from Anthropic admin API totals
         </div>
       </div>
     </div>

--- a/web/src/panels/TokenSpend.tsx
+++ b/web/src/panels/TokenSpend.tsx
@@ -1,0 +1,161 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend,
+} from 'recharts';
+import { fetchTokenSpend } from '../lib/api';
+import type { TokenSpendRow } from '../lib/types';
+
+const C = {
+  po:       'oklch(0.74 0.16 295)',
+  dev:      'oklch(0.78 0.13 210)',
+  qa:       'oklch(0.82 0.15 75)',
+  reviewer: 'oklch(0.74 0.16 0)',
+  merge:    'oklch(0.80 0.16 145)',
+  judge:    'oklch(0.80 0.12 40)',
+  fg3:      'oklch(0.58 0.008 250)',
+  bg2:      'oklch(0.205 0.007 250)',
+  border:   'oklch(0.275 0.008 250)',
+} as const;
+
+const ROLES = ['po', 'dev', 'qa', 'reviewer', 'merge', 'judge'] as const;
+
+const TOOLTIP_STYLE = {
+  background: C.bg2,
+  border: `1px solid ${C.border}`,
+  borderRadius: 2,
+  fontSize: 11,
+  fontFamily: 'var(--font-mono)',
+  color: 'oklch(0.96 0.005 250)',
+};
+
+function fmtCost(v: number): string {
+  if (v === 0) return '$0';
+  if (v < 0.001) return `$${v.toFixed(5)}`;
+  if (v < 1) return `$${v.toFixed(4)}`;
+  return `$${v.toFixed(2)}`;
+}
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}k`;
+  return String(n);
+}
+
+function buildChartData(rows: TokenSpendRow[], sevenDaysAgo: string) {
+  const map = new Map<string, Record<string, number>>();
+  for (const row of rows) {
+    if (row.date < sevenDaysAgo) continue;
+    if (!map.has(row.date)) map.set(row.date, {});
+    const d = map.get(row.date)!;
+    d[row.role] = (d[row.role] ?? 0) + row.cost_usd;
+  }
+  return [...map.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, roles]) => ({ date: date.slice(5), ...roles }));
+}
+
+function buildProjectTable(rows: TokenSpendRow[], today: string, weekAgo: string, monthAgo: string) {
+  const map = new Map<string, { today: number; week: number; month: number; inp: number; out: number }>();
+  for (const row of rows) {
+    if (!map.has(row.project)) {
+      map.set(row.project, { today: 0, week: 0, month: 0, inp: 0, out: 0 });
+    }
+    const p = map.get(row.project)!;
+    if (row.date === today) p.today += row.cost_usd;
+    if (row.date >= weekAgo) p.week += row.cost_usd;
+    if (row.date >= monthAgo) p.month += row.cost_usd;
+    p.inp += row.input_tokens;
+    p.out += row.output_tokens;
+  }
+  return [...map.entries()]
+    .map(([project, v]) => ({ project, ...v }))
+    .sort((a, b) => b.month - a.month);
+}
+
+export default function TokenSpend() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['token-spend'],
+    queryFn: fetchTokenSpend,
+    refetchInterval: 300_000,
+    staleTime: 60_000,
+  });
+
+  if (isLoading || isError || !data || data.rows.length === 0) return null;
+
+  const today = new Date().toISOString().slice(0, 10);
+  const sevenDaysAgo = new Date(Date.now() - 6 * 86_400_000).toISOString().slice(0, 10);
+  const monthAgo = new Date(Date.now() - 29 * 86_400_000).toISOString().slice(0, 10);
+
+  const chartData = buildChartData(data.rows, sevenDaysAgo);
+  const projectRows = buildProjectTable(data.rows, today, sevenDaysAgo, monthAgo);
+
+  const cfg = data.config;
+
+  return (
+    <div className="panel">
+      <div className="panel-h"><span>Token Spend</span></div>
+      <div style={{ padding: 'var(--pad-2) var(--pad-3) var(--pad-3)' }}>
+        <ResponsiveContainer width="100%" height={200}>
+          <BarChart data={chartData} margin={{ top: 4, right: 4, left: -10, bottom: 0 }}>
+            <XAxis dataKey="date" tick={{ fill: C.fg3, fontSize: 9 }} axisLine={false} tickLine={false} />
+            <YAxis
+              tick={{ fill: C.fg3, fontSize: 9 }}
+              axisLine={false}
+              tickLine={false}
+              tickFormatter={(v: number) => `$${v.toFixed(2)}`}
+            />
+            <Tooltip
+              contentStyle={TOOLTIP_STYLE}
+              cursor={{ fill: 'oklch(1 0 0 / 0.03)' }}
+              formatter={(v, name) => [typeof v === 'number' ? fmtCost(v) : String(v), String(name)]}
+            />
+            <Legend iconSize={8} wrapperStyle={{ fontSize: 9, color: C.fg3 }} />
+            {ROLES.map(role => (
+              <Bar
+                key={role}
+                dataKey={role}
+                stackId="a"
+                fill={C[role]}
+                name={role}
+                maxBarSize={32}
+              />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+
+        <table className="t" style={{ marginTop: 'var(--pad-3)', fontSize: 11 }}>
+          <thead>
+            <tr>
+              <th>Project</th>
+              <th>Today</th>
+              <th>7 d</th>
+              <th>30 d</th>
+              <th>Input tkn</th>
+              <th>Output tkn</th>
+            </tr>
+          </thead>
+          <tbody>
+            {projectRows.map(r => (
+              <tr key={r.project}>
+                <td className="mono" style={{ fontSize: 10 }}>{r.project}</td>
+                <td className="num">{fmtCost(r.today)}</td>
+                <td className="num">{fmtCost(r.week)}</td>
+                <td className="num">{fmtCost(r.month)}</td>
+                <td className="num mono" style={{ fontSize: 10, color: C.fg3 }}>{fmtTokens(r.inp)}</td>
+                <td className="num mono" style={{ fontSize: 10, color: C.fg3 }}>{fmtTokens(r.out)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        <div style={{ marginTop: 'var(--pad-2)', fontSize: 10, color: C.fg3 }}>
+          Estimated · {cfg.tokens_per_event.toLocaleString()} tokens/event
+          · ${cfg.cost_per_1m_input}/1M in · ${cfg.cost_per_1m_output}/1M out
+          · configure via <span className="mono">LOOPMON_TOKENS_PER_EVENT</span>,{' '}
+          <span className="mono">LOOPMON_COST_PER_1M_INPUT</span>,{' '}
+          <span className="mono">LOOPMON_COST_PER_1M_OUTPUT</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/screens/Overview.tsx
+++ b/web/src/screens/Overview.tsx
@@ -14,6 +14,7 @@ import RoleTag from '../components/RoleTag';
 import { relTime, durationFmt } from '../lib/utils';
 import Charts from '../panels/Charts';
 import ClaudeUsage from '../panels/ClaudeUsage';
+import TokenSpend from '../panels/TokenSpend';
 
 const COMPLETED_TYPES = new Set([
   'merge_done', 'judge_done', 'review_done', 'dev_done', 'po_done',
@@ -157,6 +158,7 @@ export default function Overview() {
         </div>
 
         <ClaudeUsage />
+        <TokenSpend />
         <Charts />
 
       </div>


### PR DESCRIPTION
Closes #137

## Changes

### Backend — `server/routes/token_spend.py` (new)
New `GET /api/token_spend` endpoint:
- Queries the `events` table for the last 30 days, grouped by `date / role / project / model`
- Converts event counts to estimated input/output token counts and USD cost
- Three configurable env vars (all optional, sensible defaults):
  - `LOOPMON_TOKENS_PER_EVENT` — estimated tokens fired per event (default 5 000)
  - `LOOPMON_INPUT_RATIO` — fraction of tokens that are input (default 0.8)
  - `LOOPMON_COST_PER_1M_INPUT` — USD per 1M input tokens (default \$3.00 — Sonnet pricing)
  - `LOOPMON_COST_PER_1M_OUTPUT` — USD per 1M output tokens (default \$15.00)
- Returns `rows[]` (per-day/role/project/model breakdown) + `config` (active settings)

### Frontend — `web/src/panels/TokenSpend.tsx` (new)
- **Stacked bar chart (7 d)** by role — each bar = one day, segments = po/dev/qa/reviewer/merge/judge, Y-axis in USD
- **Per-project table** with Today / 7 d / 30 d cost columns + input/output token totals
- Footer explains the estimation basis and which env vars to tune
- Uses the same Recharts + colour palette as existing `Charts.tsx`
- Panel renders `null` when no data (enabled: false or empty DB)

### Wiring
- `server/app.py` — registers the new router
- `web/src/lib/types.ts` — `TokenSpendRow`, `TokenSpendConfig`, `TokenSpend` interfaces
- `web/src/lib/api.ts` — `fetchTokenSpend()` with fixture fallback
- `web/src/lib/fixtures.ts` — deterministic 30-day fixture (same LCG seed)
- `web/src/screens/Overview.tsx` — `<TokenSpend />` placed below `<ClaudeUsage />`

## Test Plan
- [ ] `ruff check .` — passes (confirmed locally)
- [ ] `npm run typecheck` — passes (confirmed locally)
- [ ] `npm run build` — clean build, no TS errors (confirmed locally)
- [ ] Load `/?fixtures=1` — TokenSpend panel renders stacked bar chart and table with deterministic data
- [ ] With no events in DB — panel renders `null` (no empty card shown)
- [ ] Set `LOOPMON_TOKENS_PER_EVENT=10000` — cost values double in API response and panel
- [ ] `/api/token_spend` returns correct `date/role/project/model` groupings matching events table