### PR TITLE
[LM-200] eliminate N+1 queries in GET /api/projects/{slug}/prs

### DIFF
--- a/server/routes/runs.py
+++ b/server/routes/runs.py
@@ -87,42 +87,41 @@ def get_runs_by_project(project: str, conn: sqlite3.Connection = Depends(db_dep)
 @router.get("/api/projects/{slug}/prs")
 def get_project_prs(slug: str, include_finished: bool = False, conn: sqlite3.Connection = Depends(db_dep)):
     """PR monitor: every PR seen by the pipeline with current stage and time-in-stage."""
-    finished_clause = "" if include_finished else " AND outcome IS NULL"
-    runs = conn.execute(
-        f"""SELECT issue_number, pr_number, title, outcome, completed_at, rework_count
-           FROM pipeline_runs
-           WHERE project=? AND pr_number IS NOT NULL{finished_clause}
-           ORDER BY id DESC""",
+    finished_clause = "" if include_finished else " AND pr.outcome IS NULL"
+    rows = conn.execute(
+        f"""SELECT pr.issue_number, pr.pr_number, pr.title, pr.outcome, pr.rework_count,
+                   e.event_type, e.created_at AS event_created_at, e.payload
+            FROM pipeline_runs pr
+            LEFT JOIN events e ON e.id = (
+                SELECT MAX(id) FROM events
+                WHERE project = pr.project
+                  AND (issue_number = pr.issue_number OR pr_number = pr.pr_number)
+            )
+            WHERE pr.project = ? AND pr.pr_number IS NOT NULL{finished_clause}
+            ORDER BY pr.id DESC""",
         (slug,),
     ).fetchall()
 
     repo = PROJECTS.get(slug)
     now = datetime.now(timezone.utc)
     result = []
-    for run in runs:
-        last_event = conn.execute(
-            """SELECT event_type, created_at, payload FROM events
-               WHERE project=? AND (issue_number=? OR pr_number=?)
-               ORDER BY id DESC LIMIT 1""",
-            (slug, run["issue_number"], run["pr_number"]),
-        ).fetchone()
-
+    for row in rows:
         stage = None
         last_event_type = None
         last_event_at = None
         time_in_stage = None
         branch = None
         is_draft = None
-        if last_event:
-            last_event_type = last_event["event_type"]
-            last_event_at = last_event["created_at"]
+        if row["event_type"] is not None:
+            last_event_type = row["event_type"]
+            last_event_at = row["event_created_at"]
             stage = _derive_stage(last_event_type)
             ts = parse_ts(last_event_at)
             if ts is not None:
                 time_in_stage = int((now - ts).total_seconds())
-            if last_event["payload"]:
+            if row["payload"]:
                 try:
-                    p = json.loads(last_event["payload"])
+                    p = json.loads(row["payload"])
                     if isinstance(p, dict):
                         branch = p.get("branch")
                         if "draft" in p:
@@ -130,19 +129,19 @@ def get_project_prs(slug: str, include_finished: bool = False, conn: sqlite3.Con
                 except Exception:
                     pass
 
-        github_url = f"https://github.com/{repo}/pull/{run['pr_number']}" if repo else None
+        github_url = f"https://github.com/{repo}/pull/{row['pr_number']}" if repo else None
 
         result.append({
-            "pr_number": run["pr_number"],
-            "title": run["title"],
+            "pr_number": row["pr_number"],
+            "title": row["title"],
             "branch": branch,
             "stage": stage,
             "time_in_stage_seconds": time_in_stage,
-            "retry_count": run["rework_count"] or 0,
+            "retry_count": row["rework_count"] or 0,
             "last_event": last_event_type,
             "last_event_at": last_event_at,
             "github_url": github_url,
-            "is_finished": run["outcome"] is not None,
+            "is_finished": row["outcome"] is not None,
             "is_draft": is_draft,
         })
 

--- a/tests/test_project_prs.py
+++ b/tests/test_project_prs.py
@@ -1,0 +1,89 @@
+"""Tests for GET /api/projects/{slug}/prs — N+1 fix verification."""
+import sqlite3
+
+import server
+import server.db
+
+
+def _select_count(db_path: str) -> tuple[list[str], sqlite3.Connection]:
+    """Open a traced connection to db_path; return (queries_list, conn)."""
+    queries: list[str] = []
+    conn = sqlite3.connect(db_path)
+    conn.set_trace_callback(lambda s: queries.append(s) if s.strip().upper().startswith("SELECT") else None)
+    return queries, conn
+
+
+def test_prs_query_count_constant(isolated_client, monkeypatch):
+    """Endpoint must issue ≤2 SELECT queries regardless of open-PR count."""
+    for i in range(1, 6):
+        server._insert_event(server.ReportPayload(
+            project="ppl", role="dev", event_type="dev_start",
+            issue_number=300 + i, pr_number=400 + i,
+        ))
+        server._insert_event(server.ReportPayload(
+            project="ppl", role="reviewer", event_type="review_start",
+            issue_number=300 + i, pr_number=400 + i,
+        ))
+
+    queries: list[str] = []
+
+    original_get_db = server.db.get_db
+
+    def traced_get_db():
+        conn = original_get_db()
+        conn.set_trace_callback(lambda s: queries.append(s) if s.strip().upper().startswith("SELECT") else None)
+        return conn
+
+    monkeypatch.setattr(server.db, "get_db", traced_get_db)
+
+    resp = isolated_client.get("/api/projects/ppl/prs")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 5
+    assert len(queries) <= 2, f"Expected ≤2 SELECT queries for 5 PRs, got {len(queries)}: {queries}"
+
+
+def test_prs_no_events_returns_none_fields(isolated_client):
+    """A PR run with no matching events should have None for event-derived fields."""
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        "INSERT INTO pipeline_runs (project, issue_number, pr_number, title, rework_count) VALUES (?,?,?,?,?)",
+        ("loop", 500, 600, "No events PR", 0),
+    )
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/projects/loop/prs")
+    assert resp.status_code == 200
+    items = [p for p in resp.json() if p["pr_number"] == 600]
+    assert len(items) == 1
+    pr = items[0]
+    assert pr["stage"] is None
+    assert pr["last_event"] is None
+    assert pr["last_event_at"] is None
+    assert pr["time_in_stage_seconds"] is None
+    assert pr["branch"] is None
+    assert pr["is_draft"] is None
+    assert pr["is_finished"] is False
+
+
+def test_prs_most_recent_event_selected(isolated_client):
+    """When multiple events exist the one with the highest id is used."""
+    server._insert_event(server.ReportPayload(
+        project="ppl", role="dev", event_type="dev_start",
+        issue_number=700, pr_number=800,
+    ))
+    server._insert_event(server.ReportPayload(
+        project="ppl", role="dev", event_type="dev_done",
+        issue_number=700, pr_number=800,
+    ))
+    server._insert_event(server.ReportPayload(
+        project="ppl", role="reviewer", event_type="review_start",
+        issue_number=700, pr_number=800,
+    ))
+
+    resp = isolated_client.get("/api/projects/ppl/prs")
+    assert resp.status_code == 200
+    items = [p for p in resp.json() if p["pr_number"] == 800]
+    assert len(items) == 1
+    assert items[0]["last_event"] == "review_start"
+    assert items[0]["stage"] == "in-review"


### PR DESCRIPTION
Closes #200

## Changes

**`server/routes/runs.py`** — replaced the per-PR `conn.execute` inside the loop with a single query using a correlated `MAX(id)` subquery:

```sql
SELECT pr.*, e.event_type, e.created_at AS event_created_at, e.payload
FROM pipeline_runs pr
LEFT JOIN events e ON e.id = (
    SELECT MAX(id) FROM events
    WHERE project = pr.project
      AND (issue_number = pr.issue_number OR pr_number = pr.pr_number)
)
WHERE pr.project = ? AND pr.pr_number IS NOT NULL [AND pr.outcome IS NULL]
ORDER BY pr.id DESC
```

This reduces the query count from N+1 to **1** for any number of open PRs. The `LEFT JOIN` preserves PRs with no matching events (all event-derived fields stay `None`). The `OR`-match semantics on `issue_number`/`pr_number` are preserved.

Response shape is unchanged — all fields (`pr_number`, `title`, `branch`, `stage`, `time_in_stage_seconds`, `retry_count`, `last_event`, `last_event_at`, `github_url`, `is_finished`, `is_draft`) have identical semantics.

**`tests/test_project_prs.py`** — new test file with 3 tests:
- `test_prs_query_count_constant` — monkeypatches `get_db` to attach `set_trace_callback`, inserts 5 PRs with 2 events each, asserts ≤2 SELECT queries issued
- `test_prs_no_events_returns_none_fields` — PR with no events yields `None` for all event-derived fields
- `test_prs_most_recent_event_selected` — multiple events: only the highest-`id` event is used

## Test Plan
- All 15 tests pass (`tests/test_project_prs.py` + `tests/test_runs.py`)
- `ruff check .` passes
- `npm run typecheck && npm run build` passes
- Query count verified ≤2 for 5-PR dataset