### PR TITLE
[LM-213] Surface legacy judge events: remap event_type=judge at read time

### DIFF
--- a/server/event_mapping.py
+++ b/server/event_mapping.py
@@ -1,0 +1,11 @@
+def remap_legacy_judge(row: dict) -> dict:
+    """Read-time rewrite: legacy event_type='judge' rows surface as role='judge', event_type='judge_done'.
+
+    After loop#349 ships, new rows already have the correct shape and pass through unchanged.
+    This mapping becomes dead code once all legacy rows age out of query windows — remove then.
+    """
+    if row.get("event_type") == "judge":
+        row = dict(row)
+        row["event_type"] = "judge_done"
+        row["role"] = "judge"
+    return row

--- a/server/routes/feed.py
+++ b/server/routes/feed.py
@@ -6,6 +6,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends
 
 from server.db import db_dep
+from server.event_mapping import remap_legacy_judge
 
 router = APIRouter()
 
@@ -50,7 +51,7 @@ def history(limit: int = 50, loop_id: Optional[str] = None, conn: sqlite3.Connec
         ORDER BY d.id DESC
         LIMIT ?
     """, params).fetchall()
-    return [dict(r) for r in rows]
+    return [remap_legacy_judge(dict(r)) for r in rows]
 
 
 @router.get("/api/active")
@@ -122,7 +123,7 @@ def feed(
     now = datetime.now(timezone.utc)
     result = []
     for r in rows:
-        entry = dict(r)
+        entry = remap_legacy_judge(dict(r))
         if entry["payload"]:
             entry["payload"] = json.loads(entry["payload"])
         try:
@@ -150,7 +151,7 @@ def status(conn: sqlite3.Connection = Depends(db_dep)):
     """).fetchall()
     result = []
     for r in rows:
-        entry = dict(r)
+        entry = remap_legacy_judge(dict(r))
         if entry["payload"]:
             entry["payload"] = json.loads(entry["payload"])
         result.append(entry)

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -164,3 +164,31 @@ def test_feed_role_filter_preserves_loop_id(isolated_client):
     data = resp.json()
     assert len(data) >= 1
     assert all(item["role"] == "dev" for item in data)
+
+
+def test_feed_legacy_judge_remapped(isolated_client):
+    """Legacy (role='dev', event_type='judge') row is returned as role='judge', event_type='judge_done'."""
+    server._insert_event(server.ReportPayload(
+        project="proj-jlegacy", role="dev", event_type="judge"
+    ))
+    resp = isolated_client.get("/api/feed")
+    assert resp.status_code == 200
+    data = resp.json()
+    item = next((i for i in data if i["project"] == "proj-jlegacy"), None)
+    assert item is not None
+    assert item["role"] == "judge"
+    assert item["event_type"] == "judge_done"
+
+
+def test_feed_new_judge_unchanged(isolated_client):
+    """New-style (role='judge', event_type='judge_done') row passes through unchanged."""
+    server._insert_event(server.ReportPayload(
+        project="proj-jnew", role="judge", event_type="judge_done"
+    ))
+    resp = isolated_client.get("/api/feed")
+    assert resp.status_code == 200
+    data = resp.json()
+    item = next((i for i in data if i["project"] == "proj-jnew"), None)
+    assert item is not None
+    assert item["role"] == "judge"
+    assert item["event_type"] == "judge_done"

--- a/tests/test_judge_legacy_mapping.py
+++ b/tests/test_judge_legacy_mapping.py
@@ -1,0 +1,45 @@
+from server.event_mapping import remap_legacy_judge
+
+
+def test_legacy_judge_remapped():
+    """(role='dev', event_type='judge') → (role='judge', event_type='judge_done')."""
+    row = {"project": "p", "role": "dev", "event_type": "judge", "issue_number": 1}
+    result = remap_legacy_judge(row)
+    assert result["role"] == "judge"
+    assert result["event_type"] == "judge_done"
+    assert result["project"] == "p"
+    assert result["issue_number"] == 1
+
+
+def test_new_judge_unchanged():
+    """(role='judge', event_type='judge_done') passes through unchanged."""
+    row = {"project": "p", "role": "judge", "event_type": "judge_done", "issue_number": 2}
+    result = remap_legacy_judge(row)
+    assert result["role"] == "judge"
+    assert result["event_type"] == "judge_done"
+
+
+def test_other_event_types_unchanged():
+    """Non-judge event types are not affected."""
+    row = {"role": "dev", "event_type": "dev_done"}
+    result = remap_legacy_judge(row)
+    assert result["role"] == "dev"
+    assert result["event_type"] == "dev_done"
+
+
+def test_original_row_not_mutated():
+    """The helper returns a new dict; the original is not mutated."""
+    row = {"role": "dev", "event_type": "judge"}
+    result = remap_legacy_judge(row)
+    assert result is not row
+    assert row["role"] == "dev"
+    assert row["event_type"] == "judge"
+
+
+def test_idempotent():
+    """Applying the mapping twice produces the same result."""
+    row = {"role": "dev", "event_type": "judge"}
+    once = remap_legacy_judge(row)
+    twice = remap_legacy_judge(once)
+    assert twice["role"] == "judge"
+    assert twice["event_type"] == "judge_done"

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -124,3 +124,31 @@ def test_cycle_times_with_data(isolated_client):
     # issue_lifetime and pr_lifetime are null because columns not set
     assert data["issue_lifetime"] is None
     assert data["pr_lifetime"] is None
+
+
+def test_status_legacy_judge_remapped(isolated_client):
+    """Legacy (role='dev', event_type='judge') row surfaces as role='judge', event_type='judge_done' via /api/status."""
+    server._insert_event(server.ReportPayload(
+        project="proj-sj-legacy", role="dev", event_type="judge"
+    ))
+    resp = isolated_client.get("/api/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    item = next((i for i in data if i["project"] == "proj-sj-legacy"), None)
+    assert item is not None
+    assert item["role"] == "judge"
+    assert item["event_type"] == "judge_done"
+
+
+def test_status_new_judge_unchanged(isolated_client):
+    """New-style (role='judge', event_type='judge_done') row passes through /api/status unchanged."""
+    server._insert_event(server.ReportPayload(
+        project="proj-sj-new", role="judge", event_type="judge_done"
+    ))
+    resp = isolated_client.get("/api/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    item = next((i for i in data if i["project"] == "proj-sj-new"), None)
+    assert item is not None
+    assert item["role"] == "judge"
+    assert item["event_type"] == "judge_done"


### PR DESCRIPTION
Closes #213

## Changes

Adds a read-time mapping so legacy `event_type='judge'` rows (emitted with `role='dev'` by the old loop handler) surface correctly in the v2 UI without rewriting historical data.

**`server/event_mapping.py`** (new) — shared helper `remap_legacy_judge(row)`:
- If `event_type == 'judge'`, rewrites to `role='judge', event_type='judge_done'`
- New rows (`role='judge', event_type='judge_done'`) pass through unchanged (idempotent)
- `duration_seconds` stays `null` for legacy rows (no matching `judge_start` exists)

**`server/routes/feed.py`** — mapping applied in three endpoints:
- `/api/feed` (ActivityFeed)
- `/api/history` (completed job list)
- `/api/status` (latest event per project+role)
- `/api/active` is unchanged — it filters to `%_start` events, so legacy `judge` rows never appear there

**Audit of other routes** (`board.py`, `graph.py`, `runs.py`, `action_queue.py`, `issues_cost.py`): none return individual event rows with `role`/`event_type` fields that the v2 UI filters on — all either aggregate counts or read from other tables (`pipeline_runs`, `issue_history`, `verdicts`).

**Tests:**
- `tests/test_judge_legacy_mapping.py` — unit tests for the helper (legacy remapped, new unchanged, other types unchanged, original not mutated, idempotent)
- `tests/test_feed.py` — integration tests via `/api/feed`
- `tests/test_stats.py` — integration tests via `/api/status`

> **Future cleanup:** after loop#349 ships and legacy rows age out of the query windows, `remap_legacy_judge` becomes dead code — flag for removal in a follow-up.

## Test Plan

- [ ] Run `pytest tests/test_judge_legacy_mapping.py tests/test_feed.py tests/test_stats.py` — all 27 tests pass
- [ ] Run `ruff check .` and `pyright server/` — no errors
- [ ] Manual: open v2 UI Activity24h / ActivityFeed — legacy judge events from last 24h are visible with ★ glyph in WorkerDetail
- [ ] Verify new-style judge events are still displayed correctly (idempotent mapping)