### PR TITLE
[LM-129] fix percentile off-by-one in _percentile_stats

### DIFF
--- a/server/routes/stats.py
+++ b/server/routes/stats.py
@@ -1,3 +1,4 @@
+import math
 import sqlite3
 from typing import Optional
 
@@ -89,8 +90,8 @@ def _percentile_stats(values: list) -> Optional[dict]:
     if n == 0:
         return None
     sorted_vals = sorted(values)
-    median = sorted_vals[int(0.5 * n)]
-    p90 = sorted_vals[int(0.9 * n)]
+    median = sorted_vals[(n - 1) // 2]
+    p90 = sorted_vals[min(math.ceil(0.9 * n), n) - 1]
     return {
         "median_seconds": median,
         "p90_seconds": p90,

--- a/tests/test_percentile_stats.py
+++ b/tests/test_percentile_stats.py
@@ -1,0 +1,44 @@
+from server.routes.stats import _percentile_stats
+
+
+def test_empty():
+    assert _percentile_stats([]) is None
+
+
+def test_single_value():
+    r = _percentile_stats([42])
+    assert r["median_seconds"] == 42
+    assert r["p90_seconds"] == 42
+    assert r["sample_size"] == 1
+
+
+def test_n5():
+    r = _percentile_stats([1, 2, 3, 4, 5])
+    assert r["median_seconds"] == 3
+    assert r["p90_seconds"] == 5
+
+
+def test_n9():
+    r = _percentile_stats(list(range(1, 10)))
+    assert r["median_seconds"] == 5
+    assert r["p90_seconds"] == 9
+
+
+def test_n10_regression():
+    """n=10 used to return max (10) as P90 due to int(0.9*10)==9 (last index)."""
+    r = _percentile_stats(list(range(1, 11)))
+    assert r["median_seconds"] == 5
+    assert r["p90_seconds"] == 9
+
+
+def test_n20():
+    r = _percentile_stats(list(range(1, 21)))
+    assert r["median_seconds"] == 10
+    assert r["p90_seconds"] == 18
+
+
+def test_unsorted_input():
+    """Function must sort internally — caller should not need to pre-sort."""
+    r = _percentile_stats([10, 1, 5, 3, 7])
+    assert r["median_seconds"] == 5
+    assert r["p90_seconds"] == 10

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -114,10 +114,10 @@ def test_cycle_times_with_data(isolated_client):
     td = data["total_duration"]
     assert td is not None
     assert td["sample_size"] == 10
-    # sorted: [10,20,30,40,50,60,70,80,90,100]; floor(0.5*10)=5 → index 5 → 60
-    assert td["median_seconds"] == 60
-    # floor(0.9*10)=9 → index 9 → 100
-    assert td["p90_seconds"] == 100
+    # sorted: [10,20,30,40,50,60,70,80,90,100]; (10-1)//2=4 → index 4 → 50
+    assert td["median_seconds"] == 50
+    # ceil(0.9*10)=9, min(9,10)-1=8 → index 8 → 90
+    assert td["p90_seconds"] == 90
     # most_recent is the last inserted row
     assert td["most_recent_seconds"] == 100
 


### PR DESCRIPTION
Closes #129

## Changes

**`server/routes/stats.py`**
- Added `import math` at the top of the file.
- Fixed P90 formula from `sorted_vals[int(0.9 * n)]` to `sorted_vals[min(math.ceil(0.9 * n), n) - 1]` (nearest-rank method, 1-based rank → 0-based index, clamped to n-1). The old formula returned the maximum element for any n that is a multiple of 10 (e.g. n=10: `int(0.9*10)=9` → index 9 → last element).
- Fixed median formula from `sorted_vals[int(0.5 * n)]` to `sorted_vals[(n - 1) // 2]` (lower median). The old formula returned the upper-median for even n.

**`tests/test_percentile_stats.py`** (new)
- Unit tests covering n=1, 5, 9, 10, 20, unsorted input, and empty list.
- `test_n10_regression` is the explicit regression case for the bug.

**`tests/test_stats.py`** (updated)
- `test_cycle_times_with_data` was asserting the buggy values (median=60, p90=100 for n=10 with values [10..100]). Updated to correct values: median=50, p90=90.

## Test Plan
- `ruff check .` — passes
- `pytest tests/test_percentile_stats.py tests/test_stats.py -v` — 14/14 pass
- `pytest tests/ --ignore=tests/visual` — 145 pass, 1 pre-existing failure in `test_graph.py::test_events_graph_with_data` (unrelated to this change)