### PR TITLE
[LM-221] Fix action_queue: _infer_stage helper + updated stage vocabulary

### DIFF
--- a/server/routes/action_queue.py
+++ b/server/routes/action_queue.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sqlite3
 from datetime import datetime, timezone
@@ -12,28 +13,105 @@ from server.helpers.timeline import parse_ts
 
 router = APIRouter()
 
-STUCK_STAGES = {"blocked", "needs-clarification"}
-TIMEOUT_STAGES = {"in-progress", "in-review", "in-rework", "needs-qa", "needs-review", "ready-for-qa"}
-QA_FAIL_STAGE = "qa-fail"
+STUCK_STAGES = {"blocked", "needs-clarification", "loop:result:blocked"}
+TIMEOUT_STAGES = {
+    "in-dev", "in-review", "in-qa",
+    "loop:active:dev", "loop:active:review", "loop:active:qa",
+    "needs-dev", "needs-review", "needs-qa",
+    "loop:action:review", "loop:action:qa", "loop:action:dev",
+}
+QA_FAIL_STAGES = {"qa-fail", "loop:result:qa-fail"}
 QA_FAIL_RETRY_THRESHOLD = 3
 
 STAGE_THRESHOLD_ENV = {
-    "in-progress":  "HANDLER_TIMEOUT_DEV",
-    "in-rework":    "HANDLER_TIMEOUT_DEV",
-    "in-review":    "HANDLER_TIMEOUT_REVIEW",
-    "needs-review": "HANDLER_TIMEOUT_REVIEW",
-    "needs-qa":     "HANDLER_TIMEOUT_QA",
-    "ready-for-qa": "HANDLER_TIMEOUT_QA",
+    "in-dev":             "HANDLER_TIMEOUT_DEV",
+    "needs-dev":          "HANDLER_TIMEOUT_DEV",
+    "loop:active:dev":    "HANDLER_TIMEOUT_DEV",
+    "loop:action:dev":    "HANDLER_TIMEOUT_DEV",
+    "in-review":          "HANDLER_TIMEOUT_REVIEW",
+    "needs-review":       "HANDLER_TIMEOUT_REVIEW",
+    "loop:active:review": "HANDLER_TIMEOUT_REVIEW",
+    "loop:action:review": "HANDLER_TIMEOUT_REVIEW",
+    "in-qa":              "HANDLER_TIMEOUT_QA",
+    "needs-qa":           "HANDLER_TIMEOUT_QA",
+    "loop:active:qa":     "HANDLER_TIMEOUT_QA",
+    "loop:action:qa":     "HANDLER_TIMEOUT_QA",
 }
 
 STAGE_DEFAULTS = {
-    "in-progress":  7200,
-    "in-rework":    7200,
-    "in-review":    1800,
-    "needs-review": 1800,
-    "needs-qa":     3600,
-    "ready-for-qa": 3600,
+    "in-dev":             7200,
+    "needs-dev":          7200,
+    "loop:active:dev":    7200,
+    "loop:action:dev":    7200,
+    "in-review":          1800,
+    "needs-review":       1800,
+    "loop:active:review": 1800,
+    "loop:action:review": 1800,
+    "in-qa":              3600,
+    "needs-qa":           3600,
+    "loop:active:qa":     3600,
+    "loop:action:qa":     3600,
 }
+
+
+def _parse_label_transition(detail: Optional[str], payload: Optional[str]) -> Optional[str]:
+    """Extract the resulting stage label from a label_transition event's payload/detail."""
+    all_known = STUCK_STAGES | TIMEOUT_STAGES | QA_FAIL_STAGES
+    for raw in (payload, detail):
+        if not raw:
+            continue
+        try:
+            data = json.loads(raw)
+            # canonical event-audit schema (#106): after_labels is the authoritative field
+            after = data.get("after_labels")
+            if isinstance(after, list):
+                for label in after:
+                    if label in all_known:
+                        return label
+            # fallback: alternate payload formats ("to" / "new_label")
+            label = data.get("to") or data.get("new_label")
+            if label and label in all_known:
+                return str(label)
+        except (json.JSONDecodeError, AttributeError):
+            pass
+    return None
+
+
+def _infer_stage(
+    role: str,
+    event_type: str,
+    *,
+    detail: Optional[str] = None,
+    payload: Optional[str] = None,
+) -> Optional[str]:
+    """Map the latest event per ticket to a canonical stage label.
+
+    Temporary stop-gap; superseded once the `current_labels` table lands (see Option 1 in #221).
+    Returns None for events that imply no action is needed.
+    """
+    et = (event_type or "").lower()
+
+    if et in ("dev_start", "rework_start"):
+        return "in-dev"
+    if et == "review_start":
+        return "in-review"
+    if et == "qa_start":
+        return "in-qa"
+    if et == "qa_fail":
+        return "qa-fail"
+    if et == "po_done":
+        return "needs-dev"
+    if et in ("dev_done", "rework_done"):
+        return "needs-review"
+    if et == "review_done":
+        return "needs-qa"
+    if et in ("qa_pass", "merge_done"):
+        return None
+    if et in ("po_failed", "dev_failed", "review_failed", "merge_failed", "merge_conflict", "rework_failed"):
+        return "blocked"
+    if et == "label_transition":
+        return _parse_label_transition(detail, payload)
+    return None
 
 
 def _handler_timeout_seconds() -> int:
@@ -61,7 +139,7 @@ def _action_queue_reason(
         return "stuck_label"
     if stage in TIMEOUT_STAGES and age_seconds > threshold:
         return "timeout"
-    if stage == QA_FAIL_STAGE and retry_count >= QA_FAIL_RETRY_THRESHOLD:
+    if stage in QA_FAIL_STAGES and retry_count >= QA_FAIL_RETRY_THRESHOLD:
         return "qa_fail_repeated"
     return None
 
@@ -75,7 +153,7 @@ def action_queue(conn: sqlite3.Connection = Depends(db_dep)):
     rows = conn.execute(
         """
         SELECT e.project, e.role, e.event_type, e.issue_number, e.pr_number,
-               e.detail, e.loop_id, e.created_at,
+               e.detail, e.payload, e.loop_id, e.created_at,
                COALESCE(h.rework_count, 0) AS rework_count,
                COALESCE(r.title, '') AS title
         FROM events e
@@ -105,7 +183,9 @@ def action_queue(conn: sqlite3.Connection = Depends(db_dep)):
     now = datetime.now(timezone.utc)
     result = []
     for r in rows:
-        stage = (r["event_type"] or "").lower()
+        stage = _infer_stage(r["role"], r["event_type"], detail=r["detail"], payload=r["payload"])
+        if stage is None:
+            continue
         created = parse_ts(r["created_at"])
         age_seconds = int((now - created).total_seconds()) if created else 0
         threshold = _threshold_for_stage(stage)

--- a/tests/test_action_queue.py
+++ b/tests/test_action_queue.py
@@ -14,8 +14,9 @@ def test_action_queue_empty(isolated_client):
 
 
 def test_action_queue_blocked_label(isolated_client):
+    # dev_failed infers stage='blocked' → stuck_label
     server._insert_event(server.ReportPayload(
-        project="boba-event", role="dev", event_type="blocked", issue_number=42,
+        project="boba-event", role="dev", event_type="dev_failed", issue_number=42,
         detail="needs human"
     ))
     resp = isolated_client.get("/api/action_queue")
@@ -31,8 +32,17 @@ def test_action_queue_blocked_label(isolated_client):
 
 
 def test_action_queue_needs_clarification(isolated_client):
+    # label_transition with after_labels=["needs-clarification"] infers needs-clarification → stuck_label
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="needs-clarification", issue_number=7
+        project="loop", role="dev", event_type="label_transition", issue_number=7,
+        payload={
+            "target_kind": "issue",
+            "number": 7,
+            "before_labels": ["in-dev"],
+            "after_labels": ["needs-clarification"],
+            "op": "swap",
+            "source": "reconciler",
+        }
     ))
     resp = isolated_client.get("/api/action_queue")
     data = resp.json()
@@ -41,8 +51,9 @@ def test_action_queue_needs_clarification(isolated_client):
 
 def test_action_queue_timeout_threshold(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "200")
+    # dev_start infers stage='in-dev'
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="in-progress", issue_number=11
+        project="loop", role="dev", event_type="dev_start", issue_number=11
     ))
     # backdate created_at to 300s ago — exceeds 200s threshold
     conn = sqlite3.connect(server.db.DB_PATH)
@@ -55,14 +66,15 @@ def test_action_queue_timeout_threshold(isolated_client, monkeypatch):
     data = resp.json()
     timeout_items = [it for it in data if it["reason"] == "timeout" and it["number"] == 11]
     assert len(timeout_items) == 1
-    assert timeout_items[0]["stage"] == "in-progress"
+    assert timeout_items[0]["stage"] == "in-dev"
     assert timeout_items[0]["age_seconds"] >= 200
 
 
 def test_action_queue_in_progress_below_threshold_excluded(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "3600")
+    # dev_start infers stage='in-dev'; recent event is under threshold
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="in-progress", issue_number=13
+        project="loop", role="dev", event_type="dev_start", issue_number=13
     ))
     resp = isolated_client.get("/api/action_queue")
     data = resp.json()
@@ -71,11 +83,12 @@ def test_action_queue_in_progress_below_threshold_excluded(isolated_client, monk
 
 def test_action_queue_sorted_by_age_desc(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "100")
+    # dev_failed infers 'blocked' → always stuck_label regardless of age
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="blocked", issue_number=200
+        project="loop", role="dev", event_type="dev_failed", issue_number=200
     ))
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="blocked", issue_number=201
+        project="loop", role="dev", event_type="dev_failed", issue_number=201
     ))
     conn = sqlite3.connect(server.db.DB_PATH)
     conn.execute(
@@ -91,8 +104,9 @@ def test_action_queue_sorted_by_age_desc(isolated_client, monkeypatch):
 
 def test_action_queue_per_stage_threshold_dev_override(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "500")
+    # dev_start infers 'in-dev'
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="in-progress", issue_number=300
+        project="loop", role="dev", event_type="dev_start", issue_number=300
     ))
     conn = sqlite3.connect(server.db.DB_PATH)
     conn.execute(
@@ -109,8 +123,9 @@ def test_action_queue_per_stage_threshold_dev_override(isolated_client, monkeypa
 
 def test_action_queue_needs_qa_past_threshold(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_QA", "60")
+    # review_done infers 'needs-qa'
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="needs-qa", issue_number=301
+        project="loop", role="dev", event_type="review_done", issue_number=301
     ))
     conn = sqlite3.connect(server.db.DB_PATH)
     conn.execute(
@@ -128,8 +143,9 @@ def test_action_queue_needs_qa_past_threshold(isolated_client, monkeypatch):
 
 def test_action_queue_needs_qa_under_threshold_excluded(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_QA", "3600")
+    # review_done infers 'needs-qa'; recent event is under threshold
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="needs-qa", issue_number=302
+        project="loop", role="dev", event_type="review_done", issue_number=302
     ))
     resp = isolated_client.get("/api/action_queue")
     data = resp.json()
@@ -138,11 +154,12 @@ def test_action_queue_needs_qa_under_threshold_excluded(isolated_client, monkeyp
 
 def test_action_queue_threshold_seconds_field(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_QA", "60")
+    # review_done infers 'needs-qa'; dev_failed infers 'blocked'
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="needs-qa", issue_number=303
+        project="loop", role="dev", event_type="review_done", issue_number=303
     ))
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="blocked", issue_number=304
+        project="loop", role="dev", event_type="dev_failed", issue_number=304
     ))
     conn = sqlite3.connect(server.db.DB_PATH)
     conn.execute(
@@ -160,6 +177,101 @@ def test_action_queue_threshold_seconds_field(isolated_client, monkeypatch):
     assert stuck_item is not None
     assert stuck_item["reason"] == "stuck_label"
     assert stuck_item["threshold_seconds"] is None
+
+
+# ── AC tests (issue #221) ─────────────────────────────────────────────────────
+
+def test_ac_dev_start_timeout(isolated_client, monkeypatch):
+    """dev_start older than dev threshold → stage='in-dev', reason='timeout'."""
+    monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "200")
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="dev_start", issue_number=500
+    ))
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        "UPDATE events SET created_at = datetime('now', '-300 seconds') WHERE issue_number = 500"
+    )
+    conn.commit()
+    conn.close()
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    items = [it for it in data if it["number"] == 500]
+    assert len(items) == 1
+    assert items[0]["stage"] == "in-dev"
+    assert items[0]["reason"] == "timeout"
+    assert items[0]["age_seconds"] >= 200
+
+
+def test_ac_dev_failed_blocked(isolated_client):
+    """dev_failed maps to stage='blocked' → reason='stuck_label'."""
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="dev_failed", issue_number=501
+    ))
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    items = [it for it in data if it["number"] == 501]
+    assert len(items) == 1
+    assert items[0]["stage"] == "blocked"
+    assert items[0]["reason"] == "stuck_label"
+
+
+def test_ac_qa_fail_repeated(isolated_client):
+    """qa_fail with rework_count >= 3 → stage='qa-fail', reason='qa_fail_repeated'."""
+    # Insert initial event to create the pipeline_run, then add rework counts
+    server._insert_event(server.ReportPayload(
+        project="loop", role="qa", event_type="dev_start", issue_number=502,
+        rework_count=0,
+    ))
+    # Insert the qa_fail as the latest event
+    server._insert_event(server.ReportPayload(
+        project="loop", role="qa", event_type="qa_fail", issue_number=502,
+        rework_count=3,
+    ))
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    items = [it for it in data if it["number"] == 502]
+    assert len(items) == 1
+    assert items[0]["stage"] == "qa-fail"
+    assert items[0]["reason"] == "qa_fail_repeated"
+
+
+def test_ac_dev_done_not_returned(isolated_client):
+    """dev_done (work finished, nothing pending) → NOT returned in action queue."""
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="dev_done", issue_number=503
+    ))
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    assert all(it["number"] != 503 for it in data)
+
+
+def test_ac_label_transition_loop_active_dev_timeout(isolated_client, monkeypatch):
+    """label_transition with after_labels=['loop:active:dev'] → stage='loop:active:dev', reason='timeout'."""
+    monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "200")
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="label_transition", issue_number=504,
+        payload={
+            "target_kind": "issue",
+            "number": 504,
+            "before_labels": ["needs-dev"],
+            "after_labels": ["loop:active:dev"],
+            "op": "swap",
+            "source": "reconciler",
+        }
+    ))
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        "UPDATE events SET created_at = datetime('now', '-300 seconds') WHERE issue_number = 504"
+    )
+    conn.commit()
+    conn.close()
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    items = [it for it in data if it["number"] == 504]
+    assert len(items) == 1
+    assert items[0]["stage"] == "loop:active:dev"
+    assert items[0]["reason"] == "timeout"
+    assert items[0]["age_seconds"] >= 200
 
 
 # ── Failure-context endpoint ──────────────────────────────────────────────────


### PR DESCRIPTION
Closes #221

## Changes

### Bug fixes
- **Bug 1 (wrong column)**: Replaced `stage = (r["event_type"] or "").lower()` with `_infer_stage(role, event_type)` helper that maps actual event_type values (e.g. `dev_start`, `qa_fail`, `dev_failed`) to canonical stage labels (e.g. `in-dev`, `qa-fail`, `blocked`). The two vocabularies no longer overlap, so the match was always failing.
- **Bug 2 (deprecated vocabulary)**: Replaced `in-progress`, `in-rework`, `ready-for-qa` with canonical names (`in-dev`, `in-review`, `in-qa`, `needs-dev`, `needs-review`, `needs-qa`) plus forward-compatible `loop:*` aliases.

### New helper: `_infer_stage(role, event_type, *, detail, payload) -> str | None`
Documented as a temporary stop-gap until the `current_labels` table lands (Option 1 in #221). Maps each event_type to its implied stage per the inference table in the issue. Returns `None` for events that mean "work finished / no action needed" (e.g. `dev_done`, `qa_pass`, `merge_done`).

### label_transition support
Added `_parse_label_transition()` that reads `after_labels` from the event-audit payload schema (#106), enabling `loop:*` namespace labels (e.g. `loop:active:dev`) to surface immediately when loop#344 lands.

### Constants updated
- `STUCK_STAGES`: added `loop:result:blocked`
- `TIMEOUT_STAGES`: canonical names + loop:* aliases, deprecated names removed
- `QA_FAIL_STAGES`: set replacing single-string `QA_FAIL_STAGE`, includes `loop:result:qa-fail`
- `STAGE_THRESHOLD_ENV` + `STAGE_DEFAULTS`: full coverage for all canonical + alias names
- `_action_queue_reason`: uses `stage in QA_FAIL_STAGES` (set membership)

### Query updated
Added `e.payload` to the SELECT so `label_transition` events can be parsed.

## Test Plan

All new and updated tests in `tests/test_action_queue.py`:

- [x] `test_ac_dev_start_timeout` — `dev_start` older than threshold → `stage='in-dev'`, `reason='timeout'`
- [x] `test_ac_dev_failed_blocked` — `dev_failed` → `stage='blocked'`, `reason='stuck_label'`
- [x] `test_ac_qa_fail_repeated` — `qa_fail` with `rework_count >= 3` → `stage='qa-fail'`, `reason='qa_fail_repeated'`
- [x] `test_ac_dev_done_not_returned` — `dev_done` → NOT in queue
- [x] `test_ac_label_transition_loop_active_dev_timeout` — `label_transition` with `after_labels=['loop:active:dev']` older than threshold → `reason='timeout'`
- [x] All 10 existing tests updated to use real event_type values and continue to pass
- [x] All 5 failure-detail endpoint tests unchanged and passing
- [x] `ruff check .` clean