### PR TITLE
[LM-199] fix apply_pending_migrations DB connection leak on migration failure

### DIFF
--- a/server/db.py
+++ b/server/db.py
@@ -120,47 +120,48 @@ def _migration_already_applied(conn: sqlite3.Connection, version_id: str) -> boo
 def apply_pending_migrations():
     conn = sqlite3.connect(DB_PATH)
     conn.isolation_level = None  # manual transaction control — required so DDL stays in our transaction
-    conn.execute("""
-        CREATE TABLE IF NOT EXISTS schema_migrations (
-            version_id TEXT PRIMARY KEY,
-            applied_at TEXT
-        )
-    """)
-
-    now = datetime.now(timezone.utc).isoformat()
-    applied = {r[0] for r in conn.execute("SELECT version_id FROM schema_migrations")}
-
-    for version_id, sql in MIGRATIONS:
-        if version_id in applied:
-            continue
-        if _migration_already_applied(conn, version_id):
-            conn.execute("BEGIN IMMEDIATE")
-            conn.execute(
-                "INSERT INTO schema_migrations (version_id, applied_at) VALUES (?, ?)",
-                (version_id, now),
+    try:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                version_id TEXT PRIMARY KEY,
+                applied_at TEXT
             )
-            conn.execute("COMMIT")
-            continue
-        # Statement splitting: existing MIGRATIONS contain no ';' inside string literals.
-        statements = [s.strip() for s in sql.split(";") if s.strip()]
-        try:
-            conn.execute("BEGIN IMMEDIATE")
-            for stmt in statements:
-                conn.execute(stmt)
-            conn.execute(
-                "INSERT INTO schema_migrations (version_id, applied_at) VALUES (?, ?)",
-                (version_id, now),
-            )
-            conn.execute("COMMIT")
-        except Exception:
+        """)
+
+        now = datetime.now(timezone.utc).isoformat()
+        applied = {r[0] for r in conn.execute("SELECT version_id FROM schema_migrations")}
+
+        for version_id, sql in MIGRATIONS:
+            if version_id in applied:
+                continue
+            if _migration_already_applied(conn, version_id):
+                conn.execute("BEGIN IMMEDIATE")
+                conn.execute(
+                    "INSERT INTO schema_migrations (version_id, applied_at) VALUES (?, ?)",
+                    (version_id, now),
+                )
+                conn.execute("COMMIT")
+                continue
+            # Statement splitting: existing MIGRATIONS contain no ';' inside string literals.
+            statements = [s.strip() for s in sql.split(";") if s.strip()]
             try:
-                conn.execute("ROLLBACK")
-            except sqlite3.OperationalError:
-                pass
-            print(f"Migration failed: {version_id}\nSQL:\n{sql}")
-            raise
-
-    conn.close()
+                conn.execute("BEGIN IMMEDIATE")
+                for stmt in statements:
+                    conn.execute(stmt)
+                conn.execute(
+                    "INSERT INTO schema_migrations (version_id, applied_at) VALUES (?, ?)",
+                    (version_id, now),
+                )
+                conn.execute("COMMIT")
+            except Exception:
+                try:
+                    conn.execute("ROLLBACK")
+                except sqlite3.OperationalError:
+                    pass
+                print(f"Migration failed: {version_id}\nSQL:\n{sql}")
+                raise
+    finally:
+        conn.close()
 
 
 def get_db():

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,4 +1,5 @@
 import sqlite3
+from unittest.mock import patch
 
 import pytest
 
@@ -76,3 +77,27 @@ def test_migration_rolls_back_on_mid_script_failure(tmp_path, monkeypatch):
     ).fetchone()
     assert applied is None, "schema_migrations should not have the failed version"
     conn.close()
+
+
+def test_migration_failure_closes_connection(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "leak_test.db")
+    monkeypatch.setattr(server.db, "DB_PATH", db_path)
+    monkeypatch.setattr(server.db, "MIGRATIONS", [("9999_bad", "INVALID SQL HERE")])
+    monkeypatch.setattr(server.db, "_migration_already_applied", lambda c, v: False)
+
+    close_calls: list[bool] = []
+    real_connect = sqlite3.connect
+
+    class _TrackingConn(sqlite3.Connection):
+        def close(self) -> None:
+            close_calls.append(True)
+            super().close()
+
+    def spy_connect(path: str) -> sqlite3.Connection:
+        return real_connect(path, factory=_TrackingConn)  # type: ignore[call-arg]
+
+    with patch("server.db.sqlite3.connect", side_effect=spy_connect):
+        with pytest.raises(sqlite3.OperationalError):
+            server.db.apply_pending_migrations()
+
+    assert close_calls, "conn.close() must be called even when a migration raises"


### PR DESCRIPTION
Closes #199

## Changes

**`server/db.py`** — wrapped the entire body of `apply_pending_migrations` (everything after `conn = sqlite3.connect(DB_PATH)`) in a `try/finally` block so `conn.close()` is called on every exit path: normal completion, mid-migration exception, and DDL error before any migration runs. No other logic was changed; the manual `BEGIN/COMMIT/ROLLBACK` flow is preserved as-is (the context-manager form would conflict with `isolation_level = None`).

**`tests/test_migrations.py`** — added `test_migration_failure_closes_connection`: patches `sqlite3.connect` to return a `Connection` subclass that overrides `close()` and records calls, injects a bad migration, asserts the `OperationalError` propagates, and asserts `close()` was called.

## Test Plan
- All 4 migration tests pass (`pytest tests/test_migrations.py -v`)
- `ruff check .` clean
- `npm run typecheck && npm run build` clean