### PR TITLE
[LM-198] fix _fetch_gh_meta to use PROJECTS map instead of hardcoded org

### DIFF
--- a/server/routes/issues_cost.py
+++ b/server/routes/issues_cost.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends
 
+from server.constants import PROJECTS
 from server.db import db_dep
 
 router = APIRouter()
@@ -29,11 +30,15 @@ def _fetch_gh_meta(project: str, issue_number: int) -> dict:
             return data
 
     default: dict = {"title": "", "state": "unknown", "priority": None, "body": "", "merged": False}
+    org_repo = PROJECTS.get(project)
+    if org_repo is None:
+        _gh_cache[key] = (now + _GH_TTL, default)
+        return default
     try:
         result = subprocess.run(
             [
                 "gh", "api",
-                f"repos/svv2014/{project}/issues/{issue_number}",
+                f"repos/{org_repo}/issues/{issue_number}",
                 "--jq",
                 "{title, state, body, labels: [.labels[].name], pull_request}",
             ],

--- a/tests/test_issues_cost.py
+++ b/tests/test_issues_cost.py
@@ -142,6 +142,35 @@ def test_since_filter(tmp_path, monkeypatch):
     assert 61 in issue_numbers
 
 
+# (h) _fetch_gh_meta with unknown project slug → default stub, no subprocess call
+def test_fetch_gh_meta_unknown_project_returns_default(monkeypatch):
+    import subprocess as subprocess_mod
+    issues_cost_module._gh_cache.clear()
+    called = []
+
+    def _should_not_be_called(*args, **kwargs):
+        called.append(True)
+        raise AssertionError("subprocess.run must not be called for unknown project")
+
+    monkeypatch.setattr(subprocess_mod, "run", _should_not_be_called)
+    result = issues_cost_module._fetch_gh_meta("totally-unknown-slug", 999)
+    assert result == {"title": "", "state": "unknown", "priority": None, "body": "", "merged": False}
+    assert called == [], "subprocess.run should not have been called"
+
+
+# (i) _fetch_gh_meta unknown project slug caches the default stub
+def test_fetch_gh_meta_unknown_project_caches_result(monkeypatch):
+    import subprocess as subprocess_mod
+    issues_cost_module._gh_cache.clear()
+    monkeypatch.setattr(subprocess_mod, "run", lambda *a, **kw: None)
+
+    issues_cost_module._fetch_gh_meta("another-unknown-slug", 1)
+    key = ("another-unknown-slug", 1)
+    assert key in issues_cost_module._gh_cache, "default stub should be cached to avoid repeated lookups"
+    _expiry, cached = issues_cost_module._gh_cache[key]
+    assert cached == {"title": "", "state": "unknown", "priority": None, "body": "", "merged": False}
+
+
 # (g) limit + offset paginate correctly
 def test_limit_offset(tmp_path, monkeypatch):
     client = _make_client(monkeypatch, tmp_path, _open_meta)


### PR DESCRIPTION
Closes #198

## Changes

- Imported `PROJECTS` from `server/constants.py` in `server/routes/issues_cost.py`
- `_fetch_gh_meta` now resolves the full `org/repo` via `PROJECTS.get(project)` before calling `gh api`
- If `project` is not in `PROJECTS`, the function immediately caches and returns the default stub (same behaviour as the existing 404 path)
- Removed the hardcoded `svv2014` string from the `gh api` path

## Test Plan

- Verify that `_fetch_gh_meta` for a known project slug (e.g. `loop-monitor`) still returns correct GitHub metadata
- Verify that an unknown project slug returns the default stub (`title: "", state: "unknown"`, etc.)
- Confirm no hardcoded `svv2014` remains in `_fetch_gh_meta`