### PR TITLE
[LM-221] fix action queue: _infer_stage helper + updated stage vocabulary

### DIFF
--- a/server/routes/action_queue.py
+++ b/server/routes/action_queue.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sqlite3
 from datetime import datetime, timezone
@@ -12,28 +13,100 @@ from server.helpers.timeline import parse_ts
 
 router = APIRouter()
 
-STUCK_STAGES = {"blocked", "needs-clarification"}
-TIMEOUT_STAGES = {"in-progress", "in-review", "in-rework", "needs-qa", "needs-review", "ready-for-qa"}
-QA_FAIL_STAGE = "qa-fail"
+STUCK_STAGES = {"blocked", "needs-clarification", "loop:result:blocked"}
+TIMEOUT_STAGES = {
+    "in-dev", "in-review", "in-qa",
+    "loop:active:dev", "loop:active:review", "loop:active:qa",
+    "needs-review", "needs-qa", "needs-dev",
+    "loop:action:review", "loop:action:qa", "loop:action:dev",
+}
+QA_FAIL_STAGES = {"qa-fail", "loop:result:qa-fail"}
 QA_FAIL_RETRY_THRESHOLD = 3
 
 STAGE_THRESHOLD_ENV = {
-    "in-progress":  "HANDLER_TIMEOUT_DEV",
-    "in-rework":    "HANDLER_TIMEOUT_DEV",
-    "in-review":    "HANDLER_TIMEOUT_REVIEW",
-    "needs-review": "HANDLER_TIMEOUT_REVIEW",
-    "needs-qa":     "HANDLER_TIMEOUT_QA",
-    "ready-for-qa": "HANDLER_TIMEOUT_QA",
+    "in-dev":             "HANDLER_TIMEOUT_DEV",
+    "needs-dev":          "HANDLER_TIMEOUT_DEV",
+    "loop:active:dev":    "HANDLER_TIMEOUT_DEV",
+    "loop:action:dev":    "HANDLER_TIMEOUT_DEV",
+    "in-review":          "HANDLER_TIMEOUT_REVIEW",
+    "needs-review":       "HANDLER_TIMEOUT_REVIEW",
+    "loop:active:review": "HANDLER_TIMEOUT_REVIEW",
+    "loop:action:review": "HANDLER_TIMEOUT_REVIEW",
+    "in-qa":              "HANDLER_TIMEOUT_QA",
+    "needs-qa":           "HANDLER_TIMEOUT_QA",
+    "loop:active:qa":     "HANDLER_TIMEOUT_QA",
+    "loop:action:qa":     "HANDLER_TIMEOUT_QA",
 }
 
 STAGE_DEFAULTS = {
-    "in-progress":  7200,
-    "in-rework":    7200,
-    "in-review":    1800,
-    "needs-review": 1800,
-    "needs-qa":     3600,
-    "ready-for-qa": 3600,
+    "in-dev":             7200,
+    "needs-dev":          7200,
+    "loop:active:dev":    7200,
+    "loop:action:dev":    7200,
+    "in-review":          1800,
+    "needs-review":       1800,
+    "loop:active:review": 1800,
+    "loop:action:review": 1800,
+    "in-qa":              3600,
+    "needs-qa":           3600,
+    "loop:active:qa":     3600,
+    "loop:action:qa":     3600,
 }
+
+_KNOWN_STAGES = STUCK_STAGES | TIMEOUT_STAGES | QA_FAIL_STAGES
+
+_EVENT_TYPE_TO_STAGE: dict[str, Optional[str]] = {
+    "dev_start":      "in-dev",
+    "rework_start":   "in-dev",
+    "review_start":   "in-review",
+    "qa_start":       "in-qa",
+    "qa_fail":        "qa-fail",
+    "po_done":        "needs-dev",
+    "dev_done":       "needs-review",
+    "rework_done":    "needs-review",
+    "review_done":    "needs-qa",
+    "qa_pass":        None,
+    "merge_done":     None,
+    "po_failed":      "blocked",
+    "dev_failed":     "blocked",
+    "review_failed":  "blocked",
+    "merge_failed":   "blocked",
+    "merge_conflict": "blocked",
+    "rework_failed":  "blocked",
+}
+
+
+def _infer_stage(
+    role: str, event_type: str, detail: Optional[str] = None, payload: Optional[str] = None
+) -> Optional[str]:
+    """Infer the current ticket stage from the latest event.
+
+    Temporary stop-gap; superseded once the `current_labels` table lands (see Option 1 in #221).
+    """
+    et = (event_type or "").lower()
+
+    if et == "label_transition":
+        for src in (payload, detail):
+            if not src:
+                continue
+            try:
+                data = json.loads(src)
+                # Try direct label keys first (future schema variants), then after_labels array.
+                label = data.get("to") or data.get("new_label")
+                if label and label in _KNOWN_STAGES:
+                    return label
+                for lbl in data.get("after_labels", []):
+                    if lbl in _KNOWN_STAGES:
+                        return lbl
+            except (json.JSONDecodeError, AttributeError):
+                continue
+        # TODO(#221): wire once payload schema settles
+        return None
+
+    if et in _EVENT_TYPE_TO_STAGE:
+        return _EVENT_TYPE_TO_STAGE[et]
+
+    return None
 
 
 def _handler_timeout_seconds() -> int:
@@ -61,7 +134,7 @@ def _action_queue_reason(
         return "stuck_label"
     if stage in TIMEOUT_STAGES and age_seconds > threshold:
         return "timeout"
-    if stage == QA_FAIL_STAGE and retry_count >= QA_FAIL_RETRY_THRESHOLD:
+    if stage in QA_FAIL_STAGES and retry_count >= QA_FAIL_RETRY_THRESHOLD:
         return "qa_fail_repeated"
     return None
 
@@ -75,7 +148,7 @@ def action_queue(conn: sqlite3.Connection = Depends(db_dep)):
     rows = conn.execute(
         """
         SELECT e.project, e.role, e.event_type, e.issue_number, e.pr_number,
-               e.detail, e.loop_id, e.created_at,
+               e.detail, e.payload, e.loop_id, e.created_at,
                COALESCE(h.rework_count, 0) AS rework_count,
                COALESCE(r.title, '') AS title
         FROM events e
@@ -105,7 +178,9 @@ def action_queue(conn: sqlite3.Connection = Depends(db_dep)):
     now = datetime.now(timezone.utc)
     result = []
     for r in rows:
-        stage = (r["event_type"] or "").lower()
+        stage = _infer_stage(r["role"], r["event_type"], r["detail"], r["payload"])
+        if stage is None:
+            continue
         created = parse_ts(r["created_at"])
         age_seconds = int((now - created).total_seconds()) if created else 0
         threshold = _threshold_for_stage(stage)

--- a/tests/test_action_queue.py
+++ b/tests/test_action_queue.py
@@ -14,8 +14,9 @@ def test_action_queue_empty(isolated_client):
 
 
 def test_action_queue_blocked_label(isolated_client):
+    # dev_failed infers stage='blocked' → reason='stuck_label'
     server._insert_event(server.ReportPayload(
-        project="boba-event", role="dev", event_type="blocked", issue_number=42,
+        project="boba-event", role="dev", event_type="dev_failed", issue_number=42,
         detail="needs human"
     ))
     resp = isolated_client.get("/api/action_queue")
@@ -31,8 +32,17 @@ def test_action_queue_blocked_label(isolated_client):
 
 
 def test_action_queue_needs_clarification(isolated_client):
+    # label_transition with after_labels=["needs-clarification"] → stage='needs-clarification'
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="needs-clarification", issue_number=7
+        project="loop", role="dev", event_type="label_transition", issue_number=7,
+        payload={
+            "target_kind": "issue",
+            "number": 7,
+            "before_labels": [],
+            "after_labels": ["needs-clarification"],
+            "op": "add",
+            "source": "scanner",
+        }
     ))
     resp = isolated_client.get("/api/action_queue")
     data = resp.json()
@@ -41,8 +51,9 @@ def test_action_queue_needs_clarification(isolated_client):
 
 def test_action_queue_timeout_threshold(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "200")
+    # dev_start infers stage='in-dev'
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="in-progress", issue_number=11
+        project="loop", role="dev", event_type="dev_start", issue_number=11
     ))
     # backdate created_at to 300s ago — exceeds 200s threshold
     conn = sqlite3.connect(server.db.DB_PATH)
@@ -55,14 +66,15 @@ def test_action_queue_timeout_threshold(isolated_client, monkeypatch):
     data = resp.json()
     timeout_items = [it for it in data if it["reason"] == "timeout" and it["number"] == 11]
     assert len(timeout_items) == 1
-    assert timeout_items[0]["stage"] == "in-progress"
+    assert timeout_items[0]["stage"] == "in-dev"
     assert timeout_items[0]["age_seconds"] >= 200
 
 
 def test_action_queue_in_progress_below_threshold_excluded(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "3600")
+    # dev_start infers stage='in-dev'; ticket is fresh so age < threshold
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="in-progress", issue_number=13
+        project="loop", role="dev", event_type="dev_start", issue_number=13
     ))
     resp = isolated_client.get("/api/action_queue")
     data = resp.json()
@@ -71,11 +83,12 @@ def test_action_queue_in_progress_below_threshold_excluded(isolated_client, monk
 
 def test_action_queue_sorted_by_age_desc(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "100")
+    # dev_failed infers stage='blocked' → stuck_label (no threshold check)
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="blocked", issue_number=200
+        project="loop", role="dev", event_type="dev_failed", issue_number=200
     ))
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="blocked", issue_number=201
+        project="loop", role="dev", event_type="dev_failed", issue_number=201
     ))
     conn = sqlite3.connect(server.db.DB_PATH)
     conn.execute(
@@ -91,8 +104,9 @@ def test_action_queue_sorted_by_age_desc(isolated_client, monkeypatch):
 
 def test_action_queue_per_stage_threshold_dev_override(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "500")
+    # dev_start infers stage='in-dev' → HANDLER_TIMEOUT_DEV applies
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="in-progress", issue_number=300
+        project="loop", role="dev", event_type="dev_start", issue_number=300
     ))
     conn = sqlite3.connect(server.db.DB_PATH)
     conn.execute(
@@ -109,8 +123,9 @@ def test_action_queue_per_stage_threshold_dev_override(isolated_client, monkeypa
 
 def test_action_queue_needs_qa_past_threshold(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_QA", "60")
+    # review_done infers stage='needs-qa' → HANDLER_TIMEOUT_QA applies
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="needs-qa", issue_number=301
+        project="loop", role="dev", event_type="review_done", issue_number=301
     ))
     conn = sqlite3.connect(server.db.DB_PATH)
     conn.execute(
@@ -128,8 +143,9 @@ def test_action_queue_needs_qa_past_threshold(isolated_client, monkeypatch):
 
 def test_action_queue_needs_qa_under_threshold_excluded(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_QA", "3600")
+    # review_done infers stage='needs-qa'; ticket is fresh so age < threshold
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="needs-qa", issue_number=302
+        project="loop", role="dev", event_type="review_done", issue_number=302
     ))
     resp = isolated_client.get("/api/action_queue")
     data = resp.json()
@@ -138,11 +154,13 @@ def test_action_queue_needs_qa_under_threshold_excluded(isolated_client, monkeyp
 
 def test_action_queue_threshold_seconds_field(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_QA", "60")
+    # review_done → needs-qa timeout item
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="needs-qa", issue_number=303
+        project="loop", role="dev", event_type="review_done", issue_number=303
     ))
+    # dev_failed → blocked stuck_label item (no threshold)
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="blocked", issue_number=304
+        project="loop", role="dev", event_type="dev_failed", issue_number=304
     ))
     conn = sqlite3.connect(server.db.DB_PATH)
     conn.execute(
@@ -160,6 +178,94 @@ def test_action_queue_threshold_seconds_field(isolated_client, monkeypatch):
     assert stuck_item is not None
     assert stuck_item["reason"] == "stuck_label"
     assert stuck_item["threshold_seconds"] is None
+
+
+# ── New AC tests: _infer_stage path ──────────────────────────────────────────
+
+
+def test_action_queue_infer_dev_start_timeout(isolated_client, monkeypatch):
+    """dev_start older than dev threshold → stage='in-dev', reason='timeout'."""
+    monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "200")
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="dev_start", issue_number=500,
+    ))
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        "UPDATE events SET created_at = datetime('now', '-300 seconds') WHERE issue_number = 500"
+    )
+    conn.commit()
+    conn.close()
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    items = [it for it in data if it["number"] == 500]
+    assert len(items) == 1
+    assert items[0]["stage"] == "in-dev"
+    assert items[0]["reason"] == "timeout"
+
+
+def test_action_queue_infer_dev_failed_blocked(isolated_client):
+    """dev_failed maps to stage='blocked' → reason='stuck_label'."""
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="dev_failed", issue_number=501,
+    ))
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    items = [it for it in data if it["number"] == 501]
+    assert len(items) == 1
+    assert items[0]["stage"] == "blocked"
+    assert items[0]["reason"] == "stuck_label"
+
+
+def test_action_queue_infer_qa_fail_repeated(isolated_client):
+    """qa_fail with rework_count>=3 → stage='qa-fail', reason='qa_fail_repeated'."""
+    server._insert_event(server.ReportPayload(
+        project="loop", role="qa", event_type="qa_fail", issue_number=502,
+        rework_count=3,
+    ))
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    items = [it for it in data if it["number"] == 502]
+    assert len(items) == 1
+    assert items[0]["stage"] == "qa-fail"
+    assert items[0]["reason"] == "qa_fail_repeated"
+
+
+def test_action_queue_infer_dev_done_not_returned(isolated_client):
+    """dev_done means work finished — ticket must NOT appear in the queue."""
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="dev_done", issue_number=503,
+    ))
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    assert all(it["number"] != 503 for it in data)
+
+
+def test_action_queue_infer_label_transition_loop_active_dev(isolated_client, monkeypatch):
+    """label_transition with after_labels=['loop:active:dev'] → reason='timeout' when old."""
+    monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "200")
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="label_transition", issue_number=504,
+        payload={
+            "target_kind": "issue",
+            "number": 504,
+            "before_labels": [],
+            "after_labels": ["loop:active:dev"],
+            "op": "add",
+            "source": "scanner",
+        }
+    ))
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        "UPDATE events SET created_at = datetime('now', '-300 seconds') WHERE issue_number = 504"
+    )
+    conn.commit()
+    conn.close()
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    items = [it for it in data if it["number"] == 504]
+    assert len(items) == 1
+    assert items[0]["stage"] == "loop:active:dev"
+    assert items[0]["reason"] == "timeout"
 
 
 # ── Failure-context endpoint ──────────────────────────────────────────────────


### PR DESCRIPTION
Closes #221

## Changes

**`server/routes/action_queue.py`**
- Added `_infer_stage(role, event_type, detail, payload) -> str | None` helper that maps the latest event per ticket to a canonical stage label (e.g. `dev_start` → `in-dev`, `dev_failed` → `blocked`, `qa_fail` → `qa-fail`). Handles `label_transition` events by parsing payload `after_labels` (and `to`/`new_label` keys for future variants). Returns `None` for terminal/no-action events (`dev_done`, `qa_pass`, etc.). Documented as temporary stop-gap pending `current_labels` table (Option 1 from #221).
- Updated constants: `STUCK_STAGES` adds `loop:result:blocked`; `TIMEOUT_STAGES` replaces deprecated names (`in-progress`, `in-rework`, `ready-for-qa`) with canonical + `loop:*` aliases; `QA_FAIL_STAGE` (string) replaced with `QA_FAIL_STAGES` (set).
- Extended `STAGE_THRESHOLD_ENV`/`STAGE_DEFAULTS` to cover every entry in `TIMEOUT_STAGES`.
- SQL query now selects `e.payload` for `label_transition` parsing.
- Main loop uses `_infer_stage` instead of direct `event_type` comparison.

**`tests/test_action_queue.py`**
- Fixed 9 existing tests to use real event_types (`dev_failed`, `dev_start`, `review_done`) instead of stage names that were never valid event_type values.
- Added 5 new AC tests: `dev_start` timeout, `dev_failed` → blocked, `qa_fail` repeated, `dev_done` not returned, `label_transition` with `loop:active:dev` payload.

## Test Plan
- `ruff check .` — clean
- `pytest tests/ --ignore=tests/visual --ignore=tests/test_graph.py` — 159 passed (test_graph failure is pre-existing on main, unrelated)