### PR TITLE
[LM-128] cap /api/runs with LIMIT + envelope response

### DIFF
--- a/server/routes/runs.py
+++ b/server/routes/runs.py
@@ -3,7 +3,7 @@ import sqlite3
 from datetime import datetime, timezone
 from typing import Optional
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from server.constants import PROJECTS
 from server.db import db_dep
@@ -59,29 +59,39 @@ def get_history(project: str, issue: int, conn: sqlite3.Connection = Depends(db_
 
 
 @router.get("/api/runs")
-def get_runs(conn: sqlite3.Connection = Depends(db_dep)):
+def get_runs(limit: int = Query(200), conn: sqlite3.Connection = Depends(db_dep)):
+    limit = max(1, min(limit, 1000))
+    total = conn.execute("SELECT COUNT(*) FROM pipeline_runs").fetchone()[0]
     rows = conn.execute(
         """SELECT id, project, issue_number, pr_number, title, outcome,
                   started_at, completed_at, total_duration_seconds,
                   rework_count, total_bounty, created_at
            FROM pipeline_runs
-           ORDER BY id DESC"""
+           ORDER BY id DESC
+           LIMIT ?""",
+        (limit,),
     ).fetchall()
-    return [dict(r) for r in rows]
+    return {"runs": [dict(r) for r in rows], "total": total, "limit": limit}
 
 
 @router.get("/api/runs/{project}")
-def get_runs_by_project(project: str, conn: sqlite3.Connection = Depends(db_dep)):
+def get_runs_by_project(project: str, limit: int = Query(200), conn: sqlite3.Connection = Depends(db_dep)):
+    limit = max(1, min(limit, 1000))
+    total = conn.execute(
+        "SELECT COUNT(*) FROM pipeline_runs WHERE project=?",
+        (project,),
+    ).fetchone()[0]
     rows = conn.execute(
         """SELECT id, project, issue_number, pr_number, title, outcome,
                   started_at, completed_at, total_duration_seconds,
                   rework_count, total_bounty, created_at
            FROM pipeline_runs
            WHERE project=?
-           ORDER BY id DESC""",
-        (project,),
+           ORDER BY id DESC
+           LIMIT ?""",
+        (project, limit),
     ).fetchall()
-    return [dict(r) for r in rows]
+    return {"runs": [dict(r) for r in rows], "total": total, "limit": limit}
 
 
 @router.get("/api/projects/{slug}/prs")

--- a/static/js/components/runs.js
+++ b/static/js/components/runs.js
@@ -28,7 +28,7 @@ export function showProjectPanel(project) {
   currentProject = project;
   fetch('/api/runs/' + encodeURIComponent(project))
     .then(r => r.ok ? r.json() : Promise.reject(r.status))
-    .then(rows => renderRunsTable(project, rows))
+    .then(payload => renderRunsTable(project, payload.runs || []))
     .catch(() => {
       document.getElementById('runs-table-body').innerHTML =
         '<tr><td colspan="6" style="color:var(--red);text-align:center;padding:16px">Failed to load runs</td></tr>';

--- a/static/js/components/stats.js
+++ b/static/js/components/stats.js
@@ -32,8 +32,8 @@ async function fetchAndRenderCycleTime(proj) {
     const p90    = fmtDur(total.p90_seconds);
     const label  = `median: ${median} · P90: ${p90} · (last ${total.sample_size} runs)`;
     const runsRes  = await fetch(`/api/runs/${encodeURIComponent(proj)}`);
-    const runsData = runsRes.ok ? await runsRes.json() : [];
-    const spark    = renderSparkline(runsData);
+    const runsJson = runsRes.ok ? await runsRes.json() : {};
+    const spark    = renderSparkline(runsJson.runs || []);
     panel.innerHTML =
       `<span title="Median time from first event to completion, last ${total.sample_size} runs" style="color:var(--muted)">${escHtml(label)}</span>${spark}`;
   } catch {

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -58,7 +58,10 @@ def test_finished_event_sets_lifecycle(isolated_client):
 def test_runs_empty(isolated_client):
     response = isolated_client.get("/api/runs")
     assert response.status_code == 200
-    assert response.json() == []
+    data = response.json()
+    assert data["runs"] == []
+    assert data["total"] == 0
+    assert data["limit"] == 200
 
 
 def test_runs_created_after_report(isolated_client):
@@ -68,9 +71,10 @@ def test_runs_created_after_report(isolated_client):
     response = isolated_client.get("/api/runs")
     assert response.status_code == 200
     data = response.json()
-    assert len(data) == 1
-    assert data[0]["issue_number"] == 20
-    assert data[0]["project"] == "proj-r"
+    assert len(data["runs"]) == 1
+    assert data["runs"][0]["issue_number"] == 20
+    assert data["runs"][0]["project"] == "proj-r"
+    assert data["total"] == 1
 
 
 def test_runs_by_project(isolated_client):
@@ -83,8 +87,9 @@ def test_runs_by_project(isolated_client):
     response = isolated_client.get("/api/runs/proj-p1")
     assert response.status_code == 200
     data = response.json()
-    assert len(data) == 1
-    assert data[0]["project"] == "proj-p1"
+    assert len(data["runs"]) == 1
+    assert data["runs"][0]["project"] == "proj-p1"
+    assert data["total"] == 1
 
 
 def test_pipeline_run_not_duplicated(isolated_client):
@@ -97,8 +102,44 @@ def test_pipeline_run_not_duplicated(isolated_client):
     response = isolated_client.get("/api/runs/proj-nd")
     assert response.status_code == 200
     data = response.json()
-    assert len(data) == 1
-    assert data[0]["pr_number"] == 99
+    assert len(data["runs"]) == 1
+    assert data["runs"][0]["pr_number"] == 99
+
+
+def test_runs_default_cap(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    n = 210
+    conn.executemany(
+        """INSERT INTO pipeline_runs (project, issue_number, created_at)
+           VALUES (?, ?, '2026-01-01T00:00:00+00:00')""",
+        [("proj-cap", i) for i in range(1, n + 1)],
+    )
+    conn.commit()
+    conn.close()
+
+    response = isolated_client.get("/api/runs/proj-cap")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["runs"]) == 200
+    assert data["total"] == n
+    assert data["limit"] == 200
+
+
+def test_runs_custom_limit_clamped(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.executemany(
+        """INSERT INTO pipeline_runs (project, issue_number, created_at)
+           VALUES (?, ?, '2026-01-01T00:00:00+00:00')""",
+        [("proj-clamp", i) for i in range(1, 6)],
+    )
+    conn.commit()
+    conn.close()
+
+    resp_low = isolated_client.get("/api/runs/proj-clamp?limit=0")
+    assert resp_low.json()["limit"] == 1
+
+    resp_high = isolated_client.get("/api/runs/proj-clamp?limit=9999")
+    assert resp_high.json()["limit"] == 1000
 
 
 def test_history_loop_id_filter(isolated_client):

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -93,9 +93,18 @@ export async function fetchActionQueue(): Promise<QueueItem[]> {
   return get<QueueItem[]>('/api/action_queue');
 }
 
-export async function fetchRuns(project: string): Promise<PipelineRun[]> {
-  if (isFixtureMode()) return fx.getFixtureRuns(project);
-  return get<PipelineRun[]>(`/api/runs/${encodeURIComponent(project)}`);
+export interface RunsEnvelope {
+  runs: PipelineRun[];
+  total: number;
+  limit: number;
+}
+
+export async function fetchRuns(project: string): Promise<RunsEnvelope> {
+  if (isFixtureMode()) {
+    const runs = fx.getFixtureRuns(project);
+    return { runs, total: runs.length, limit: 200 };
+  }
+  return get<RunsEnvelope>(`/api/runs/${encodeURIComponent(project)}`);
 }
 
 export async function fetchPRMonitor(project: string): Promise<PRMonitorEntry[]> {

--- a/web/src/screens/ProjectDetail.tsx
+++ b/web/src/screens/ProjectDetail.tsx
@@ -72,7 +72,7 @@ export default function ProjectDetail({ projectId, allProjectIds, onBack, onProj
     setRuns([]);
     fetch(`/api/runs/${encodeURIComponent(projectId)}`)
       .then(r => r.ok ? r.json() : Promise.reject(r.status))
-      .then((data: PipelineRun[]) => setRuns(data))
+      .then((data: { runs: PipelineRun[] }) => setRuns(data.runs))
       .catch(() => setRuns([]));
   }, [projectId]);
 


### PR DESCRIPTION
Closes #128

## Changes

- **`server/routes/runs.py`**: Added `limit: int = Query(200)` parameter to both `get_runs` and `get_runs_by_project`. Limit is clamped to `[1, 1000]` in Python before binding. Both queries now use `LIMIT ?` as a bound parameter. A second `COUNT(*)` query runs in the same connection to get the unbounded total. Response shape changed from bare list to `{"runs": [...], "total": <int>, "limit": <int>}`.

- **`static/js/components/stats.js`**: Updated to read `payload.runs` instead of treating response as array.

- **`static/js/components/runs.js`**: Updated to read `payload.runs` instead of treating response as array.

- **`web/src/lib/api.ts`**: Added `RunsEnvelope` interface; updated `fetchRuns` return type from `PipelineRun[]` to `RunsEnvelope`. Fixture mode returns the same envelope shape.

- **`web/src/screens/ProjectDetail.tsx`**: Updated inline fetch to destructure `data.runs` instead of casting response as `PipelineRun[]`.

- **`tests/test_runs.py`**: Adapted all four existing runs tests to the new envelope shape. Added `test_runs_default_cap` (inserts 210 rows, asserts `len(runs)==200` and `total==210`) and `test_runs_custom_limit_clamped` (verifies out-of-range values silently clamp to 1 and 1000).

## Test Plan

- `ruff check .` — clean
- `pyright server/` — 0 errors
- `pytest tests/test_runs.py -v` — 14/14 passed
- `npm run typecheck && npm run build` — clean build