### PR TITLE
[LM-221] fix action_queue: inference helper + updated stage vocabulary

### DIFF
--- a/server/routes/action_queue.py
+++ b/server/routes/action_queue.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sqlite3
 from datetime import datetime, timezone
@@ -12,28 +13,92 @@ from server.helpers.timeline import parse_ts
 
 router = APIRouter()
 
-STUCK_STAGES = {"blocked", "needs-clarification"}
-TIMEOUT_STAGES = {"in-progress", "in-review", "in-rework", "needs-qa", "needs-review", "ready-for-qa"}
-QA_FAIL_STAGE = "qa-fail"
+STUCK_STAGES = {"blocked", "needs-clarification", "loop:result:blocked"}
+TIMEOUT_STAGES = {
+    "in-dev", "in-review", "in-qa",
+    "loop:active:dev", "loop:active:review", "loop:active:qa",
+    "needs-review", "needs-qa", "needs-dev",
+    "loop:action:review", "loop:action:qa", "loop:action:dev",
+}
+QA_FAIL_STAGES = {"qa-fail", "loop:result:qa-fail"}
 QA_FAIL_RETRY_THRESHOLD = 3
 
 STAGE_THRESHOLD_ENV = {
-    "in-progress":  "HANDLER_TIMEOUT_DEV",
-    "in-rework":    "HANDLER_TIMEOUT_DEV",
-    "in-review":    "HANDLER_TIMEOUT_REVIEW",
-    "needs-review": "HANDLER_TIMEOUT_REVIEW",
-    "needs-qa":     "HANDLER_TIMEOUT_QA",
-    "ready-for-qa": "HANDLER_TIMEOUT_QA",
+    # dev-phase canonical + loop:* aliases
+    "in-dev":             "HANDLER_TIMEOUT_DEV",
+    "needs-dev":          "HANDLER_TIMEOUT_DEV",
+    "loop:active:dev":    "HANDLER_TIMEOUT_DEV",
+    "loop:action:dev":    "HANDLER_TIMEOUT_DEV",
+    # review-phase canonical + loop:* aliases
+    "in-review":          "HANDLER_TIMEOUT_REVIEW",
+    "needs-review":       "HANDLER_TIMEOUT_REVIEW",
+    "loop:active:review": "HANDLER_TIMEOUT_REVIEW",
+    "loop:action:review": "HANDLER_TIMEOUT_REVIEW",
+    # qa-phase canonical + loop:* aliases
+    "in-qa":              "HANDLER_TIMEOUT_QA",
+    "needs-qa":           "HANDLER_TIMEOUT_QA",
+    "loop:active:qa":     "HANDLER_TIMEOUT_QA",
+    "loop:action:qa":     "HANDLER_TIMEOUT_QA",
 }
 
 STAGE_DEFAULTS = {
-    "in-progress":  7200,
-    "in-rework":    7200,
-    "in-review":    1800,
-    "needs-review": 1800,
-    "needs-qa":     3600,
-    "ready-for-qa": 3600,
+    "in-dev":             7200,
+    "needs-dev":          7200,
+    "loop:active:dev":    7200,
+    "loop:action:dev":    7200,
+    "in-review":          1800,
+    "needs-review":       1800,
+    "loop:active:review": 1800,
+    "loop:action:review": 1800,
+    "in-qa":              3600,
+    "needs-qa":           3600,
+    "loop:active:qa":     3600,
+    "loop:action:qa":     3600,
 }
+
+_ALL_KNOWN_STAGES = STUCK_STAGES | TIMEOUT_STAGES | QA_FAIL_STAGES
+
+_INFERENCE_MAP: dict[str, Optional[str]] = {
+    "dev_start":      "in-dev",
+    "rework_start":   "in-dev",
+    "review_start":   "in-review",
+    "qa_start":       "in-qa",
+    "qa_fail":        "qa-fail",
+    "po_done":        "needs-dev",
+    "dev_done":       "needs-review",
+    "rework_done":    "needs-review",
+    "review_done":    "needs-qa",
+    "qa_pass":        None,
+    "merge_done":     None,
+    "po_failed":      "blocked",
+    "dev_failed":     "blocked",
+    "review_failed":  "blocked",
+    "merge_failed":   "blocked",
+    "merge_conflict": "blocked",
+    "rework_failed":  "blocked",
+}
+
+
+def _infer_stage(role: str, event_type: str, payload: Optional[str] = None) -> Optional[str]:
+    """Map the latest event for a ticket to a canonical stage label.
+
+    Temporary stop-gap; superseded once the `current_labels` table lands (see Option 1 in #221).
+
+    Returns None for events that imply no action is needed (work finished or unknown state).
+    """
+    if event_type == "label_transition":
+        if payload:
+            try:
+                p = json.loads(payload) if isinstance(payload, str) else payload
+                after_labels = p.get("after_labels", [])
+                for label in after_labels:
+                    if label in _ALL_KNOWN_STAGES:
+                        return label
+            except (json.JSONDecodeError, AttributeError, TypeError):
+                pass
+        # TODO(#221): wire once payload schema settles
+        return None
+    return _INFERENCE_MAP.get(event_type)
 
 
 def _handler_timeout_seconds() -> int:
@@ -61,7 +126,7 @@ def _action_queue_reason(
         return "stuck_label"
     if stage in TIMEOUT_STAGES and age_seconds > threshold:
         return "timeout"
-    if stage == QA_FAIL_STAGE and retry_count >= QA_FAIL_RETRY_THRESHOLD:
+    if stage in QA_FAIL_STAGES and retry_count >= QA_FAIL_RETRY_THRESHOLD:
         return "qa_fail_repeated"
     return None
 
@@ -75,7 +140,7 @@ def action_queue(conn: sqlite3.Connection = Depends(db_dep)):
     rows = conn.execute(
         """
         SELECT e.project, e.role, e.event_type, e.issue_number, e.pr_number,
-               e.detail, e.loop_id, e.created_at,
+               e.detail, e.payload, e.loop_id, e.created_at,
                COALESCE(h.rework_count, 0) AS rework_count,
                COALESCE(r.title, '') AS title
         FROM events e
@@ -105,7 +170,9 @@ def action_queue(conn: sqlite3.Connection = Depends(db_dep)):
     now = datetime.now(timezone.utc)
     result = []
     for r in rows:
-        stage = (r["event_type"] or "").lower()
+        stage = _infer_stage(r["role"] or "", r["event_type"] or "", r["payload"])
+        if stage is None:
+            continue
         created = parse_ts(r["created_at"])
         age_seconds = int((now - created).total_seconds()) if created else 0
         threshold = _threshold_for_stage(stage)

--- a/tests/test_action_queue.py
+++ b/tests/test_action_queue.py
@@ -15,7 +15,7 @@ def test_action_queue_empty(isolated_client):
 
 def test_action_queue_blocked_label(isolated_client):
     server._insert_event(server.ReportPayload(
-        project="boba-event", role="dev", event_type="blocked", issue_number=42,
+        project="boba-event", role="dev", event_type="dev_failed", issue_number=42,
         detail="needs human"
     ))
     resp = isolated_client.get("/api/action_queue")
@@ -32,7 +32,12 @@ def test_action_queue_blocked_label(isolated_client):
 
 def test_action_queue_needs_clarification(isolated_client):
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="needs-clarification", issue_number=7
+        project="loop", role="dev", event_type="label_transition", issue_number=7,
+        payload={
+            "target_kind": "issue", "number": 7,
+            "before_labels": [], "after_labels": ["needs-clarification"],
+            "op": "add", "source": "test",
+        },
     ))
     resp = isolated_client.get("/api/action_queue")
     data = resp.json()
@@ -42,7 +47,7 @@ def test_action_queue_needs_clarification(isolated_client):
 def test_action_queue_timeout_threshold(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "200")
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="in-progress", issue_number=11
+        project="loop", role="dev", event_type="dev_start", issue_number=11
     ))
     # backdate created_at to 300s ago — exceeds 200s threshold
     conn = sqlite3.connect(server.db.DB_PATH)
@@ -55,14 +60,14 @@ def test_action_queue_timeout_threshold(isolated_client, monkeypatch):
     data = resp.json()
     timeout_items = [it for it in data if it["reason"] == "timeout" and it["number"] == 11]
     assert len(timeout_items) == 1
-    assert timeout_items[0]["stage"] == "in-progress"
+    assert timeout_items[0]["stage"] == "in-dev"
     assert timeout_items[0]["age_seconds"] >= 200
 
 
 def test_action_queue_in_progress_below_threshold_excluded(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "3600")
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="in-progress", issue_number=13
+        project="loop", role="dev", event_type="dev_start", issue_number=13
     ))
     resp = isolated_client.get("/api/action_queue")
     data = resp.json()
@@ -72,10 +77,10 @@ def test_action_queue_in_progress_below_threshold_excluded(isolated_client, monk
 def test_action_queue_sorted_by_age_desc(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "100")
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="blocked", issue_number=200
+        project="loop", role="dev", event_type="dev_failed", issue_number=200
     ))
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="blocked", issue_number=201
+        project="loop", role="dev", event_type="dev_failed", issue_number=201
     ))
     conn = sqlite3.connect(server.db.DB_PATH)
     conn.execute(
@@ -92,7 +97,7 @@ def test_action_queue_sorted_by_age_desc(isolated_client, monkeypatch):
 def test_action_queue_per_stage_threshold_dev_override(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "500")
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="in-progress", issue_number=300
+        project="loop", role="dev", event_type="dev_start", issue_number=300
     ))
     conn = sqlite3.connect(server.db.DB_PATH)
     conn.execute(
@@ -110,7 +115,7 @@ def test_action_queue_per_stage_threshold_dev_override(isolated_client, monkeypa
 def test_action_queue_needs_qa_past_threshold(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_QA", "60")
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="needs-qa", issue_number=301
+        project="loop", role="dev", event_type="review_done", issue_number=301
     ))
     conn = sqlite3.connect(server.db.DB_PATH)
     conn.execute(
@@ -129,7 +134,7 @@ def test_action_queue_needs_qa_past_threshold(isolated_client, monkeypatch):
 def test_action_queue_needs_qa_under_threshold_excluded(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_QA", "3600")
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="needs-qa", issue_number=302
+        project="loop", role="dev", event_type="review_done", issue_number=302
     ))
     resp = isolated_client.get("/api/action_queue")
     data = resp.json()
@@ -139,10 +144,10 @@ def test_action_queue_needs_qa_under_threshold_excluded(isolated_client, monkeyp
 def test_action_queue_threshold_seconds_field(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_QA", "60")
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="needs-qa", issue_number=303
+        project="loop", role="dev", event_type="review_done", issue_number=303
     ))
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="blocked", issue_number=304
+        project="loop", role="dev", event_type="dev_failed", issue_number=304
     ))
     conn = sqlite3.connect(server.db.DB_PATH)
     conn.execute(
@@ -160,6 +165,90 @@ def test_action_queue_threshold_seconds_field(isolated_client, monkeypatch):
     assert stuck_item is not None
     assert stuck_item["reason"] == "stuck_label"
     assert stuck_item["threshold_seconds"] is None
+
+
+# ── New tests for issue #221 ──────────────────────────────────────────────────
+
+def test_action_queue_dev_start_timeout(isolated_client, monkeypatch):
+    """dev_start older than threshold → stage='in-dev', reason='timeout'."""
+    monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "100")
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="dev_start", issue_number=400
+    ))
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        "UPDATE events SET created_at = datetime('now', '-200 seconds') WHERE issue_number = 400"
+    )
+    conn.commit()
+    conn.close()
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    items = [it for it in data if it["number"] == 400]
+    assert len(items) == 1
+    assert items[0]["stage"] == "in-dev"
+    assert items[0]["reason"] == "timeout"
+
+
+def test_action_queue_dev_failed_blocked(isolated_client):
+    """dev_failed → stage='blocked', reason='stuck_label'."""
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="dev_failed", issue_number=401
+    ))
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    items = [it for it in data if it["number"] == 401]
+    assert len(items) == 1
+    assert items[0]["stage"] == "blocked"
+    assert items[0]["reason"] == "stuck_label"
+
+
+def test_action_queue_qa_fail_repeated(isolated_client):
+    """qa_fail with rework_count >= 3 → reason='qa_fail_repeated'."""
+    server._insert_event(server.ReportPayload(
+        project="loop", role="qa", event_type="qa_fail", issue_number=402,
+        rework_count=3,
+    ))
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    items = [it for it in data if it["number"] == 402]
+    assert len(items) == 1
+    assert items[0]["stage"] == "qa-fail"
+    assert items[0]["reason"] == "qa_fail_repeated"
+
+
+def test_action_queue_dev_done_not_returned(isolated_client):
+    """dev_done → no action needed, ticket NOT returned."""
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="dev_done", issue_number=403
+    ))
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    assert all(it["number"] != 403 for it in data)
+
+
+def test_action_queue_loop_label_transition_active_dev(isolated_client, monkeypatch):
+    """label_transition with loop:active:dev in after_labels → reason='timeout' if old enough."""
+    monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "100")
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="label_transition", issue_number=404,
+        payload={
+            "target_kind": "issue", "number": 404,
+            "before_labels": [], "after_labels": ["loop:active:dev"],
+            "op": "add", "source": "scanner",
+        },
+    ))
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        "UPDATE events SET created_at = datetime('now', '-200 seconds') WHERE issue_number = 404"
+    )
+    conn.commit()
+    conn.close()
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    items = [it for it in data if it["number"] == 404]
+    assert len(items) == 1
+    assert items[0]["stage"] == "loop:active:dev"
+    assert items[0]["reason"] == "timeout"
 
 
 # ── Failure-context endpoint ──────────────────────────────────────────────────


### PR DESCRIPTION
Closes #221

## Changes

**`server/routes/action_queue.py`**
- Added `_infer_stage(role, event_type, payload) -> str | None` that maps real `event_type` column values (e.g. `dev_start`, `qa_fail`, `dev_failed`) to canonical stage labels. This fixes the core bug: the old code compared `event_type` directly against label-style stage names, which never matched.
- Updated `STUCK_STAGES` → adds `loop:result:blocked`; removed deprecated names.
- Updated `TIMEOUT_STAGES` → canonical names (`in-dev`, `in-review`, `in-qa`, `needs-dev`, `needs-review`, `needs-qa`) plus `loop:*` aliases for forward-compat with loop#344; removed `in-progress`, `in-rework`, `ready-for-qa`.
- Replaced `QA_FAIL_STAGE` string with `QA_FAIL_STAGES` set covering `qa-fail` and `loop:result:qa-fail`.
- Extended `STAGE_THRESHOLD_ENV` / `STAGE_DEFAULTS` to cover all `TIMEOUT_STAGES` members with explicit entries.
- Added `e.payload` to the SELECT so `label_transition` `after_labels` can be parsed for stage inference.
- `_action_queue_reason` updated to use `stage in QA_FAIL_STAGES`.
- `action_queue_failure` handler is unchanged.

**`tests/test_action_queue.py`**
- Updated existing tests that used label-style `event_type` values (`blocked`, `in-progress`, `needs-qa`) to use real event types that correctly flow through `_infer_stage`.
- Added AC fixtures: `dev_start` timeout → `in-dev`/`timeout`; `dev_failed` → `blocked`/`stuck_label`; `qa_fail` with `rework_count≥3` → `qa-fail`/`qa_fail_repeated`; `dev_done` → not returned; `label_transition` with `loop:active:dev` in `after_labels` → `timeout`.

## Test Plan
- `pytest tests/test_action_queue.py` — 20 tests pass
- `pytest tests/ --ignore=tests/visual -x` — all pass (pre-existing `test_graph` failure unrelated to this PR)
- `ruff check .` — clean
- `cd web && npm run typecheck && npm run build` — clean