### PR TITLE
Map legacy judge events at read time

### DIFF
--- a/server/helpers/event_mapping.py
+++ b/server/helpers/event_mapping.py
@@ -1,0 +1,11 @@
+def remap_legacy_judge_event(row: dict) -> dict:
+    """Map legacy judge rows to the v2 judge_done shape at read time."""
+    if row.get("event_type") != "judge":
+        return row
+
+    mapped = dict(row)
+    mapped["role"] = "judge"
+    mapped["event_type"] = "judge_done"
+    if "duration_seconds" in mapped:
+        mapped["duration_seconds"] = None
+    return mapped

--- a/server/routes/feed.py
+++ b/server/routes/feed.py
@@ -6,6 +6,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends
 
 from server.db import db_dep
+from server.helpers.event_mapping import remap_legacy_judge_event
 
 router = APIRouter()
 
@@ -45,12 +46,17 @@ def history(limit: int = 50, loop_id: Optional[str] = None, conn: sqlite3.Connec
                   AND v2.created_at >= d.created_at
                   AND v2.reason LIKE '%auto: ' || d.event_type || '%'
             )
-        WHERE (d.event_type LIKE '%_done' OR d.event_type LIKE '%_pass' OR d.event_type LIKE '%_failed')
+        WHERE (
+            d.event_type LIKE '%_done'
+            OR d.event_type LIKE '%_pass'
+            OR d.event_type LIKE '%_failed'
+            OR d.event_type = 'judge'
+        )
         {loop_clause}
         ORDER BY d.id DESC
         LIMIT ?
     """, params).fetchall()
-    return [dict(r) for r in rows]
+    return [remap_legacy_judge_event(dict(r)) for r in rows]
 
 
 @router.get("/api/active")
@@ -103,11 +109,17 @@ def feed(
         params.append(loop_id)
 
     if role:
-        where_clauses.append("lower(role) = lower(?)")
-        params.append(role)
+        if role.lower() == "judge":
+            where_clauses.append("(lower(role) = lower(?) OR event_type = 'judge')")
+            params.append(role)
+        else:
+            where_clauses.append("lower(role) = lower(?)")
+            params.append(role)
 
     if status_lower == 'fail':
         where_clauses.append("(event_type LIKE '%_fail' OR event_type LIKE '%_failed')")
+    elif status_lower == 'done':
+        where_clauses.append("(event_type LIKE '%_done' OR event_type = 'judge')")
     elif status_lower:
         where_clauses.append(f"event_type LIKE '%_{status_lower}'")
 
@@ -122,7 +134,7 @@ def feed(
     now = datetime.now(timezone.utc)
     result = []
     for r in rows:
-        entry = dict(r)
+        entry = remap_legacy_judge_event(dict(r))
         if entry["payload"]:
             entry["payload"] = json.loads(entry["payload"])
         try:
@@ -150,7 +162,7 @@ def status(conn: sqlite3.Connection = Depends(db_dep)):
     """).fetchall()
     result = []
     for r in rows:
-        entry = dict(r)
+        entry = remap_legacy_judge_event(dict(r))
         if entry["payload"]:
             entry["payload"] = json.loads(entry["payload"])
         result.append(entry)

--- a/server/routes/graph.py
+++ b/server/routes/graph.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from server.constants import PROJECTS
 from server.db import db_dep
+from server.helpers.event_mapping import remap_legacy_judge_event
 from server.helpers.timeline import build_timeline_events, parse_ts
 
 router = APIRouter()
@@ -46,7 +47,7 @@ def _get_timeline_data(conn: sqlite3.Connection, project: str, issue: int) -> di
             (project, issue),
         ).fetchall()
 
-    events = build_timeline_events(history_rows)
+    events = build_timeline_events([remap_legacy_judge_event(dict(r)) for r in history_rows])
 
     total_elapsed_seconds = None
     ts_candidates = []
@@ -91,7 +92,7 @@ def get_timeline_by_pr(project: str, pr_number: int, conn: sqlite3.Connection = 
             "project": project,
             "issue_number": None,
             "summary": {},
-            "events": [dict(r) for r in rows],
+            "events": [remap_legacy_judge_event(dict(r)) for r in rows],
         }
 
     return _get_timeline_data(conn, project, run_row["issue_number"])
@@ -107,7 +108,10 @@ def get_timeline(project: str, issue: int, conn: sqlite3.Connection = Depends(db
 def get_events_graph(window: int = 24, conn: sqlite3.Connection = Depends(db_dep)):
     window = max(1, min(window, 168))
     rows = conn.execute(
-        """SELECT strftime('%Y-%m-%dT%H:00:00', created_at) AS hour, role, COUNT(*) AS count
+        """SELECT
+              strftime('%Y-%m-%dT%H:00:00', created_at) AS hour,
+              CASE WHEN event_type = 'judge' THEN 'judge' ELSE role END AS role,
+              COUNT(*) AS count
            FROM events
            WHERE created_at > datetime('now', ? || ' hours')
            GROUP BY hour, role

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -164,3 +164,45 @@ def test_feed_role_filter_preserves_loop_id(isolated_client):
     data = resp.json()
     assert len(data) >= 1
     assert all(item["role"] == "dev" for item in data)
+
+
+def test_feed_remaps_legacy_judge_rows_and_filters_as_done(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        """INSERT INTO events
+           (project, role, event_type, issue_number, created_at)
+           VALUES (?, ?, ?, ?, datetime('now'))""",
+        ("proj-judge", "dev", "judge", 213),
+    )
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/feed?role=judge&status=done")
+    assert resp.status_code == 200
+    item = next((i for i in resp.json() if i["project"] == "proj-judge"), None)
+
+    assert item is not None
+    assert item["role"] == "judge"
+    assert item["event_type"] == "judge_done"
+    assert item["status"] == "done"
+
+
+def test_history_includes_legacy_judge_rows_with_null_duration(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        """INSERT INTO events
+           (project, role, event_type, issue_number, created_at)
+           VALUES (?, ?, ?, ?, datetime('now'))""",
+        ("proj-history-judge", "dev", "judge", 213),
+    )
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/history")
+    assert resp.status_code == 200
+    item = next((i for i in resp.json() if i["project"] == "proj-history-judge"), None)
+
+    assert item is not None
+    assert item["role"] == "judge"
+    assert item["event_type"] == "judge_done"
+    assert item["duration_seconds"] is None

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,4 +1,5 @@
 import sqlite3
+from datetime import datetime, timedelta
 
 import server
 import server.db
@@ -12,18 +13,24 @@ def test_events_graph_empty_db(isolated_client):
 
 
 def test_events_graph_with_data(isolated_client):
+    base = (datetime.now() - timedelta(hours=2)).replace(minute=0, second=0, microsecond=0)
+    first = base.isoformat()
+    second = (base + timedelta(minutes=30)).isoformat()
+    third = (base + timedelta(hours=1)).isoformat()
+    first_hour = base.strftime("%Y-%m-%dT%H:00:00")
+
     conn = sqlite3.connect(server.db.DB_PATH)
     conn.execute(
         "INSERT INTO events (project, role, event_type, created_at) VALUES (?,?,?,?)",
-        ("proj-g", "po", "po_done", "2026-04-28T10:00:00"),
+        ("proj-g", "po", "po_done", first),
     )
     conn.execute(
         "INSERT INTO events (project, role, event_type, created_at) VALUES (?,?,?,?)",
-        ("proj-g", "po", "po_done", "2026-04-28T10:30:00"),
+        ("proj-g", "po", "po_done", second),
     )
     conn.execute(
         "INSERT INTO events (project, role, event_type, created_at) VALUES (?,?,?,?)",
-        ("proj-g", "dev", "dev_done", "2026-04-28T11:00:00"),
+        ("proj-g", "dev", "dev_done", third),
     )
     conn.commit()
     conn.close()
@@ -34,7 +41,7 @@ def test_events_graph_with_data(isolated_client):
     assert data["window_hours"] == 168
     buckets = data["buckets"]
     assert isinstance(buckets, list)
-    po_bucket = next((b for b in buckets if b["role"] == "po" and b["hour"] == "2026-04-28T10:00:00"), None)
+    po_bucket = next((b for b in buckets if b["role"] == "po" and b["hour"] == first_hour), None)
     assert po_bucket is not None
     assert po_bucket["count"] == 2
     dev_bucket = next((b for b in buckets if b["role"] == "dev"), None)
@@ -61,3 +68,46 @@ def test_events_graph_default_window(isolated_client):
     assert resp.status_code == 200
     data = resp.json()
     assert data["window_hours"] == 24
+
+
+def test_events_graph_counts_legacy_judge_rows_as_judge_role(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        """INSERT INTO events
+           (project, role, event_type, issue_number, created_at)
+           VALUES (?, ?, ?, ?, datetime('now', '-1 hour'))""",
+        ("proj-judge-graph", "dev", "judge", 213),
+    )
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/events_graph?window=24")
+    assert resp.status_code == 200
+    buckets = resp.json()["buckets"]
+
+    judge_bucket = next((b for b in buckets if b["role"] == "judge"), None)
+    assert judge_bucket is not None
+    assert judge_bucket["count"] == 1
+
+
+def test_timeline_remaps_legacy_judge_pr_rows(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        """INSERT INTO events
+           (project, role, event_type, issue_number, pr_number, created_at)
+           VALUES (?, ?, ?, ?, ?, datetime('now', '-1 hour'))""",
+        ("proj-judge-timeline", "dev", "judge", 213, 17),
+    )
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/stats/timeline/pr/proj-judge-timeline/17")
+    assert resp.status_code == 200
+    events = resp.json()["events"]
+
+    assert len(events) == 1
+    assert events[0]["project"] == "proj-judge-timeline"
+    assert events[0]["role"] == "judge"
+    assert events[0]["event_type"] == "judge_done"
+    assert events[0]["issue_number"] == 213
+    assert events[0]["pr_number"] == 17


### PR DESCRIPTION
## Summary
- Adds a shared read-time mapper for legacy `event_type='judge'` rows.
- Maps legacy rows to `role='judge'` / `event_type='judge_done'` in feed, history, status, PR timeline fallback, and 24h graph aggregation.
- Keeps legacy history duration as `null` and leaves already-correct `judge_done` rows unchanged.
- Stabilizes the graph test fixture so it stays inside the rolling window.

Closes #213.

## Validation
- `python -m pytest tests/test_feed.py tests/test_graph.py -q`
- `python -m py_compile server/helpers/event_mapping.py server/routes/feed.py server/routes/graph.py tests/test_feed.py tests/test_graph.py`
- `git diff --check`