### PR TITLE
feat: move project registry to config file (reusability blocker #1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ static/dist/
 
 # Visual regression diff artifacts (never committed)
 tests/visual/_artifacts/
+
+# Operator-local project registry (see config/projects.yaml.example)
+config/projects.yaml

--- a/README.md
+++ b/README.md
@@ -47,12 +47,37 @@
 git clone https://github.com/svv2014/loop-monitor.git
 cd loop-monitor
 pip install -r requirements.txt
+cp config/projects.yaml.example config/projects.yaml   # then edit
 ./run.sh
 ```
 
 `run.sh` is the server entrypoint — it starts the uvicorn process on port 18792.
 
 Open http://127.0.0.1:18792.
+
+## Configure your projects
+
+Loop-monitor needs a registry mapping project slugs to GitHub repositories.
+The slug is whatever your pipeline sends in the `project` field of its
+bounty events; the repo is `owner/repo` form for building issue/PR links.
+
+Edit `config/projects.yaml` (gitignored, operator-local):
+
+```yaml
+projects:
+  my-app:      org/my-app
+  docs-site:   org/docs-site
+  ml-pipeline: org/ml-pipeline
+```
+
+Lookup order:
+
+1. `$LOOP_MONITOR_PROJECTS_CONFIG` — absolute path override (useful for tests / CI)
+2. `./config/projects.yaml` — repo-relative default
+3. Empty registry — loop-monitor still runs, but project-specific UI links
+   (issue URLs, repo navigation) will be absent
+
+The registry is loaded once at startup; restart the server after editing.
 
 ## Wire it to Loop
 

--- a/config/projects.yaml.example
+++ b/config/projects.yaml.example
@@ -1,0 +1,20 @@
+# loop-monitor — project registry
+#
+# Each entry maps a project slug (the value pipelines send in the `project`
+# field of their bounty events) to a GitHub repository in `owner/repo` form.
+#
+# How loop-monitor finds this file (in order):
+#   1. $LOOP_MONITOR_PROJECTS_CONFIG (absolute path to a yaml file)
+#   2. ./config/projects.yaml (relative to repo root)
+#   3. Fall back to an empty registry (loop-monitor still runs; some links
+#      will be absent in the UI)
+#
+# Copy this file to `config/projects.yaml` and edit. `config/projects.yaml`
+# is gitignored so your operator-specific list does not enter version control.
+#
+# Format: a single top-level `projects` map.
+
+projects:
+  # example-app:        org-name/example-app
+  # docs-site:          org-name/docs-site
+  # ml-pipeline:        org-name/ml-pipeline

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi>=0.111.0
 uvicorn>=0.29.0
 aiofiles>=23.0
+pyyaml>=6.0

--- a/server/constants.py
+++ b/server/constants.py
@@ -1,19 +1,88 @@
+"""Static config + project registry.
+
+`PROJECTS` is a dict mapping slug → 'owner/repo' for every project this
+loop-monitor instance tracks. It is loaded at import time from (in order):
+
+  1. $LOOP_MONITOR_PROJECTS_CONFIG (path to a yaml file)
+  2. ./config/projects.yaml (relative to repo root)
+
+If neither file exists, the registry is empty — loop-monitor still runs, but
+project-specific links (issue URLs, repo navigation) will be absent. See
+`config/projects.yaml.example` for the file format.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 SUPPORTED_API_MAJOR = "1"
 _version_file = Path(__file__).parent.parent / "VERSION"
 MONITOR_VERSION = _version_file.read_text().strip() if _version_file.exists() else "unknown"
 
-PROJECTS = {
-    'ppl':               'svv2014/ppl-study',
-    'boba-event':        'svv2014/boba-event',
-    'loop':              'svv2014/loop',
-    'loop-monitor':      'svv2014/loop-monitor',     # was 'bounty'
-    'vrefm-classifier':  'svv2014/vrefm-classifier',
-    'pa-scanner':        'svv2014/pa-scanner',
-    'ntc':               'svv2014/NanoTraderCopilot',
-    'boba-orchestrator': 'svv2014/boba-orchestrator',
-    'suprun':            'svv2014/suprun.ca',
-}
-
 HANDLER_TIMEOUT = 30
+
+_REPO_ROOT = Path(__file__).parent.parent
+
+
+def _candidate_config_paths() -> list[Path]:
+    env_override = os.environ.get("LOOP_MONITOR_PROJECTS_CONFIG")
+    if env_override:
+        return [Path(env_override)]
+    return [_REPO_ROOT / "config" / "projects.yaml"]
+
+
+def _load_projects() -> dict[str, str]:
+    """Load the project registry from the first yaml file that exists.
+
+    Each entry is validated as `owner/repo` shape. Malformed entries are
+    skipped with a warning so a single typo does not take the whole server
+    down.
+    """
+    try:
+        import yaml
+    except ImportError:
+        logger.warning(
+            "pyyaml not installed — project registry will be empty. "
+            "Install with: pip install pyyaml"
+        )
+        return {}
+
+    for path in _candidate_config_paths():
+        if not path.is_file():
+            continue
+        try:
+            data = yaml.safe_load(path.read_text()) or {}
+        except yaml.YAMLError as exc:
+            logger.error("failed to parse %s: %s", path, exc)
+            return {}
+
+        raw = data.get("projects") if isinstance(data, dict) else None
+        if not isinstance(raw, dict):
+            logger.warning("%s missing top-level `projects:` map", path)
+            return {}
+
+        result: dict[str, str] = {}
+        for slug, repo in raw.items():
+            if not isinstance(slug, str) or not isinstance(repo, str):
+                logger.warning("skipping non-string entry: %r → %r", slug, repo)
+                continue
+            if "/" not in repo or repo.count("/") != 1:
+                logger.warning("skipping %r — value %r is not owner/repo", slug, repo)
+                continue
+            result[slug] = repo
+        logger.info("loaded %d projects from %s", len(result), path)
+        return result
+
+    logger.info(
+        "no projects.yaml found at %s — project registry is empty. "
+        "Copy config/projects.yaml.example to config/projects.yaml to populate.",
+        " or ".join(str(p) for p in _candidate_config_paths()),
+    )
+    return {}
+
+
+PROJECTS: dict[str, str] = _load_projects()

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,22 +1,61 @@
+"""Tests for the project registry loader.
+
+Note: these tests exercise the loader through env-var overrides so they do
+not depend on any operator-local `config/projects.yaml` that may or may not
+exist on the host running them.
+"""
+
+from __future__ import annotations
+
+import importlib
 import re
-
-from server.constants import PROJECTS
-
-
-def test_new_slugs_present():
-    for slug in ('loop-monitor', 'boba-orchestrator', 'suprun'):
-        assert slug in PROJECTS, f"missing slug: {slug}"
+import sys
+from pathlib import Path
+from textwrap import dedent
 
 
-def test_bounty_key_absent():
-    assert 'bounty' not in PROJECTS
+def _reload_constants_with_config(monkeypatch, config_path: Path | None) -> dict[str, str]:
+    if config_path is None:
+        monkeypatch.delenv("LOOP_MONITOR_PROJECTS_CONFIG", raising=False)
+    else:
+        monkeypatch.setenv("LOOP_MONITOR_PROJECTS_CONFIG", str(config_path))
+    sys.modules.pop("server.constants", None)
+    mod = importlib.import_module("server.constants")
+    return mod.PROJECTS
 
 
-def test_all_values_owner_repo_shape():
-    pattern = re.compile(r'^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$')
+def test_loads_well_formed_yaml(tmp_path, monkeypatch):
+    cfg = tmp_path / "projects.yaml"
+    cfg.write_text(dedent("""\
+        projects:
+          example:   org/example
+          docs-site: org/docs-site
+    """))
+    projects = _reload_constants_with_config(monkeypatch, cfg)
+    assert projects == {"example": "org/example", "docs-site": "org/docs-site"}
+
+
+def test_skips_malformed_entries(tmp_path, monkeypatch):
+    cfg = tmp_path / "projects.yaml"
+    cfg.write_text(dedent("""\
+        projects:
+          good:    org/good
+          no-slash: not-a-repo
+          two/slashes: org/sub/repo
+    """))
+    projects = _reload_constants_with_config(monkeypatch, cfg)
+    assert projects == {"good": "org/good"}
+
+
+def test_missing_file_yields_empty(tmp_path, monkeypatch):
+    nonexistent = tmp_path / "absent.yaml"
+    projects = _reload_constants_with_config(monkeypatch, nonexistent)
+    assert projects == {}
+
+
+def test_owner_repo_shape():
+    """If projects are loaded from the host's actual config, validate shape."""
+    from server.constants import PROJECTS
+    pattern = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
     for slug, repo in PROJECTS.items():
         assert pattern.match(repo), f"{slug!r} value {repo!r} is not owner/repo"
-
-
-def test_loop_monitor_maps_correctly():
-    assert PROJECTS['loop-monitor'] == 'svv2014/loop-monitor'


### PR DESCRIPTION
## Summary

First of four planned changes to make loop-monitor reusable by anyone, not just the original operator (see #226 if filed — the 'evaluate reusability' track).

The PROJECTS dict was hardcoded in `server/constants.py` with `svv2014`-specific paths. Anyone wanting to point loop-monitor at their own pipelines had to fork or patch this file. After this change, the registry is a yaml file the operator owns.

## What changed

- `server/constants.py` — `PROJECTS` is now loaded by `_load_projects()` from yaml. Same `dict[slug, 'owner/repo']` shape, so all callers (action_queue.py, graph.py, runs.py, stats.py) keep working without modification.
- `config/projects.yaml.example` — checked-in template documenting the format + lookup chain.
- `config/projects.yaml` — gitignored, operator-local config. The current operator's existing project list is preserved by creating this file locally (not committed).
- `.gitignore` — excludes `config/projects.yaml`.
- `requirements.txt` — adds `pyyaml>=6.0` (already a transitive dep via uvicorn config in some setups, but pin explicitly).
- `tests/test_constants.py` — rewritten to exercise the loader via env-var overrides. Covers: well-formed yaml, malformed-entry rejection, missing-file → empty registry, owner/repo shape validation against whatever the host has loaded.
- `README.md` — new 'Configure your projects' section; install path updated to mention the example→local copy step.

## Lookup chain (documented in `server/constants.py` docstring and README)

1. `$LOOP_MONITOR_PROJECTS_CONFIG` (absolute path override — for CI / tests)
2. `./config/projects.yaml` (repo-relative default)
3. Empty registry — loop-monitor still runs, but project-specific UI links are absent

Malformed entries (non-string, missing slash, multiple slashes) are skipped with a warning rather than killing startup. Single typo can't take the server down.

## Backwards compat

For the operator already running loop-monitor against `svv2014` projects: the existing nine entries are written to `config/projects.yaml` (gitignored) as part of this change, so `from server.constants import PROJECTS` returns the exact same dict it did before the refactor. Verified:

```python
{
  "ppl": "svv2014/ppl-study",
  "boba-event": "svv2014/boba-event",
  "loop": "svv2014/loop",
  "loop-monitor": "svv2014/loop-monitor",
  "vrefm-classifier": "svv2014/vrefm-classifier",
  "pa-scanner": "svv2014/pa-scanner",
  "ntc": "svv2014/NanoTraderCopilot",
  "boba-orchestrator": "svv2014/boba-orchestrator",
  "suprun": "svv2014/suprun.ca"
}
```

## Test plan

- [x] `pytest tests/test_constants.py` — 4/4 pass (covers loader, malformed rejection, env override, missing-file fallback, shape validation)
- [x] `pytest tests/ --ignore=tests/visual` — 158/159 pass; the one failure (`test_events_graph_with_data`) is a pre-existing timestamp-related failure unrelated to this PR, confirmed by running it against `main` before this change.
- [x] `ruff check server/constants.py tests/test_constants.py` — clean
- [x] Manual smoke: server starts, `from server.constants import PROJECTS` returns the expected dict.

## Follow-up tickets (out of scope for this PR)

This is blocker 1 of 4. Subsequent PRs will address:
- Frontend duplication: `web/src/lib/fixtures.ts` repeats the project list (DRY violation; should derive from the same yaml at build time or via an API call).
- Hardcoded `svv2014` URL fragments in `web/src/screens/Cost.tsx` and `web/src/screens/Logs.tsx`.
- Loop-specific event vocabulary (`po`, `dev`, `qa`, `reviewer`, `merge`, `judge`) baked into UI components — should be config-driven so non-Loop pipelines work too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)