### PR TITLE
[LM-214] restore clickable #N GitHub refs on Overview, NowStrip, ActivityFeed, ProjectDetail

### DIFF
--- a/server/routes/feed.py
+++ b/server/routes/feed.py
@@ -5,9 +5,21 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends
 
+from server.constants import PROJECTS
 from server.db import db_dep
 
 router = APIRouter()
+
+
+def _github_url(project: str, issue_number: Optional[int], pr_number: Optional[int]) -> Optional[str]:
+    repo = PROJECTS.get(project)
+    if not repo:
+        return None
+    if issue_number is not None:
+        return f"https://github.com/{repo}/issues/{issue_number}"
+    if pr_number is not None:
+        return f"https://github.com/{repo}/pull/{pr_number}"
+    return None
 
 
 @router.get("/api/history")
@@ -50,7 +62,12 @@ def history(limit: int = 50, loop_id: Optional[str] = None, conn: sqlite3.Connec
         ORDER BY d.id DESC
         LIMIT ?
     """, params).fetchall()
-    return [dict(r) for r in rows]
+    result = []
+    for r in rows:
+        entry = dict(r)
+        entry["github_url"] = _github_url(entry["project"], entry.get("issue_number"), entry.get("pr_number"))
+        result.append(entry)
+    return result
 
 
 @router.get("/api/active")
@@ -133,6 +150,7 @@ def feed(
         except Exception:
             entry["age_seconds"] = None
         entry["status"] = _derive_status(entry["event_type"])
+        entry["github_url"] = _github_url(entry["project"], entry.get("issue_number"), entry.get("pr_number"))
         result.append(entry)
     return result
 

--- a/web/src/components/IssueRef.tsx
+++ b/web/src/components/IssueRef.tsx
@@ -1,0 +1,28 @@
+interface IssueRefProps {
+  number: number;
+  url?: string | null;
+}
+
+export default function IssueRef({ number, url }: IssueRefProps) {
+  if (url) {
+    return (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mono"
+        style={{
+          fontSize: 'inherit',
+          color: 'var(--fg-3)',
+          textDecoration: 'none',
+          cursor: 'pointer',
+        }}
+        onMouseEnter={e => (e.currentTarget.style.textDecoration = 'underline')}
+        onMouseLeave={e => (e.currentTarget.style.textDecoration = 'none')}
+      >
+        #{number}
+      </a>
+    );
+  }
+  return <span className="mono">#{number}</span>;
+}

--- a/web/src/lib/fixtures.ts
+++ b/web/src/lib/fixtures.ts
@@ -161,6 +161,7 @@ export function getFixtureFeed(): FeedItem[] {
     created_at: e.created_at,
     age_seconds: Math.floor((Date.now() - e.ts) / 1000),
     status: e.event_type.endsWith('_fail') ? 'fail' : e.event_type.endsWith('_pass') ? 'pass' : 'done',
+    github_url: null,
   }));
 }
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -43,6 +43,7 @@ export interface FeedItem {
   created_at: string;
   age_seconds: number | null;
   status: string;
+  github_url: string | null;
 }
 
 export interface LoopEvent {
@@ -59,6 +60,7 @@ export interface LoopEvent {
   started_at?: string | null;
   duration_seconds?: number | null;
   points?: number | null;
+  github_url?: string | null;
 }
 
 export interface StatusEntry {

--- a/web/src/panels/ActivityFeed.tsx
+++ b/web/src/panels/ActivityFeed.tsx
@@ -3,6 +3,7 @@ import type { FeedItem } from '../lib/types';
 import { relTime } from '../lib/utils';
 import RoleTag from '../components/RoleTag';
 import EventGlyph from '../components/EventGlyph';
+import IssueRef from '../components/IssueRef';
 
 const ROLES = ['all', 'po', 'dev', 'qa', 'reviewer', 'merge', 'judge'] as const;
 
@@ -45,7 +46,9 @@ export default function ActivityFeed({ events }: ActivityFeedProps) {
                   <span className="mono" style={{ fontSize: 12 }}>{e.event_type}</span>
                   <span className="muted mono" style={{ fontSize: 11 }}>
                     · {e.project}
-                    {e.issue_number != null ? `#${e.issue_number}` : ''}
+                    {e.issue_number != null && (
+                      <IssueRef number={e.issue_number} url={e.github_url} />
+                    )}
                   </span>
                 </div>
                 <div className="muted" style={{ fontSize: 11, marginTop: 2 }}>

--- a/web/src/panels/NowStrip.tsx
+++ b/web/src/panels/NowStrip.tsx
@@ -1,6 +1,7 @@
 import type { Worker, FeedItem } from '../lib/types';
 import { relTime, durationFmt, useTick } from '../lib/utils';
 import EventGlyph from '../components/EventGlyph';
+import IssueRef from '../components/IssueRef';
 
 interface NowStripProps {
   workers: Worker[];
@@ -39,7 +40,9 @@ export default function NowStrip({ workers, events }: NowStripProps) {
               <span className="muted">·</span>
               <span className="muted mono">
                 {lastEvent.project}
-                {lastEvent.issue_number != null ? `#${lastEvent.issue_number}` : ''}
+                {lastEvent.issue_number != null && (
+                  <IssueRef number={lastEvent.issue_number} url={lastEvent.github_url} />
+                )}
               </span>
               <span className="muted">·</span>
               <span className="muted">{relTime(lastTs)} ago</span>

--- a/web/src/screens/Overview.tsx
+++ b/web/src/screens/Overview.tsx
@@ -14,6 +14,7 @@ import RoleTag from '../components/RoleTag';
 import { relTime, durationFmt } from '../lib/utils';
 import Charts from '../panels/Charts';
 import ClaudeUsage from '../panels/ClaudeUsage';
+import IssueRef from '../components/IssueRef';
 
 const COMPLETED_TYPES = new Set([
   'merge_done', 'judge_done', 'review_done', 'dev_done', 'po_done',
@@ -137,7 +138,9 @@ export default function Overview() {
                       </div>
                       <div className="muted mono" style={{ fontSize: 11, marginTop: 2 }}>
                         {e.event_type}
-                        {e.issue_number != null ? ` · #${e.issue_number}` : ''}
+                        {e.issue_number != null && (
+                          <> · <IssueRef number={e.issue_number} url={e.github_url} /></>
+                        )}
                         {durMs > 0 ? ` · ${durationFmt(durMs)}` : ''}
                       </div>
                     </div>

--- a/web/src/screens/ProjectDetail.tsx
+++ b/web/src/screens/ProjectDetail.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import PrMonitorTable from '../components/PrMonitorTable';
+import IssueRef from '../components/IssueRef';
 import type { Worker, FeedItem, PipelineRun, PRMonitorEntry, CycleTimesResponse, SloConfig } from '../lib/types';
 import { fetchCycleTimes, fetchSlo } from '../lib/api';
 
@@ -430,7 +431,9 @@ export default function ProjectDetail({ projectId, allProjectIds, onBack, onProj
                     </span>
                     <span className="mono">{e.event_type}</span>
                     {e.issue_number != null && (
-                      <span className="muted mono" style={{ fontSize: 11 }}>· #{e.issue_number}</span>
+                      <span className="muted mono" style={{ fontSize: 11 }}>
+                        · <IssueRef number={e.issue_number} url={e.github_url} />
+                      </span>
                     )}
                     {e.model && (
                       <span className="muted mono" style={{ fontSize: 11 }}>· {e.model}</span>


### PR DESCRIPTION
Closes #214

## Changes

**Server (`server/routes/feed.py`)**
- Added `_github_url()` helper that builds a GitHub URL from project + issue_number/pr_number using the `PROJECTS` map (same source-of-truth used by `action_queue.py`).
- Applied to both `/api/feed` (feeds NowStrip, ActivityFeed, ProjectDetail) and `/api/history` (feeds Overview recent events), so all four surfaces receive `github_url` in each event row.

**Types (`web/src/lib/types.ts`)**
- Added `github_url: string | null` to `FeedItem`.
- Added `github_url?: string | null` to `LoopEvent`.

**New component (`web/src/components/IssueRef.tsx`)**
- Renders `#N` as a styled `<a>` when `url` is provided, plain `<span>` otherwise.
- Styling: muted color (`var(--fg-3)`), no underline by default, underline on hover, cursor-pointer — visually quiet, no layout shift.

**Four affected surfaces**
- `web/src/screens/Overview.tsx` — recent events list
- `web/src/panels/NowStrip.tsx` — ticker last event
- `web/src/panels/ActivityFeed.tsx` — feed rows
- `web/src/screens/ProjectDetail.tsx` — event stream panel

**Fixtures (`web/src/lib/fixtures.ts`)**
- Added `github_url: null` to fixture `FeedItem` entries to satisfy the updated type.

Queue, Cost, FailureInspector, and PrMonitorTable are untouched.

## Test Plan
- Open Overview > recent events: click `#N` → GitHub issue/PR opens in new tab.
- Same check on NowStrip ticker, ActivityFeed panel, ProjectDetail event stream.
- Hover state shows underline + pointer cursor.
- Event row with no issue_number still renders cleanly (no link, no error).
- Queue / Cost / FailureInspector / PrMonitorTable unchanged.