### PR TITLE
[LM-111] per-project cycle-time stage breakdown + SLO dashboard

### DIFF
--- a/scripts/reconciler.py
+++ b/scripts/reconciler.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Reconciler tick — checks SLO breaches and emits alerts.
+
+Intended to be invoked on a schedule (e.g. every 15 min by cron or the
+loop orchestrator).  Reads from bounty.db, checks each project with a
+configured SLO, and sends a Signal alert when a sustained breach is detected.
+
+Environment variables:
+    DB_PATH            path to bounty.db (default: bounty.db)
+    SIGNAL_NOTIFY_CMD  path to the notification command; receives the alert
+                       message as a single argument. When absent, the alert
+                       is written to stdout instead.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+
+_TS_FORMATS = (
+    "%Y-%m-%dT%H:%M:%S.%f%z",
+    "%Y-%m-%dT%H:%M:%S%z",
+    "%Y-%m-%dT%H:%M:%S",
+    "%Y-%m-%d %H:%M:%S",
+)
+
+
+def _parse_unix(ts_str: str | None) -> int | None:
+    if not ts_str:
+        return None
+    normalized = str(ts_str).replace("+0000", "+00:00").replace(" ", "T")
+    for fmt in _TS_FORMATS:
+        try:
+            dt = datetime.strptime(normalized, fmt)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return int(dt.timestamp())
+        except ValueError:
+            continue
+    return None
+
+
+def send_signal_alert(message: str) -> None:
+    """Emit an alert via SIGNAL_NOTIFY_CMD or stdout fallback."""
+    cmd = os.environ.get("SIGNAL_NOTIFY_CMD")
+    if not cmd:
+        print(f"[SLO-ALERT] {message}", flush=True)
+        return
+    try:
+        subprocess.run([cmd, message], check=True, timeout=10)
+    except (subprocess.SubprocessError, OSError) as exc:
+        print(f"[SLO-ALERT send-failed: {exc}] {message}", flush=True)
+
+
+def _find_breach_streak_start(conn: sqlite3.Connection, slug: str, total_seconds: int) -> int | None:
+    """Return Unix timestamp of the first run in the current unbroken breach streak, or None."""
+    runs = conn.execute(
+        """SELECT total_duration_seconds, started_at
+           FROM pipeline_runs
+           WHERE project = ? AND total_duration_seconds IS NOT NULL
+           ORDER BY id DESC LIMIT 50""",
+        (slug,),
+    ).fetchall()
+
+    streak_start: int | None = None
+    for run in runs:
+        if run["total_duration_seconds"] > total_seconds:
+            ts = _parse_unix(run["started_at"])
+            if ts is not None:
+                streak_start = ts
+        else:
+            break
+    return streak_start
+
+
+def check_slo_breaches(conn: sqlite3.Connection) -> None:
+    """Check all configured project SLOs and alert on sustained breaches."""
+    slos = conn.execute(
+        "SELECT slug, total_seconds, breach_grace_seconds, last_alerted_at"
+        " FROM project_slos WHERE total_seconds IS NOT NULL"
+    ).fetchall()
+
+    now = int(time.time())
+
+    for slo in slos:
+        slug = slo["slug"]
+        total_seconds = slo["total_seconds"]
+        grace = slo["breach_grace_seconds"]
+        last_alerted_at = slo["last_alerted_at"]
+
+        streak_start = _find_breach_streak_start(conn, slug, total_seconds)
+        if streak_start is None:
+            continue
+
+        breach_duration = now - streak_start
+        if breach_duration < grace:
+            continue
+
+        # Dedupe: skip if already alerted for this breach episode
+        if last_alerted_at is not None and last_alerted_at >= streak_start:
+            continue
+
+        msg = (
+            f"SLO breach: project '{slug}' has exceeded {total_seconds}s "
+            f"for {breach_duration}s (grace threshold: {grace}s)"
+        )
+        send_signal_alert(msg)
+
+        conn.execute(
+            "UPDATE project_slos SET last_alerted_at = ? WHERE slug = ?",
+            (now, slug),
+        )
+        conn.commit()
+
+
+def main() -> int:
+    db_path = os.environ.get("DB_PATH", "bounty.db")
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=10000")
+    try:
+        check_slo_breaches(conn)
+        return 0
+    except Exception as exc:
+        print(f"reconciler error: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/app.py
+++ b/server/app.py
@@ -28,6 +28,7 @@ from server.routes import (  # noqa: E402
     logs,
     runs,
     scanner_state,
+    slos,
     stats,
 )
 
@@ -43,6 +44,7 @@ app.include_router(claude_usage.router)
 app.include_router(issues_cost.router)
 app.include_router(logs.router)
 app.include_router(scanner_state.router)
+app.include_router(slos.router)
 
 if os.path.isdir("static/dist"):
     app.mount("/v2", StaticFiles(directory="static/dist", html=True), name="dist")

--- a/server/db.py
+++ b/server/db.py
@@ -96,6 +96,16 @@ MIGRATIONS = [
             WHERE pr_number IS NOT NULL
         """,
     ),
+    (
+        "0005_project_slos",
+        """CREATE TABLE IF NOT EXISTS project_slos (
+            slug TEXT PRIMARY KEY,
+            total_seconds INTEGER,
+            breach_grace_seconds INTEGER NOT NULL DEFAULT 3600,
+            updated_at INTEGER,
+            last_alerted_at INTEGER
+        )""",
+    ),
 ]
 
 
@@ -114,6 +124,9 @@ def _migration_already_applied(conn: sqlite3.Connection, version_id: str) -> boo
     if version_id == "0004_event_audit_indexes":
         indexes = {r[1] for r in conn.execute("SELECT type, name FROM sqlite_master WHERE type='index'")}
         return "idx_events_project_event_type_created_at" in indexes
+    if version_id == "0005_project_slos":
+        tables = {r[1] for r in conn.execute("SELECT type, name FROM sqlite_master WHERE type='table'")}
+        return "project_slos" in tables
     return False
 
 

--- a/server/routes/slos.py
+++ b/server/routes/slos.py
@@ -1,0 +1,47 @@
+import sqlite3
+import time
+from typing import Optional
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from server.db import db_dep
+
+router = APIRouter()
+
+
+class SloBody(BaseModel):
+    total_seconds: Optional[int] = None
+    breach_grace_seconds: int = 3600
+
+
+@router.get("/api/projects/{slug}/slo")
+def get_slo(slug: str, conn: sqlite3.Connection = Depends(db_dep)):
+    row = conn.execute(
+        "SELECT slug, total_seconds, breach_grace_seconds, updated_at FROM project_slos WHERE slug = ?",
+        (slug,),
+    ).fetchone()
+    if not row:
+        return {"slug": slug, "total_seconds": None, "breach_grace_seconds": 3600, "updated_at": None}
+    return dict(row)
+
+
+@router.put("/api/projects/{slug}/slo")
+def put_slo(slug: str, body: SloBody, conn: sqlite3.Connection = Depends(db_dep)):
+    now = int(time.time())
+    conn.execute(
+        """INSERT INTO project_slos (slug, total_seconds, breach_grace_seconds, updated_at)
+           VALUES (?, ?, ?, ?)
+           ON CONFLICT(slug) DO UPDATE SET
+               total_seconds = excluded.total_seconds,
+               breach_grace_seconds = excluded.breach_grace_seconds,
+               updated_at = excluded.updated_at""",
+        (slug, body.total_seconds, body.breach_grace_seconds, now),
+    )
+    conn.commit()
+    return {
+        "slug": slug,
+        "total_seconds": body.total_seconds,
+        "breach_grace_seconds": body.breach_grace_seconds,
+        "updated_at": now,
+    }

--- a/server/routes/stats.py
+++ b/server/routes/stats.py
@@ -1,4 +1,6 @@
+import json
 import sqlite3
+from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends
@@ -84,6 +86,109 @@ def get_projects(conn: sqlite3.Connection = Depends(db_dep)):
     return [{"project": p, "repo": r} for p, r in PROJECTS.items() if p in active]
 
 
+_TS_FORMATS = (
+    "%Y-%m-%dT%H:%M:%S.%f%z",
+    "%Y-%m-%dT%H:%M:%S%z",
+    "%Y-%m-%dT%H:%M:%S",
+    "%Y-%m-%d %H:%M:%S",
+)
+
+_MIN_STAGE_SAMPLES = 5
+
+
+def _parse_ts_unix(ts_str: Optional[str]) -> Optional[float]:
+    if not ts_str:
+        return None
+    normalized = str(ts_str).replace("+0000", "+00:00").replace(" ", "T")
+    for fmt in _TS_FORMATS:
+        try:
+            dt = datetime.strptime(normalized, fmt)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.timestamp()
+        except ValueError:
+            continue
+    return None
+
+
+def _load_label_transitions(conn: sqlite3.Connection, slug: str) -> dict[int, list]:
+    """Load label_transition events grouped by issue_number."""
+    rows = conn.execute(
+        """SELECT issue_number, payload, created_at
+           FROM events
+           WHERE project = ? AND event_type = 'label_transition' AND issue_number IS NOT NULL
+           ORDER BY issue_number, created_at ASC""",
+        (slug,),
+    ).fetchall()
+
+    by_issue: dict[int, list] = {}
+    for row in rows:
+        inum = row["issue_number"]
+        if inum not in by_issue:
+            by_issue[inum] = []
+        try:
+            payload = json.loads(row["payload"]) if isinstance(row["payload"], str) else (row["payload"] or {})
+        except (json.JSONDecodeError, TypeError):
+            payload = {}
+        by_issue[inum].append({"payload": payload, "created_at": row["created_at"]})
+
+    return by_issue
+
+
+def _compute_stage_durations(by_issue: dict) -> dict[str, list[float]]:
+    """Bucket consecutive label_transition event durations by (from_label, to_label)."""
+    buckets: dict[str, list[float]] = {}
+
+    for _issue_num, events in by_issue.items():
+        prev_ts: Optional[float] = None
+
+        for ev in events:
+            payload = ev["payload"]
+            ts = _parse_ts_unix(ev["created_at"])
+
+            before = set(payload.get("before_labels") or [])
+            after = set(payload.get("after_labels") or [])
+            removed = before - after
+            added = after - before
+
+            if prev_ts is not None and removed and added and ts is not None:
+                duration = ts - prev_ts
+                if duration >= 0:
+                    for fl in removed:
+                        for tl in added:
+                            key = f"{fl}->{tl}"
+                            buckets.setdefault(key, []).append(duration)
+
+            prev_ts = ts
+
+    return buckets
+
+
+def _detect_rework_for_run(events: list) -> bool:
+    """Return True if this run has a backward label transition (label reappears after removal)."""
+    removed_labels: set[str] = set()
+    for ev in events:
+        payload = ev["payload"]
+        before = set(payload.get("before_labels") or [])
+        after = set(payload.get("after_labels") or [])
+        if removed_labels & after:
+            return True
+        removed_labels |= before - after
+    return False
+
+
+def _stage_percentile_stats(values: list) -> Optional[dict]:
+    n = len(values)
+    if n < _MIN_STAGE_SAMPLES:
+        return None
+    sv = sorted(values)
+    return {
+        "p50_seconds": sv[int(0.5 * n)],
+        "p90_seconds": sv[int(0.9 * n)],
+        "sample_size": n,
+    }
+
+
 def _percentile_stats(values: list) -> Optional[dict]:
     n = len(values)
     if n == 0:
@@ -101,7 +206,10 @@ def _percentile_stats(values: list) -> Optional[dict]:
 
 @router.get("/api/projects/{slug}/cycle_times")
 def get_cycle_times(slug: str, conn: sqlite3.Connection = Depends(db_dep)):
-    null_response = {"total_duration": None, "issue_lifetime": None, "pr_lifetime": None}
+    null_response: dict = {
+        "total_duration": None, "issue_lifetime": None, "pr_lifetime": None,
+        "stages": {}, "rework_rate": None,
+    }
     rows = conn.execute(
         """SELECT total_duration_seconds, issue_lifetime_seconds, pr_lifetime_seconds
            FROM pipeline_runs
@@ -110,8 +218,22 @@ def get_cycle_times(slug: str, conn: sqlite3.Connection = Depends(db_dep)):
         (slug,),
     ).fetchall()
 
+    by_issue = _load_label_transitions(conn, slug)
+
+    stage_buckets = _compute_stage_durations(by_issue)
+    stages: dict = {}
+    for key, durations in stage_buckets.items():
+        stats = _stage_percentile_stats(durations)
+        if stats is not None:
+            stages[key] = stats
+
+    rework_rate: Optional[float] = None
+    if by_issue:
+        reworked = sum(1 for evs in by_issue.values() if _detect_rework_for_run(evs))
+        rework_rate = round(reworked / len(by_issue), 4)
+
     if not rows:
-        return null_response
+        return {**null_response, "stages": stages, "rework_rate": rework_rate}
 
     total_vals = [r["total_duration_seconds"] for r in rows]
     issue_vals = [r["issue_lifetime_seconds"] for r in rows if r["issue_lifetime_seconds"] is not None]
@@ -121,4 +243,6 @@ def get_cycle_times(slug: str, conn: sqlite3.Connection = Depends(db_dep)):
         "total_duration": _percentile_stats(total_vals),
         "issue_lifetime": _percentile_stats(issue_vals) if issue_vals else None,
         "pr_lifetime": _percentile_stats(pr_vals) if pr_vals else None,
+        "stages": stages,
+        "rework_rate": rework_rate,
     }

--- a/static/js/components/stats.js
+++ b/static/js/components/stats.js
@@ -1,11 +1,13 @@
 import { escHtml, eventEmoji, fmtDur, timeAgo, timelineLink, durFromIso } from '/js/utils.js';
 import { activeWorkers, statusEntries, projectScores } from '/js/state.js';
 
-function renderSparkline(runs) {
+function renderSparklineWithSlo(runs, slo) {
   const pts = (runs || []).filter(r => r.total_duration_seconds != null).slice(0, 7).reverse();
   if (pts.length < 2) return '';
   const vals = pts.map(r => r.total_duration_seconds);
-  const min = Math.min(...vals), max = Math.max(...vals);
+  const sloVal = slo && slo.total_seconds ? slo.total_seconds : null;
+  const allVals = sloVal != null ? [...vals, sloVal] : vals;
+  const min = Math.min(...allVals), max = Math.max(...allVals);
   const range = max - min || 1;
   const W = 60, H = 24, PAD = 2;
   const points = vals.map((v, i) => {
@@ -13,16 +15,30 @@ function renderSparkline(runs) {
     const y = PAD + (1 - (v - min) / range) * (H - PAD * 2);
     return `${x.toFixed(1)},${y.toFixed(1)}`;
   }).join(' ');
-  return `<svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" style="display:block;margin-top:4px"><polyline points="${points}" fill="none" stroke="var(--accent2)" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"/></svg>`;
+  const dotsHtml = vals.map((v, i) => {
+    if (sloVal == null || v <= sloVal) return '';
+    const x = PAD + (i / (vals.length - 1)) * (W - PAD * 2);
+    const y = PAD + (1 - (v - min) / range) * (H - PAD * 2);
+    return `<circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="1.5" fill="var(--red,#ef4444)"/>`;
+  }).join('');
+  const sloLineHtml = sloVal != null ? (() => {
+    const y = PAD + (1 - (sloVal - min) / range) * (H - PAD * 2);
+    return `<line x1="${PAD}" y1="${y.toFixed(1)}" x2="${W - PAD}" y2="${y.toFixed(1)}" stroke="var(--red,#ef4444)" stroke-width="0.75" stroke-dasharray="2,1"/>`;
+  })() : '';
+  return `<svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" style="display:block;margin-top:4px"><polyline points="${points}" fill="none" stroke="var(--accent2)" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"/>${sloLineHtml}${dotsHtml}</svg>`;
 }
 
 async function fetchAndRenderCycleTime(proj) {
   const panel = document.querySelector(`.agent-card[data-proj="${CSS.escape(proj)}"] .cycle-time-panel`);
   if (!panel) return;
   try {
-    const res = await fetch(`/api/projects/${encodeURIComponent(proj)}/cycle_times`);
-    if (!res.ok) throw new Error('failed');
-    const data = await res.json();
+    const [ctRes, sloRes] = await Promise.all([
+      fetch(`/api/projects/${encodeURIComponent(proj)}/cycle_times`),
+      fetch(`/api/projects/${encodeURIComponent(proj)}/slo`),
+    ]);
+    if (!ctRes.ok) throw new Error('failed');
+    const data = await ctRes.json();
+    const slo = sloRes.ok ? await sloRes.json() : null;
     const total = data.total_duration;
     if (!total || !total.sample_size) {
       panel.innerHTML = '<span style="color:var(--muted)">—</span>';
@@ -33,9 +49,25 @@ async function fetchAndRenderCycleTime(proj) {
     const label  = `median: ${median} · P90: ${p90} · (last ${total.sample_size} runs)`;
     const runsRes  = await fetch(`/api/runs/${encodeURIComponent(proj)}`);
     const runsData = runsRes.ok ? await runsRes.json() : [];
-    const spark    = renderSparkline(runsData);
+    const spark    = renderSparklineWithSlo(runsData, slo);
+
+    const stages = data.stages || {};
+    const stageKeys = Object.keys(stages);
+    const stagesHtml = stageKeys.length
+      ? `<div style="margin-top:6px;display:flex;flex-wrap:wrap;gap:4px">${
+          stageKeys.map(k => {
+            const s = stages[k];
+            return `<span title="${escHtml(k)}: P50=${fmtDur(s.p50_seconds)}, P90=${fmtDur(s.p90_seconds)}, n=${s.sample_size}" style="font-size:0.65rem;color:var(--muted);background:var(--bg-2);padding:1px 4px">${escHtml(k)}: ${fmtDur(s.p50_seconds)}/${fmtDur(s.p90_seconds)}</span>`;
+          }).join('')
+        }</div>`
+      : '';
+
+    const reworkHtml = data.rework_rate != null
+      ? `<div style="font-size:0.65rem;color:var(--muted);margin-top:2px">rework: ${Math.round(data.rework_rate * 100)}%</div>`
+      : '';
+
     panel.innerHTML =
-      `<span title="Median time from first event to completion, last ${total.sample_size} runs" style="color:var(--muted)">${escHtml(label)}</span>${spark}`;
+      `<span title="Median time from first event to completion, last ${total.sample_size} runs" style="color:var(--muted)">${escHtml(label)}</span>${spark}${stagesHtml}${reworkHtml}`;
   } catch {
     panel.innerHTML = '<span style="color:var(--muted)">—</span>';
   }

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -19,10 +19,12 @@ def test_fresh_db_applies_all_migrations(tmp_path, monkeypatch):
         "0002_add_loop_id",
         "0003_add_pipeline_run_cols",
         "0004_event_audit_indexes",
+        "0005_project_slos",
     ]
     conn = sqlite3.connect(db_path)
     event_cols = {r[1] for r in conn.execute("PRAGMA table_info(events)")}
     run_cols = {r[1] for r in conn.execute("PRAGMA table_info(pipeline_runs)")}
+    slo_cols = {r[1] for r in conn.execute("PRAGMA table_info(project_slos)")}
     indexes = {r[1] for r in conn.execute("SELECT type, name FROM sqlite_master WHERE type='index'")}
     conn.close()
     assert "loop_id" in event_cols
@@ -32,6 +34,10 @@ def test_fresh_db_applies_all_migrations(tmp_path, monkeypatch):
     assert "idx_events_project_event_type_created_at" in indexes
     assert "idx_events_project_issue_created_at" in indexes
     assert "idx_events_project_pr_created_at" in indexes
+    assert "slug" in slo_cols
+    assert "total_seconds" in slo_cols
+    assert "breach_grace_seconds" in slo_cols
+    assert "last_alerted_at" in slo_cols
 
 
 def test_apply_pending_migrations_idempotent(tmp_path, monkeypatch):
@@ -48,6 +54,7 @@ def test_apply_pending_migrations_idempotent(tmp_path, monkeypatch):
         "0002_add_loop_id",
         "0003_add_pipeline_run_cols",
         "0004_event_audit_indexes",
+        "0005_project_slos",
     ]
 
 

--- a/tests/test_slo.py
+++ b/tests/test_slo.py
@@ -1,0 +1,423 @@
+"""Tests for SLO config CRUD, stage duration math, rework detection, and breach logic."""
+import json
+import sqlite3
+import time
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+import server
+import server.db
+from scripts.reconciler import _find_breach_streak_start, check_slo_breaches
+from server.routes.stats import (
+    _compute_stage_durations,
+    _detect_rework_for_run,
+    _load_label_transitions,
+    _stage_percentile_stats,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _insert_label_transition(conn, project, issue_number, before_labels, after_labels, created_at):
+    payload = json.dumps({
+        "target_kind": "issue",
+        "number": issue_number,
+        "before_labels": before_labels,
+        "after_labels": after_labels,
+        "op": "swap",
+        "source": "test",
+    })
+    conn.execute(
+        "INSERT INTO events (project, role, event_type, issue_number, payload, created_at)"
+        " VALUES (?, 'scanner', 'label_transition', ?, ?, ?)",
+        (project, issue_number, payload, created_at),
+    )
+
+
+def _insert_run(conn, project, issue_number, duration_seconds, started_at=None, completed_at=None):
+    started = started_at or "2024-01-01T10:00:00"
+    completed = completed_at or "2024-01-01T11:00:00"
+    conn.execute(
+        """INSERT INTO pipeline_runs
+           (project, issue_number, total_duration_seconds, started_at, completed_at, created_at)
+           VALUES (?, ?, ?, ?, ?, datetime('now'))""",
+        (project, issue_number, duration_seconds, started, completed),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stage duration math
+# ---------------------------------------------------------------------------
+
+def test_stage_durations_basic(isolated_client):
+    """Stage durations computed from consecutive label_transition events.
+
+    The bucket key (from->to) uses the removed/added labels of each event; the
+    duration is the elapsed time from the PREVIOUS event to the CURRENT event
+    (i.e. time spent in the 'from' state before transitioning to 'to').
+    """
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.row_factory = sqlite3.Row
+
+    # t=10:00 — enter in-progress (swap open → in-progress)
+    _insert_label_transition(conn, "proj-sd", 1,
+                             ["open"], ["in-progress"],
+                             "2024-01-01T10:00:00")
+    # t=10:10 — enter review (swap in-progress → review), 600s in in-progress
+    _insert_label_transition(conn, "proj-sd", 1,
+                             ["in-progress"], ["review"],
+                             "2024-01-01T10:10:00")
+    # t=10:40 — enter merged (swap review → merged), 1800s in review
+    _insert_label_transition(conn, "proj-sd", 1,
+                             ["review"], ["merged"],
+                             "2024-01-01T10:40:00")
+    conn.commit()
+    conn.close()
+
+    conn2 = sqlite3.connect(server.db.DB_PATH)
+    conn2.row_factory = sqlite3.Row
+    by_issue = _load_label_transitions(conn2, "proj-sd")
+    conn2.close()
+
+    assert 1 in by_issue
+    buckets = _compute_stage_durations(by_issue)
+
+    # Duration from event 1 to event 2 = 600s → bucket key from event 2: "in-progress->review"
+    assert "in-progress->review" in buckets
+    assert abs(buckets["in-progress->review"][0] - 600) < 2
+
+    # Duration from event 2 to event 3 = 1800s → bucket key from event 3: "review->merged"
+    assert "review->merged" in buckets
+    assert abs(buckets["review->merged"][0] - 1800) < 2
+
+
+def test_stage_durations_multiple_runs(isolated_client):
+    """Multiple runs contribute to the same bucket."""
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.row_factory = sqlite3.Row
+
+    for issue_num in range(1, 8):
+        # t=10:00 — swap open → in-progress
+        _insert_label_transition(conn, "proj-mr", issue_num,
+                                 ["open"], ["in-progress"],
+                                 f"2024-01-{issue_num:02d}T10:00:00")
+        # t=10:30 — swap in-progress → merged (1800s elapsed)
+        _insert_label_transition(conn, "proj-mr", issue_num,
+                                 ["in-progress"], ["merged"],
+                                 f"2024-01-{issue_num:02d}T10:30:00")
+    conn.commit()
+    conn.close()
+
+    conn2 = sqlite3.connect(server.db.DB_PATH)
+    conn2.row_factory = sqlite3.Row
+    by_issue = _load_label_transitions(conn2, "proj-mr")
+    buckets = _compute_stage_durations(by_issue)
+    conn2.close()
+
+    # 7 issues, each contributing 1800s to "in-progress->merged"
+    assert "in-progress->merged" in buckets
+    assert len(buckets["in-progress->merged"]) == 7
+    stats = _stage_percentile_stats(buckets["in-progress->merged"])
+    assert stats is not None
+    assert stats["sample_size"] == 7
+    assert stats["p50_seconds"] == pytest.approx(1800, abs=2)
+
+
+def test_stage_percentile_stats_below_min_returns_none():
+    """_stage_percentile_stats returns None for fewer than 5 samples."""
+    assert _stage_percentile_stats([]) is None
+    assert _stage_percentile_stats([100, 200, 300, 400]) is None
+
+
+def test_stage_percentile_stats_with_five_samples():
+    """Five samples meet the minimum; correct P50/P90 returned."""
+    vals = [100, 200, 300, 400, 500]
+    stats = _stage_percentile_stats(vals)
+    assert stats is not None
+    assert stats["sample_size"] == 5
+    # int(0.5 * 5) = 2 -> sorted[2] = 300
+    assert stats["p50_seconds"] == 300
+    # int(0.9 * 5) = 4 -> sorted[4] = 500
+    assert stats["p90_seconds"] == 500
+
+
+def test_cycle_times_includes_stages(isolated_client):
+    """GET /api/projects/{slug}/cycle_times response includes stages when data is available."""
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.row_factory = sqlite3.Row
+
+    # Insert 6 issues each with two transitions: open→in-progress, in-progress→done
+    for i in range(1, 7):
+        _insert_label_transition(conn, "proj-cts", i,
+                                 ["open"], ["in-progress"],
+                                 f"2024-01-{i:02d}T09:00:00")
+        # 1h later: in-progress → done (3600s elapsed)
+        _insert_label_transition(conn, "proj-cts", i,
+                                 ["in-progress"], ["done"],
+                                 f"2024-01-{i:02d}T10:00:00")
+        _insert_run(conn, "proj-cts", i, 3600)
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/projects/proj-cts/cycle_times")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "stages" in data
+    # Duration from event 1→event 2 = 3600s in bucket "in-progress->done"
+    # 6 samples >= MIN_STAGE_SAMPLES(5), so stage stats should be populated
+    assert "in-progress->done" in data["stages"]
+    stage = data["stages"]["in-progress->done"]
+    assert "p50_seconds" in stage
+    assert "p90_seconds" in stage
+    assert stage["sample_size"] == 6
+
+
+# ---------------------------------------------------------------------------
+# Rework detection
+# ---------------------------------------------------------------------------
+
+def test_rework_detected_when_label_reappears():
+    """A run is flagged as reworked when a removed label reappears."""
+    events = [
+        {"payload": {"before_labels": ["open"], "after_labels": ["in-progress"]},
+         "created_at": "2024-01-01T10:00:00"},
+        {"payload": {"before_labels": ["in-progress"], "after_labels": ["review"]},
+         "created_at": "2024-01-01T11:00:00"},
+        # rework: in-progress reappears after review
+        {"payload": {"before_labels": ["review"], "after_labels": ["in-progress"]},
+         "created_at": "2024-01-01T12:00:00"},
+    ]
+    assert _detect_rework_for_run(events) is True
+
+
+def test_no_rework_for_clean_progression():
+    """A clean forward progression is not flagged as rework."""
+    events = [
+        {"payload": {"before_labels": ["open"], "after_labels": ["in-progress"]},
+         "created_at": "2024-01-01T10:00:00"},
+        {"payload": {"before_labels": ["in-progress"], "after_labels": ["review"]},
+         "created_at": "2024-01-01T11:00:00"},
+        {"payload": {"before_labels": ["review"], "after_labels": ["merged"]},
+         "created_at": "2024-01-01T12:00:00"},
+    ]
+    assert _detect_rework_for_run(events) is False
+
+
+def test_rework_rate_in_cycle_times(isolated_client):
+    """rework_rate in GET /api/projects/{slug}/cycle_times reflects actual reworks."""
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.row_factory = sqlite3.Row
+
+    # Issue 1: clean run
+    _insert_label_transition(conn, "proj-rw", 1,
+                             ["open"], ["in-progress"], "2024-01-01T10:00:00")
+    _insert_label_transition(conn, "proj-rw", 1,
+                             ["in-progress"], ["done"], "2024-01-01T11:00:00")
+    _insert_run(conn, "proj-rw", 1, 3600)
+
+    # Issue 2: rework (in-progress reappears)
+    _insert_label_transition(conn, "proj-rw", 2,
+                             ["open"], ["in-progress"], "2024-01-02T10:00:00")
+    _insert_label_transition(conn, "proj-rw", 2,
+                             ["in-progress"], ["review"], "2024-01-02T11:00:00")
+    _insert_label_transition(conn, "proj-rw", 2,
+                             ["review"], ["in-progress"], "2024-01-02T12:00:00")
+    _insert_run(conn, "proj-rw", 2, 7200)
+
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/projects/proj-rw/cycle_times")
+    assert resp.status_code == 200
+    data = resp.json()
+    # 1 out of 2 issues reworked = 0.5
+    assert data["rework_rate"] == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# SLO CRUD
+# ---------------------------------------------------------------------------
+
+def test_slo_get_returns_defaults_when_not_set(isolated_client):
+    """GET /api/projects/{slug}/slo returns defaults for an unconfigured project."""
+    resp = isolated_client.get("/api/projects/new-proj/slo")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["slug"] == "new-proj"
+    assert data["total_seconds"] is None
+    assert data["breach_grace_seconds"] == 3600
+    assert data["updated_at"] is None
+
+
+def test_slo_put_and_get_roundtrip(isolated_client):
+    """PUT followed by GET returns the stored SLO values."""
+    put_resp = isolated_client.put("/api/projects/my-proj/slo", json={
+        "total_seconds": 7200,
+        "breach_grace_seconds": 1800,
+    })
+    assert put_resp.status_code == 200
+    put_data = put_resp.json()
+    assert put_data["total_seconds"] == 7200
+    assert put_data["breach_grace_seconds"] == 1800
+    assert put_data["updated_at"] is not None
+
+    get_resp = isolated_client.get("/api/projects/my-proj/slo")
+    assert get_resp.status_code == 200
+    get_data = get_resp.json()
+    assert get_data["total_seconds"] == 7200
+    assert get_data["breach_grace_seconds"] == 1800
+
+
+def test_slo_put_update_overwrites(isolated_client):
+    """A second PUT updates the existing SLO row."""
+    isolated_client.put("/api/projects/proj-ow/slo", json={
+        "total_seconds": 3600,
+        "breach_grace_seconds": 600,
+    })
+    isolated_client.put("/api/projects/proj-ow/slo", json={
+        "total_seconds": 9000,
+        "breach_grace_seconds": 300,
+    })
+    get_resp = isolated_client.get("/api/projects/proj-ow/slo")
+    data = get_resp.json()
+    assert data["total_seconds"] == 9000
+    assert data["breach_grace_seconds"] == 300
+
+
+def test_slo_put_null_total_seconds(isolated_client):
+    """total_seconds can be set to null (disables the SLO threshold)."""
+    isolated_client.put("/api/projects/proj-null/slo", json={
+        "total_seconds": 3600,
+        "breach_grace_seconds": 600,
+    })
+    resp = isolated_client.put("/api/projects/proj-null/slo", json={
+        "total_seconds": None,
+        "breach_grace_seconds": 600,
+    })
+    assert resp.status_code == 200
+    assert resp.json()["total_seconds"] is None
+
+
+# ---------------------------------------------------------------------------
+# Breach detection and dedup
+# ---------------------------------------------------------------------------
+
+_RUN_INSERT = (
+    "INSERT INTO pipeline_runs"
+    " (project, issue_number, total_duration_seconds, started_at, completed_at, created_at)"
+    " VALUES (?, ?, ?, ?, ?, ?)"
+)
+
+
+def _make_reconciler_db(tmp_path):
+    db_path = str(tmp_path / "breach.db")
+    old_path = server.db.DB_PATH
+    server.db.DB_PATH = db_path
+    server.db.apply_pending_migrations()
+    server.db.DB_PATH = old_path
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn, db_path
+
+
+def test_breach_streak_start_found(tmp_path):
+    """_find_breach_streak_start returns the oldest ts in a continuous breach streak."""
+    conn, _ = _make_reconciler_db(tmp_path)
+
+    conn.execute(_RUN_INSERT, ("proj", 1, 5000,
+                               "2024-01-01T08:00:00", "2024-01-01T09:00:00", "2024-01-01T09:00:00"))
+    conn.execute(_RUN_INSERT, ("proj", 2, 9000,
+                               "2024-01-02T08:00:00", "2024-01-02T09:30:00", "2024-01-02T09:30:00"))
+    conn.execute(_RUN_INSERT, ("proj", 3, 12000,
+                               "2024-01-03T08:00:00", "2024-01-03T11:00:00", "2024-01-03T11:00:00"))
+    conn.commit()
+
+    # SLO = 7200s; runs 2 and 3 breach, run 1 doesn't
+    streak_start = _find_breach_streak_start(conn, "proj", 7200)
+    conn.close()
+
+    # The streak includes runs 2 and 3 (DESC order stops at run 1 which doesn't breach)
+    assert streak_start is not None
+    expected = int(datetime(2024, 1, 2, 8, 0, 0, tzinfo=timezone.utc).timestamp())
+    assert streak_start == expected
+
+
+def test_breach_streak_none_when_no_breach(tmp_path):
+    """_find_breach_streak_start returns None when no runs exceed the SLO."""
+    conn, _ = _make_reconciler_db(tmp_path)
+    conn.execute(_RUN_INSERT, ("proj", 1, 1000,
+                               "2024-01-01T08:00:00", "2024-01-01T09:00:00", "2024-01-01T09:00:00"))
+    conn.commit()
+    result = _find_breach_streak_start(conn, "proj", 7200)
+    conn.close()
+    assert result is None
+
+
+def test_check_slo_breaches_sends_alert(tmp_path):
+    """check_slo_breaches calls send_signal_alert when breach exceeds grace period."""
+    conn, _ = _make_reconciler_db(tmp_path)
+
+    two_hours_ago = time.time() - 7200
+    started_iso = datetime.fromtimestamp(two_hours_ago, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    conn.execute(_RUN_INSERT, ("proj-breach", 1, 9000, started_iso, started_iso, started_iso))
+    conn.execute(
+        "INSERT INTO project_slos (slug, total_seconds, breach_grace_seconds)"
+        " VALUES ('proj-breach', 7200, 3600)"
+    )
+    conn.commit()
+
+    alerts: list[str] = []
+    with patch("scripts.reconciler.send_signal_alert", side_effect=lambda m: alerts.append(m)):
+        check_slo_breaches(conn)
+
+    conn.close()
+    assert len(alerts) == 1
+    assert "proj-breach" in alerts[0]
+
+
+def test_check_slo_breaches_deduplicates(tmp_path):
+    """check_slo_breaches does not send a second alert for the same breach episode."""
+    conn, _ = _make_reconciler_db(tmp_path)
+
+    two_hours_ago = time.time() - 7200
+    started_iso = datetime.fromtimestamp(two_hours_ago, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    conn.execute(_RUN_INSERT, ("proj-dd", 1, 9000, started_iso, started_iso, started_iso))
+    # last_alerted_at set to now (already alerted for this breach episode)
+    conn.execute(
+        "INSERT INTO project_slos (slug, total_seconds, breach_grace_seconds, last_alerted_at)"
+        " VALUES ('proj-dd', 7200, 3600, ?)",
+        (int(time.time()),),
+    )
+    conn.commit()
+
+    alerts: list[str] = []
+    with patch("scripts.reconciler.send_signal_alert", side_effect=lambda m: alerts.append(m)):
+        check_slo_breaches(conn)
+
+    conn.close()
+    assert len(alerts) == 0
+
+
+def test_check_slo_breaches_skips_within_grace(tmp_path):
+    """check_slo_breaches does not alert when breach duration is within grace period."""
+    conn, _ = _make_reconciler_db(tmp_path)
+
+    # Run started 10 minutes ago, grace is 1 hour
+    ten_min_ago = time.time() - 600
+    started_iso = datetime.fromtimestamp(ten_min_ago, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    conn.execute(_RUN_INSERT, ("proj-grace", 1, 9000, started_iso, started_iso, started_iso))
+    conn.execute(
+        "INSERT INTO project_slos (slug, total_seconds, breach_grace_seconds)"
+        " VALUES ('proj-grace', 7200, 3600)"
+    )
+    conn.commit()
+
+    alerts: list[str] = []
+    with patch("scripts.reconciler.send_signal_alert", side_effect=lambda m: alerts.append(m)):
+        check_slo_breaches(conn)
+
+    conn.close()
+    assert len(alerts) == 0

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -90,7 +90,11 @@ def test_cycle_times_empty(isolated_client):
     resp = isolated_client.get("/api/projects/no-such-project/cycle_times")
     assert resp.status_code == 200
     data = resp.json()
-    assert data == {"total_duration": None, "issue_lifetime": None, "pr_lifetime": None}
+    assert data["total_duration"] is None
+    assert data["issue_lifetime"] is None
+    assert data["pr_lifetime"] is None
+    assert data["stages"] == {}
+    assert data["rework_rate"] is None
 
 
 def test_cycle_times_with_data(isolated_client):

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -22,6 +22,8 @@ import type {
   LogsResponse,
   IssueCostRow,
   FailureContext,
+  CycleTimesResponse,
+  SloConfig,
 } from './types';
 import * as fx from './fixtures';
 
@@ -159,6 +161,24 @@ export async function fetchFailureContext(
   return get<FailureContext>(
     `/api/action_queue/${encodeURIComponent(project)}/${encodeURIComponent(kind)}/${number}/failure`,
   );
+}
+
+export async function fetchCycleTimes(project: string): Promise<CycleTimesResponse> {
+  return get<CycleTimesResponse>(`/api/projects/${encodeURIComponent(project)}/cycle_times`);
+}
+
+export async function fetchSlo(project: string): Promise<SloConfig> {
+  return get<SloConfig>(`/api/projects/${encodeURIComponent(project)}/slo`);
+}
+
+export async function putSlo(project: string, body: { total_seconds: number | null; breach_grace_seconds: number }): Promise<SloConfig> {
+  const res = await fetch(`/api/projects/${encodeURIComponent(project)}/slo`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.json() as Promise<SloConfig>;
 }
 
 export class LogsDisabledError extends Error {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -213,6 +213,34 @@ export interface FailureContext {
   log_path: string | null;
 }
 
+export interface StageStat {
+  p50_seconds: number;
+  p90_seconds: number;
+  sample_size: number;
+}
+
+export interface PercentileStat {
+  median_seconds: number;
+  p90_seconds: number;
+  sample_size: number;
+  most_recent_seconds: number;
+}
+
+export interface CycleTimesResponse {
+  total_duration: PercentileStat | null;
+  issue_lifetime: PercentileStat | null;
+  pr_lifetime: PercentileStat | null;
+  stages: Record<string, StageStat>;
+  rework_rate: number | null;
+}
+
+export interface SloConfig {
+  slug: string;
+  total_seconds: number | null;
+  breach_grace_seconds: number;
+  updated_at: number | null;
+}
+
 export interface IssueCostRow {
   project: string;
   issue_number: number;

--- a/web/src/screens/ProjectDetail.tsx
+++ b/web/src/screens/ProjectDetail.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import PrMonitorTable from '../components/PrMonitorTable';
-import type { Worker, FeedItem, PipelineRun, PRMonitorEntry } from '../lib/types';
+import type { Worker, FeedItem, PipelineRun, PRMonitorEntry, CycleTimesResponse, SloConfig } from '../lib/types';
+import { fetchCycleTimes, fetchSlo } from '../lib/api';
 
 interface IssueRollup {
   num: number;
@@ -58,6 +59,109 @@ function fmtDuration(secs: number | null): string {
   return m ? `${h}h ${m}m` : `${h}h`;
 }
 
+function Sparkline({ runs, slo }: { runs: PipelineRun[]; slo: SloConfig | null }) {
+  const pts = runs.filter(r => r.total_duration_seconds != null).slice(0, 7).reverse();
+  if (pts.length < 2) return null;
+  const vals = pts.map(r => r.total_duration_seconds as number);
+  const sloVal = slo?.total_seconds ?? null;
+  const allVals = sloVal != null ? [...vals, sloVal] : vals;
+  const min = Math.min(...allVals), max = Math.max(...allVals);
+  const range = max - min || 1;
+  const W = 80, H = 28, PAD = 3;
+  const pointsStr = vals.map((v, i) => {
+    const x = PAD + (i / (vals.length - 1)) * (W - PAD * 2);
+    const y = PAD + (1 - (v - min) / range) * (H - PAD * 2);
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  }).join(' ');
+  const sloY = sloVal != null ? PAD + (1 - (sloVal - min) / range) * (H - PAD * 2) : null;
+  return (
+    <svg width={W} height={H} viewBox={`0 0 ${W} ${H}`} style={{ display: 'block' }}>
+      <polyline points={pointsStr} fill="none" stroke="var(--accent2,#7c3aed)" strokeWidth={1.5} strokeLinejoin="round" strokeLinecap="round" />
+      {sloY != null && (
+        <line x1={PAD} y1={sloY} x2={W - PAD} y2={sloY} stroke="var(--fail,#ef4444)" strokeWidth={0.75} strokeDasharray="2,1" />
+      )}
+      {vals.map((v, i) => {
+        if (sloVal == null || v <= sloVal) return null;
+        const x = PAD + (i / (vals.length - 1)) * (W - PAD * 2);
+        const y = PAD + (1 - (v - min) / range) * (H - PAD * 2);
+        return <circle key={i} cx={x} cy={y} r={1.5} fill="var(--fail,#ef4444)" />;
+      })}
+    </svg>
+  );
+}
+
+interface CycleTimePanelProps {
+  cycleTimes: CycleTimesResponse | null;
+  slo: SloConfig | null;
+  runs: PipelineRun[];
+}
+
+function CycleTimePanel({ cycleTimes, slo, runs }: CycleTimePanelProps) {
+  const total = cycleTimes?.total_duration;
+  const stages = cycleTimes?.stages ?? {};
+  const stageKeys = Object.keys(stages);
+  const reworkRate = cycleTimes?.rework_rate;
+
+  return (
+    <div className="panel">
+      <div className="panel-h">
+        <span>Cycle time</span>
+        {slo?.total_seconds != null && (
+          <span className="muted mono" style={{ fontSize: 11 }}>SLO: {fmtDuration(slo.total_seconds)}</span>
+        )}
+      </div>
+      <div style={{ padding: 'var(--pad-3) var(--pad-4)' }}>
+        {!total ? (
+          <div className="muted" style={{ fontSize: 12 }}>No completed runs yet</div>
+        ) : (
+          <>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+              <div>
+                <div className="muted" style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.1em' }}>Median</div>
+                <div className="num" style={{ fontSize: 18 }}>{fmtDuration(total.median_seconds)}</div>
+              </div>
+              <div>
+                <div className="muted" style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.1em' }}>P90</div>
+                <div className="num" style={{ fontSize: 18 }}>{fmtDuration(total.p90_seconds)}</div>
+              </div>
+              <div>
+                <div className="muted" style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.1em' }}>Samples</div>
+                <div className="num muted" style={{ fontSize: 18 }}>{total.sample_size}</div>
+              </div>
+              {reworkRate != null && (
+                <div>
+                  <div className="muted" style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.1em' }}>Rework</div>
+                  <div className="num" style={{ fontSize: 18 }}>{Math.round(reworkRate * 100)}%</div>
+                </div>
+              )}
+              <div style={{ flex: 1, display: 'flex', justifyContent: 'flex-end' }}>
+                <Sparkline runs={runs} slo={slo} />
+              </div>
+            </div>
+            {stageKeys.length > 0 && (
+              <div style={{ marginTop: 10, display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))', gap: 6 }}>
+                {stageKeys.map(k => {
+                  const s = stages[k];
+                  return (
+                    <div key={k} style={{ background: 'var(--bg-2)', padding: '4px 8px' }}>
+                      <div className="muted mono" style={{ fontSize: 10, marginBottom: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={k}>{k}</div>
+                      <div style={{ display: 'flex', gap: 8, fontSize: 11 }}>
+                        <span><span className="muted">P50 </span>{fmtDuration(s.p50_seconds)}</span>
+                        <span><span className="muted">P90 </span>{fmtDuration(s.p90_seconds)}</span>
+                        <span className="muted">n={s.sample_size}</span>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export default function ProjectDetail({ projectId, allProjectIds, onBack, onProjectChange }: ProjectDetailProps) {
   const [runs, setRuns] = useState<PipelineRun[]>([]);
   const [prs, setPrs] = useState<PRMonitorEntry[]>([]);
@@ -66,6 +170,8 @@ export default function ProjectDetail({ projectId, allProjectIds, onBack, onProj
   const [prsLoading, setPrsLoading] = useState(true);
   const [prsError, setPrsError] = useState(false);
   const [includeFinishedPrs, setIncludeFinishedPrs] = useState(false);
+  const [cycleTimes, setCycleTimes] = useState<CycleTimesResponse | null>(null);
+  const [sloConfig, setSloConfig] = useState<SloConfig | null>(null);
 
   // Fetch runs
   useEffect(() => {
@@ -93,6 +199,18 @@ export default function ProjectDetail({ projectId, allProjectIds, onBack, onProj
       .then(r => r.ok ? r.json() : Promise.reject(r.status))
       .then((data: FeedItem[]) => setFeed(data.filter(e => e.project === projectId)))
       .catch(() => setFeed([]));
+  }, [projectId]);
+
+  // Fetch cycle times and SLO config
+  useEffect(() => {
+    setCycleTimes(null);
+    setSloConfig(null);
+    fetchCycleTimes(projectId)
+      .then(data => setCycleTimes(data))
+      .catch(() => setCycleTimes(null));
+    fetchSlo(projectId)
+      .then(data => setSloConfig(data))
+      .catch(() => setSloConfig(null));
   }, [projectId]);
 
   // Fetch active workers
@@ -277,6 +395,9 @@ export default function ProjectDetail({ projectId, allProjectIds, onBack, onProj
             </div>
           </div>
         </div>
+
+        {/* Cycle time + SLO panel */}
+        <CycleTimePanel cycleTimes={cycleTimes} slo={sloConfig} runs={runs} />
 
         {/* PR Monitor */}
         <PrMonitorTable


### PR DESCRIPTION
Closes #111

## Changes

### Backend
- **`server/routes/stats.py`** — `GET /api/projects/{slug}/cycle_times` now returns `stages` (P50/P90/sample_size per `from_label->to_label` transition derived from `label_transition` events in the events table) and `rework_rate` (fraction of issues where a removed label reappears). Stage stats return `null` when sample_size < 5, matching the existing thin-data guard.
- **`server/routes/slos.py`** — new `GET/PUT /api/projects/{slug}/slo` endpoints; stored in `project_slos` table.
- **`server/db.py`** — migration `0005_project_slos` creates `project_slos(slug PK, total_seconds, breach_grace_seconds DEFAULT 3600, updated_at, last_alerted_at)`.
- **`server/app.py`** — wires the new slos router.
- **`scripts/reconciler.py`** — new reconciler tick: checks all projects with SLO configs, sends Signal alert (via `SIGNAL_NOTIFY_CMD` env var, stdout fallback) when a sustained breach exceeds `breach_grace_seconds`. Alert is deduped by storing `last_alerted_at` (one alert per breach episode).

### Frontend
- **`static/js/components/stats.js`** — `fetchAndRenderCycleTime` now fetches SLO config in parallel; sparkline shows a dashed red SLO threshold line and highlights breached samples; stage P50/P90 chips rendered below the sparkline; rework rate shown.
- **`web/src/screens/ProjectDetail.tsx`** — new `CycleTimePanel` component with inline sparkline (SVG with SLO line + breach dots), per-stage P50/P90 grid, and rework rate.
- **`web/src/lib/types.ts`** — `CycleTimesResponse`, `StageStat`, `PercentileStat`, `SloConfig` types.
- **`web/src/lib/api.ts`** — `fetchCycleTimes`, `fetchSlo`, `putSlo` functions.

### Tests
- **`tests/test_slo.py`** — 17 new tests covering: stage-duration math from synthetic label_transition fixtures, rework detection (positive + negative), SLO CRUD round-trip (GET defaults, PUT, update overwrite, null total_seconds), breach streak detection, alert send, dedup, and within-grace skip.
- **`tests/test_stats.py`** — updated `test_cycle_times_empty` to match new response shape.
- **`tests/test_migrations.py`** — updated to expect `0005_project_slos` in the applied list.

## Test Plan
- [ ] `ruff check .` passes
- [ ] `npm run typecheck && npm run build` passes
- [ ] `pytest tests/test_slo.py tests/test_stats.py tests/test_migrations.py` — 27/27 pass
- [ ] Manually: PUT `/api/projects/my-proj/slo` with `{"total_seconds": 3600, "breach_grace_seconds": 600}` → GET returns the same values
- [ ] Manually: GET `/api/projects/my-proj/cycle_times` returns `stages: {}` when no label_transition events; returns populated stage stats after inserting ≥5 label_transition events