### PR TITLE
[LM-215] add per-ticket timeline drill-down endpoint and panel

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -29,6 +29,7 @@ from server.routes import (  # noqa: E402
     runs,
     scanner_state,
     stats,
+    timeline,
 )
 
 app.include_router(health.router)
@@ -43,6 +44,7 @@ app.include_router(claude_usage.router)
 app.include_router(issues_cost.router)
 app.include_router(logs.router)
 app.include_router(scanner_state.router)
+app.include_router(timeline.router)
 
 if os.path.isdir("static/dist"):
     app.mount("/v2", StaticFiles(directory="static/dist", html=True), name="dist")

--- a/server/routes/timeline.py
+++ b/server/routes/timeline.py
@@ -1,0 +1,233 @@
+import sqlite3
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from server.db import db_dep
+
+router = APIRouter()
+
+_ROLE_MAP = {
+    "po_start": "po", "po_done": "po", "po_failed": "po",
+    "dev_start": "dev", "dev_done": "dev", "dev_failed": "dev",
+    "review_start": "review", "review_done": "review", "review_failed": "review",
+    "qa_start": "qa", "qa_done": "qa", "qa_failed": "qa", "qa_pass": "qa", "qa_fail": "qa",
+    "merge_start": "merge", "merge_done": "merge", "merge_failed": "merge",
+    "judge_start": "judge", "judge_done": "judge", "judge_failed": "judge",
+}
+
+
+def _pair_durations(events: list[dict]) -> list[dict]:
+    """Add duration_seconds by pairing *_start with the next matching *_done for the same role."""
+    # Build a mutable list; iterate forwards
+    result = []
+    for i, ev in enumerate(events):
+        ev = dict(ev)
+        ev["duration_seconds"] = None
+        if ev["event_type"].endswith("_start"):
+            role = ev.get("role") or _ROLE_MAP.get(ev["event_type"])
+            # Look forward for next *_done for same role
+            for j in range(i + 1, len(events)):
+                nxt = events[j]
+                nxt_role = nxt.get("role") or _ROLE_MAP.get(nxt["event_type"])
+                if nxt_role == role and nxt["event_type"].endswith("_done"):
+                    try:
+                        t0 = _parse_ts(ev["created_at"])
+                        t1 = _parse_ts(nxt["created_at"])
+                        ev["duration_seconds"] = max(0, int(t1 - t0))
+                    except Exception:
+                        pass
+                    break
+        result.append(ev)
+    return result
+
+
+def _parse_ts(s: str) -> float:
+    from datetime import datetime, timezone
+
+    s = s.replace(" ", "T")
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        dt = datetime.strptime(s[:19], "%Y-%m-%dT%H:%M:%S")
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.timestamp()
+
+
+def _compute_totals(events: list[dict], conn: sqlite3.Connection, project: str) -> dict:
+    total_dur = None
+    for ev in events:
+        d = ev.get("duration_seconds")
+        if d is not None:
+            total_dur = (total_dur or 0) + d
+
+    rework_count = sum(
+        1 for ev in events
+        if ev["event_type"].endswith("_start")
+        and ev["event_type"] not in ("po_start",)
+        # count any re-start (more than one start per role) as rework
+    )
+    # rework = extra starts beyond the first per role
+    role_starts: dict[str, int] = {}
+    for ev in events:
+        if ev["event_type"].endswith("_start"):
+            role = ev.get("role") or _ROLE_MAP.get(ev["event_type"], "unknown")
+            role_starts[role] = role_starts.get(role, 0) + 1
+    rework_count = sum(max(0, v - 1) for v in role_starts.values())
+
+    # Get total points from verdicts — scoped to this project in the time window
+    total_points: Optional[int] = None
+    if events:
+        first_at = min(ev["created_at"] for ev in events)
+        last_at = max(ev["created_at"] for ev in events)
+        row = conn.execute(
+            "SELECT COALESCE(SUM(points), 0) FROM verdicts WHERE project = ? AND created_at BETWEEN ? AND ?",
+            (project, first_at, last_at),
+        ).fetchone()
+        if row:
+            total_points = row[0]
+
+    # verdict: last judge_done or dev_done detail
+    verdict: Optional[str] = None
+    for ev in reversed(events):
+        if ev["event_type"] in ("judge_done", "qa_pass", "merge_done"):
+            verdict = ev.get("detail") or ev["event_type"]
+            break
+
+    return {
+        "total_duration_seconds": total_dur,
+        "total_points": total_points,
+        "rework_count": rework_count,
+        "verdict": verdict,
+    }
+
+
+@router.get("/api/timeline")
+def get_timeline(
+    project: str,
+    issue: Optional[int] = None,
+    pr: Optional[int] = None,
+    conn: sqlite3.Connection = Depends(db_dep),
+) -> dict:
+    if issue is None and pr is None:
+        raise HTTPException(status_code=400, detail="Provide either 'issue' or 'pr' query param")
+    if issue is not None and pr is not None:
+        raise HTTPException(status_code=400, detail="Provide only one of 'issue' or 'pr', not both")
+
+    kind = "issue" if issue is not None else "pr"
+    number = issue if issue is not None else pr
+
+    # Fetch events for this ticket
+    if kind == "issue":
+        rows = conn.execute(
+            """
+            SELECT id, role, model, event_type, issue_number, pr_number, detail, created_at
+            FROM events
+            WHERE project = ? AND issue_number = ?
+            ORDER BY created_at ASC, id ASC
+            """,
+            (project, number),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            """
+            SELECT id, role, model, event_type, issue_number, pr_number, detail, created_at
+            FROM events
+            WHERE project = ? AND pr_number = ?
+            ORDER BY created_at ASC, id ASC
+            """,
+            (project, number),
+        ).fetchall()
+
+    events = [dict(r) for r in rows]
+
+    # Pair durations
+    events = _pair_durations(events)
+
+    # Derive stage from the most recent label_transition event detail, if any
+    stage: Optional[str] = None
+    label_rows = conn.execute(
+        """
+        SELECT detail FROM events
+        WHERE project = ? AND event_type = 'label_transition'
+        ORDER BY created_at DESC, id DESC
+        LIMIT 1
+        """,
+        (project,),
+    ).fetchone()
+    if label_rows and label_rows[0]:
+        stage = label_rows[0]
+
+    # Derive title from latest event detail
+    title: Optional[str] = None
+    for ev in reversed(events):
+        if ev.get("detail"):
+            title = ev["detail"]
+            break
+
+    # Linked PR / linked issue detection
+    linked_pr: Optional[int] = None
+    linked_issue: Optional[int] = None
+    if kind == "issue":
+        # Look for events in same project with same issue_number AND a pr_number
+        pr_row = conn.execute(
+            """
+            SELECT pr_number FROM events
+            WHERE project = ? AND issue_number = ? AND pr_number IS NOT NULL
+            ORDER BY created_at DESC LIMIT 1
+            """,
+            (project, number),
+        ).fetchone()
+        if pr_row:
+            linked_pr = pr_row[0]
+    else:
+        # Look for events in same project with same pr_number AND an issue_number
+        iss_row = conn.execute(
+            """
+            SELECT issue_number FROM events
+            WHERE project = ? AND pr_number = ? AND issue_number IS NOT NULL
+            ORDER BY created_at DESC LIMIT 1
+            """,
+            (project, number),
+        ).fetchone()
+        if iss_row:
+            linked_issue = iss_row[0]
+
+    # GitHub URL
+    base = f"https://github.com/svv2014/{project}"
+    if kind == "issue":
+        github_url = f"{base}/issues/{number}"
+    else:
+        github_url = f"{base}/pull/{number}"
+
+    totals = _compute_totals(events, conn, project)
+
+    # Strip internal fields not in response shape
+    clean_events = []
+    for ev in events:
+        clean_events.append({
+            "id": ev["id"],
+            "role": ev["role"],
+            "event_type": ev["event_type"],
+            "model": ev.get("model"),
+            "created_at": ev["created_at"],
+            "duration_seconds": ev["duration_seconds"],
+            "points": None,  # points come from verdicts table, not per-event
+            "detail": ev.get("detail"),
+        })
+
+    return {
+        "project": project,
+        "kind": kind,
+        "number": number,
+        "title": title,
+        "github_url": github_url,
+        "stage": stage,
+        "linked_pr": linked_pr,
+        "linked_issue": linked_issue,
+        "events": clean_events,
+        "totals": totals,
+    }

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,0 +1,190 @@
+import sqlite3
+
+from fastapi.testclient import TestClient
+
+import server
+import server.db
+
+
+def _make_client(monkeypatch, tmp_path):
+    monkeypatch.setattr(server.db, "DB_PATH", str(tmp_path / "test.db"))
+    server.db.apply_pending_migrations()
+    return TestClient(server.app)
+
+
+def _insert_events(db_path: str, events: list) -> None:
+    conn = sqlite3.connect(db_path)
+    for ev in events:
+        conn.execute(
+            """
+            INSERT INTO events (project, role, event_type, issue_number, pr_number, detail, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                ev["project"],
+                ev["role"],
+                ev["event_type"],
+                ev.get("issue_number"),
+                ev.get("pr_number"),
+                ev.get("detail"),
+                ev["created_at"],
+            ),
+        )
+    conn.commit()
+    conn.close()
+
+
+# (a) happy path — events returned and basic fields present
+def test_happy_path_issue(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-a", "role": "dev", "event_type": "dev_start",
+         "issue_number": 10, "created_at": "2026-04-01T10:00:00+00:00"},
+        {"project": "proj-a", "role": "dev", "event_type": "dev_done",
+         "issue_number": 10, "created_at": "2026-04-01T10:30:00+00:00"},
+    ])
+    resp = client.get("/api/timeline?project=proj-a&issue=10")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["project"] == "proj-a"
+    assert data["kind"] == "issue"
+    assert data["number"] == 10
+    assert len(data["events"]) == 2
+    assert data["github_url"] == "https://github.com/svv2014/proj-a/issues/10"
+
+
+# (b) happy path for PR
+def test_happy_path_pr(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-b", "role": "review", "event_type": "review_start",
+         "pr_number": 55, "created_at": "2026-04-01T11:00:00+00:00"},
+    ])
+    resp = client.get("/api/timeline?project=proj-b&pr=55")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["kind"] == "pr"
+    assert data["number"] == 55
+    assert data["github_url"] == "https://github.com/svv2014/proj-b/pull/55"
+
+
+# (c) 400 on missing params (no issue or pr)
+def test_missing_params(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    resp = client.get("/api/timeline?project=proj-a")
+    assert resp.status_code == 400
+
+
+# (d) 400 on both params provided
+def test_both_params(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    resp = client.get("/api/timeline?project=proj-a&issue=10&pr=20")
+    assert resp.status_code == 400
+
+
+# (e) 200 with empty events when no rows match
+def test_empty_events(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    resp = client.get("/api/timeline?project=no-such-project&issue=999")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["events"] == []
+
+
+# (f) duration pairing — start → done computes correct duration_seconds
+def test_duration_pairing(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-c", "role": "dev", "event_type": "dev_start",
+         "issue_number": 20, "created_at": "2026-04-01T10:00:00+00:00"},
+        {"project": "proj-c", "role": "dev", "event_type": "dev_done",
+         "issue_number": 20, "created_at": "2026-04-01T10:15:00+00:00"},
+    ])
+    resp = client.get("/api/timeline?project=proj-c&issue=20")
+    assert resp.status_code == 200
+    events = resp.json()["events"]
+    start_ev = next(e for e in events if e["event_type"] == "dev_start")
+    # 15 minutes = 900 seconds
+    assert start_ev["duration_seconds"] == 900
+    done_ev = next(e for e in events if e["event_type"] == "dev_done")
+    assert done_ev["duration_seconds"] is None
+
+
+# (g) duration pairing — start with no matching done → duration is None
+def test_duration_no_done(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-d", "role": "po", "event_type": "po_start",
+         "issue_number": 30, "created_at": "2026-04-01T09:00:00+00:00"},
+    ])
+    resp = client.get("/api/timeline?project=proj-d&issue=30")
+    assert resp.status_code == 200
+    start_ev = resp.json()["events"][0]
+    assert start_ev["duration_seconds"] is None
+
+
+# (h) linked-PR detection — issue with pr_number in events
+def test_linked_pr_detection(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-e", "role": "dev", "event_type": "dev_done",
+         "issue_number": 50, "pr_number": 75, "created_at": "2026-04-01T12:00:00+00:00"},
+    ])
+    resp = client.get("/api/timeline?project=proj-e&issue=50")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["linked_pr"] == 75
+    assert data["linked_issue"] is None
+
+
+# (i) linked-issue detection — pr with issue_number in events
+def test_linked_issue_detection(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-f", "role": "review", "event_type": "review_done",
+         "issue_number": 60, "pr_number": 80, "created_at": "2026-04-01T13:00:00+00:00"},
+    ])
+    resp = client.get("/api/timeline?project=proj-f&pr=80")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["linked_issue"] == 60
+    assert data["linked_pr"] is None
+
+
+# (j) totals — rework_count is correct for multiple starts of same role
+def test_rework_count(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-g", "role": "dev", "event_type": "dev_start",
+         "issue_number": 70, "created_at": "2026-04-01T10:00:00+00:00"},
+        {"project": "proj-g", "role": "dev", "event_type": "dev_done",
+         "issue_number": 70, "created_at": "2026-04-01T10:30:00+00:00"},
+        {"project": "proj-g", "role": "dev", "event_type": "dev_start",
+         "issue_number": 70, "created_at": "2026-04-01T11:00:00+00:00"},
+        {"project": "proj-g", "role": "dev", "event_type": "dev_done",
+         "issue_number": 70, "created_at": "2026-04-01T11:30:00+00:00"},
+    ])
+    resp = client.get("/api/timeline?project=proj-g&issue=70")
+    assert resp.status_code == 200
+    totals = resp.json()["totals"]
+    assert totals["rework_count"] == 1  # 2 starts - 1 = 1 rework
+
+
+# (k) totals — total_duration_seconds sums all paired durations
+def test_total_duration(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-h", "role": "po", "event_type": "po_start",
+         "issue_number": 80, "created_at": "2026-04-01T10:00:00+00:00"},
+        {"project": "proj-h", "role": "po", "event_type": "po_done",
+         "issue_number": 80, "created_at": "2026-04-01T10:10:00+00:00"},
+        {"project": "proj-h", "role": "dev", "event_type": "dev_start",
+         "issue_number": 80, "created_at": "2026-04-01T10:20:00+00:00"},
+        {"project": "proj-h", "role": "dev", "event_type": "dev_done",
+         "issue_number": 80, "created_at": "2026-04-01T10:50:00+00:00"},
+    ])
+    resp = client.get("/api/timeline?project=proj-h&issue=80")
+    assert resp.status_code == 200
+    totals = resp.json()["totals"]
+    # po: 600s, dev: 1800s
+    assert totals["total_duration_seconds"] == 2400

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import ProjectDetail from './screens/ProjectDetail';
 import Queue from './screens/Queue';
 import WorkerDetail from './screens/WorkerDetail';
 import Cost from './screens/Cost';
+import Timeline from './panels/Timeline';
 import { useHashRoute } from './router';
 import { fetchActive, fetchHealth } from './lib/api';
 
@@ -106,6 +107,7 @@ export default function App() {
 
   return (
     <div className="app">
+      <Timeline />
       <Logo />
       <TopBar events={events} online={online} version={version} />
       <NavRail screen={isProjectDetail ? 'projects' : navScreen} setScreen={handleNavChange} />

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -22,6 +22,7 @@ import type {
   LogsResponse,
   IssueCostRow,
   FailureContext,
+  Timeline,
 } from './types';
 import * as fx from './fixtures';
 
@@ -159,6 +160,16 @@ export async function fetchFailureContext(
   return get<FailureContext>(
     `/api/action_queue/${encodeURIComponent(project)}/${encodeURIComponent(kind)}/${number}/failure`,
   );
+}
+
+export async function fetchTimeline(
+  project: string,
+  kind: 'issue' | 'pr',
+  number: number,
+): Promise<Timeline> {
+  if (isFixtureMode()) return fx.getFixtureTimeline(project, kind, number);
+  const param = kind === 'issue' ? 'issue' : 'pr';
+  return get<Timeline>(`/api/timeline?project=${encodeURIComponent(project)}&${param}=${number}`);
 }
 
 export class LogsDisabledError extends Error {

--- a/web/src/lib/fixtures.ts
+++ b/web/src/lib/fixtures.ts
@@ -20,6 +20,7 @@ import type {
   ClaudeUsage,
   ScannerState,
   IssueCostRow,
+  Timeline,
 } from './types';
 
 const PROJECTS = [
@@ -357,6 +358,69 @@ export function getFixtureIssuesCost(): IssueCostRow[] {
       last_event_at: new Date(Date.now() - randInt(60, 7 * 86400) * 1000).toISOString(),
     };
   }).sort((a, b) => b.rework_factor - a.rework_factor || b.actual_runs - a.actual_runs);
+}
+
+export function getFixtureTimeline(project: string, kind: 'issue' | 'pr', number: number): Timeline {
+  const base = kind === 'issue' ? 'issues' : 'pull';
+  const now = Date.now();
+  return {
+    project,
+    kind,
+    number,
+    title: `Fixture: ${kind} #${number} — example timeline`,
+    github_url: `https://github.com/svv2014/${project}/${base}/${number}`,
+    stage: 'loop:stage:dev',
+    linked_pr: kind === 'issue' ? number + 10 : null,
+    linked_issue: kind === 'pr' ? number - 10 : null,
+    events: [
+      {
+        id: 1,
+        role: 'po',
+        event_type: 'po_start',
+        model: 'sonnet-4-6',
+        created_at: new Date(now - 3600 * 1000).toISOString(),
+        duration_seconds: 600,
+        points: null,
+        detail: 'spec breakdown',
+      },
+      {
+        id: 2,
+        role: 'po',
+        event_type: 'po_done',
+        model: 'sonnet-4-6',
+        created_at: new Date(now - 3000 * 1000).toISOString(),
+        duration_seconds: null,
+        points: null,
+        detail: null,
+      },
+      {
+        id: 3,
+        role: 'dev',
+        event_type: 'dev_start',
+        model: 'opus-4-1',
+        created_at: new Date(now - 2900 * 1000).toISOString(),
+        duration_seconds: 1800,
+        points: null,
+        detail: 'implement feature',
+      },
+      {
+        id: 4,
+        role: 'dev',
+        event_type: 'dev_done',
+        model: 'opus-4-1',
+        created_at: new Date(now - 1100 * 1000).toISOString(),
+        duration_seconds: null,
+        points: null,
+        detail: null,
+      },
+    ],
+    totals: {
+      total_duration_seconds: 2400,
+      total_points: 5,
+      rework_count: 0,
+      verdict: 'approved',
+    },
+  };
 }
 
 export function getFixtureScannerState(): ScannerState {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -224,3 +224,34 @@ export interface IssueCostRow {
   actual_runs: number;
   last_event_at: string | null;
 }
+
+export interface TimelineEvent {
+  id: number;
+  role: string;
+  event_type: string;
+  model: string | null;
+  created_at: string;
+  duration_seconds: number | null;
+  points: number | null;
+  detail: string | null;
+}
+
+export interface TimelineTotals {
+  total_duration_seconds: number | null;
+  total_points: number | null;
+  rework_count: number;
+  verdict: string | null;
+}
+
+export interface Timeline {
+  project: string;
+  kind: 'issue' | 'pr';
+  number: number;
+  title: string | null;
+  github_url: string;
+  stage: string | null;
+  linked_pr: number | null;
+  linked_issue: number | null;
+  events: TimelineEvent[];
+  totals: TimelineTotals;
+}

--- a/web/src/panels/Timeline.tsx
+++ b/web/src/panels/Timeline.tsx
@@ -1,0 +1,279 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import Drawer from '../components/Drawer';
+import RoleTag from '../components/RoleTag';
+import EventGlyph from '../components/EventGlyph';
+import { fetchTimeline } from '../lib/api';
+import type { Timeline as TimelineData, TimelineEvent } from '../lib/types';
+import { relTime, durationFmt } from '../lib/utils';
+
+// Parse hash for timeline key: #...&timeline=<project>/<kind>/<n>
+function parseTimelineHash(hash: string): { project: string; kind: 'issue' | 'pr'; number: number } | null {
+  if (!hash) return null;
+  const raw = hash.startsWith('#') ? hash.slice(1) : hash;
+  const params = new URLSearchParams(raw);
+  const val = params.get('timeline');
+  if (!val) return null;
+  const parts = val.split('/');
+  if (parts.length < 3) return null;
+  const [project, kind, numStr] = parts;
+  if (kind !== 'issue' && kind !== 'pr') return null;
+  const number = parseInt(numStr, 10);
+  if (isNaN(number)) return null;
+  return { project, kind, number };
+}
+
+function clearTimelineHash(): void {
+  const raw = window.location.hash.startsWith('#')
+    ? window.location.hash.slice(1)
+    : window.location.hash;
+  const params = new URLSearchParams(raw);
+  params.delete('timeline');
+  const str = params.toString();
+  history.replaceState(
+    null,
+    '',
+    window.location.pathname + window.location.search + (str ? `#${str}` : ''),
+  );
+  window.dispatchEvent(new HashChangeEvent('hashchange'));
+}
+
+function setTimelineHash(project: string, kind: 'issue' | 'pr', number: number): void {
+  const raw = window.location.hash.startsWith('#')
+    ? window.location.hash.slice(1)
+    : window.location.hash;
+  const params = new URLSearchParams(raw);
+  params.set('timeline', `${project}/${kind}/${number}`);
+  history.replaceState(
+    null,
+    '',
+    window.location.pathname + window.location.search + `#${params.toString()}`,
+  );
+  window.dispatchEvent(new HashChangeEvent('hashchange'));
+}
+
+const DT_STYLE: React.CSSProperties = {
+  color: 'var(--fg-3)',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 10,
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  alignSelf: 'center',
+};
+
+function EventRow({ ev }: { ev: TimelineEvent }) {
+  const ts = new Date(ev.created_at).getTime();
+  return (
+    <div className="feed-row" style={{ alignItems: 'flex-start' }}>
+      <EventGlyph event={ev.event_type} />
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+          <RoleTag role={ev.role} />
+          <span className="mono" style={{ fontSize: 12 }}>{ev.event_type}</span>
+          {ev.model && (
+            <span className="muted mono" style={{ fontSize: 11 }}>{ev.model}</span>
+          )}
+        </div>
+        {ev.detail && (
+          <div className="muted" style={{ fontSize: 11, marginTop: 2, wordBreak: 'break-word' }}>
+            {ev.detail}
+          </div>
+        )}
+      </div>
+      <div style={{ textAlign: 'right', flexShrink: 0 }}>
+        {ev.duration_seconds != null && (
+          <div className="mono" style={{ fontSize: 11, color: 'var(--fg-2)' }}>
+            {durationFmt(ev.duration_seconds * 1000)}
+          </div>
+        )}
+        <div className="muted mono" style={{ fontSize: 10 }}>{relTime(ts)}</div>
+      </div>
+    </div>
+  );
+}
+
+function TotalsRow({ data }: { data: TimelineData }) {
+  const t = data.totals;
+  return (
+    <div style={{
+      borderTop: '1px solid var(--border)',
+      paddingTop: 'var(--pad-3)',
+      display: 'grid',
+      gridTemplateColumns: 'auto 1fr',
+      gap: '6px var(--pad-3)',
+      fontSize: 12,
+    }}>
+      {t.total_duration_seconds != null && (
+        <>
+          <dt style={DT_STYLE}>Total time</dt>
+          <dd style={{ margin: 0 }} className="mono">
+            {durationFmt(t.total_duration_seconds * 1000)}
+          </dd>
+        </>
+      )}
+      {t.total_points != null && t.total_points > 0 && (
+        <>
+          <dt style={DT_STYLE}>Points</dt>
+          <dd className="mono" style={{ margin: 0, color: 'var(--accent)' }}>
+            +{t.total_points}
+          </dd>
+        </>
+      )}
+      {t.rework_count > 0 && (
+        <>
+          <dt style={DT_STYLE}>Rework</dt>
+          <dd className="mono" style={{ margin: 0, color: 'var(--role-err)' }}>
+            {t.rework_count}×
+          </dd>
+        </>
+      )}
+      {t.verdict && (
+        <>
+          <dt style={DT_STYLE}>Verdict</dt>
+          <dd style={{ margin: 0 }} className="mono">{t.verdict}</dd>
+        </>
+      )}
+    </div>
+  );
+}
+
+interface TimelinePanelInnerProps {
+  project: string;
+  kind: 'issue' | 'pr';
+  number: number;
+  onClose: () => void;
+}
+
+function TimelinePanelInner({ project, kind, number, onClose }: TimelinePanelInnerProps) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['timeline', project, kind, number],
+    queryFn: () => fetchTimeline(project, kind, number),
+    staleTime: 30_000,
+    refetchOnWindowFocus: false,
+  });
+
+  // Active tab: 'current' or 'linked'
+  const [tab, setTab] = useState<'current' | 'linked'>('current');
+
+  const hasLinked = data && (
+    (data.kind === 'issue' && data.linked_pr != null) ||
+    (data.kind === 'pr' && data.linked_issue != null)
+  );
+
+  const linkedKind: 'issue' | 'pr' = data?.kind === 'issue' ? 'pr' : 'issue';
+  const linkedNumber = data?.kind === 'issue' ? data?.linked_pr : data?.linked_issue;
+
+  // Linked tab query — only runs when tab='linked' and linked exists
+  const linkedQuery = useQuery({
+    queryKey: ['timeline', project, linkedKind, linkedNumber],
+    queryFn: () => fetchTimeline(project, linkedKind, linkedNumber!),
+    enabled: tab === 'linked' && linkedNumber != null,
+    staleTime: 30_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const activeData = tab === 'linked' ? linkedQuery.data : data;
+  const activeLoading = tab === 'linked' ? linkedQuery.isLoading : isLoading;
+
+  const drawerTitle = data
+    ? `${data.project} ${data.kind} #${data.number}${data.title ? ` — ${data.title}` : ''}`
+    : `${project} ${kind} #${number}`;
+
+  return (
+    <Drawer open={true} onClose={onClose} title={drawerTitle}>
+      {/* Header meta */}
+      {data && (
+        <div style={{ display: 'flex', gap: 'var(--pad-2)', alignItems: 'center', flexWrap: 'wrap' }}>
+          <a
+            href={data.github_url}
+            target="_blank"
+            rel="noreferrer"
+            className="btn"
+            style={{ fontSize: 11, textDecoration: 'none' }}
+          >
+            GitHub ↗
+          </a>
+          {data.stage && (
+            <span
+              className="tag mono"
+              style={{ fontSize: 11, background: 'var(--bg-3)', color: 'var(--fg-2)' }}
+            >
+              {data.stage}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Tabs for linked ticket */}
+      {hasLinked && data && (
+        <div style={{ display: 'flex', gap: 4 }}>
+          <button
+            className={`btn ${tab === 'current' ? 'primary' : ''}`}
+            onClick={() => setTab('current')}
+            style={{ fontSize: 11 }}
+          >
+            {data.kind} #{data.number}
+          </button>
+          <button
+            className={`btn ${tab === 'linked' ? 'primary' : ''}`}
+            onClick={() => setTab('linked')}
+            style={{ fontSize: 11 }}
+          >
+            {linkedKind} #{linkedNumber}
+          </button>
+        </div>
+      )}
+
+      <hr style={{ border: 'none', borderTop: '1px solid var(--border)', margin: 0 }} />
+
+      {/* Events list */}
+      {activeLoading ? (
+        <div className="muted" style={{ fontSize: 12 }}>Loading timeline…</div>
+      ) : isError ? (
+        <div style={{ fontSize: 12, color: 'var(--role-err)' }}>Failed to load timeline.</div>
+      ) : !activeData || activeData.events.length === 0 ? (
+        <div className="muted" style={{ fontSize: 12 }}>No events recorded</div>
+      ) : (
+        <>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            {activeData.events.map(ev => (
+              <EventRow key={ev.id} ev={ev} />
+            ))}
+          </div>
+          <TotalsRow data={activeData} />
+        </>
+      )}
+    </Drawer>
+  );
+}
+
+export default function Timeline() {
+  const [parsed, setParsed] = useState(() => parseTimelineHash(window.location.hash));
+
+  const refresh = useCallback(() => {
+    setParsed(parseTimelineHash(window.location.hash));
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('hashchange', refresh);
+    return () => window.removeEventListener('hashchange', refresh);
+  }, [refresh]);
+
+  function handleClose() {
+    clearTimelineHash();
+  }
+
+  if (!parsed) return null;
+
+  return (
+    <TimelinePanelInner
+      project={parsed.project}
+      kind={parsed.kind}
+      number={parsed.number}
+      onClose={handleClose}
+    />
+  );
+}
+
+// Export helper for other components to open the timeline
+export { setTimelineHash };


### PR DESCRIPTION
Closes #215

## Changes
- New `GET /api/timeline` endpoint (`server/routes/timeline.py`) returning aggregated events for a ticket with duration pairing, linked-PR detection, stage, and totals
- Register timeline router in `server/app.py`
- New `tests/test_timeline.py` covering happy path, 400 errors, empty result, duration pairing (start→done), linked-PR/issue detection, rework count, total duration
- New `web/src/panels/Timeline.tsx` side panel with hash-route `#timeline=<project>/<kind>/<n>`, tabbed linked-ticket support, role glyphs, totals row, empty state, Esc to close
- Extended `web/src/lib/types.ts` with `TimelineEvent`, `TimelineTotals`, `Timeline` interfaces
- Extended `web/src/lib/api.ts` with `fetchTimeline(project, kind, n)` (fixture-mode aware)
- Extended `web/src/lib/fixtures.ts` with `getFixtureTimeline()` returning deterministic data
- Mounted `<Timeline />` globally in `App.tsx` so it reacts to hash changes across all screens

## Test Plan
- Hit `GET /api/timeline?project=loop-monitor&issue=163` — returns events array and totals
- Hit without params → 400
- Hit with both `issue` and `pr` → 400
- No matching rows → 200 with `events: []`
- Navigate to `#timeline=loop-monitor/issue/163` in browser → panel opens
- Clear hash → panel closes
- Esc key → panel closes
- Issue with linked PR → tabs appear to switch between timelines
- No events → "No events recorded" shown
- Fixture mode (`?fixtures=1#timeline=loop-monitor/issue/163`) → panel shows seeded data with no network calls