### PR TITLE
feat: configurable role/event vocabulary via config/roles.yaml (reusability blocker #3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ tests/visual/_artifacts/
 
 # Operator-local project registry (see config/projects.yaml.example)
 config/projects.yaml
+
+# Operator-local role vocabulary (see config/roles.yaml.example)
+config/roles.yaml

--- a/README.md
+++ b/README.md
@@ -79,6 +79,41 @@ Lookup order:
 
 The registry is loaded once at startup; restart the server after editing.
 
+## Customize the role vocabulary
+
+By default loop-monitor displays the six Loop pipeline stages (`po`, `dev`,
+`qa`, `reviewer`, `merge`, `judge`) with their colors. If your pipeline
+emits a different vocabulary (e.g. `lint`, `build`, `test`, `deploy`),
+override it by copying the example:
+
+```bash
+cp config/roles.yaml.example config/roles.yaml
+# then edit
+```
+
+```yaml
+roles:
+  - id: lint
+    label: Lint
+    color: cyan
+  - id: build
+    label: Build
+    color: blue
+  - id: test
+    label: Test
+    color: amber
+  - id: deploy
+    label: Deploy
+    color: green
+```
+
+Allowed colors: `violet`, `blue`, `cyan`, `amber`, `pink`, `green`,
+`indigo`, `red`, `gray`. Order matters — it determines display order in
+charts and filters. The frontend reads this list from `/api/config/roles`
+at startup; restart the server to pick up changes.
+
+If no config file exists, the built-in Loop defaults apply.
+
 ## Wire it to Loop
 
 In your Loop core's `loop.env`:

--- a/config/roles.yaml.example
+++ b/config/roles.yaml.example
@@ -1,0 +1,51 @@
+# loop-monitor — role / event vocabulary
+#
+# Defines the roles your pipeline uses (e.g. po, dev, qa) and how they appear
+# in the dashboard. Override these if your pipeline emits a different
+# vocabulary — e.g. build/test/deploy instead of po/dev/qa.
+#
+# How loop-monitor finds this file (in order):
+#   1. $LOOP_MONITOR_ROLES_CONFIG (absolute path)
+#   2. ./config/roles.yaml (relative to repo root)
+#   3. Fall back to the built-in Loop defaults (po, dev, qa, reviewer, merge, judge)
+#
+# Copy this file to `config/roles.yaml` and edit. The file is gitignored
+# so your operator-specific vocabulary stays out of version control.
+
+roles:
+  # Each role is a stage your pipeline reports through bounty events.
+  # Order matters — it determines display order in charts and filters.
+  - id: po              # short identifier — must match the `role` field your pipeline emits
+    label: PO           # display name in the UI
+    color: violet       # one of: violet, blue, cyan, amber, pink, green, indigo, red, gray
+  - id: dev
+    label: Dev
+    color: blue
+  - id: qa
+    label: QA
+    color: amber
+  - id: reviewer
+    label: Reviewer
+    color: pink
+  - id: merge
+    label: Merge
+    color: green
+  - id: judge
+    label: Judge
+    color: indigo
+
+# Example: a deploy-pipeline operator might use:
+#
+# roles:
+#   - id: lint
+#     label: Lint
+#     color: cyan
+#   - id: build
+#     label: Build
+#     color: blue
+#   - id: test
+#     label: Test
+#     color: amber
+#   - id: deploy
+#     label: Deploy
+#     color: green

--- a/server/app.py
+++ b/server/app.py
@@ -20,6 +20,7 @@ from server.routes import (  # noqa: E402
     action_queue,
     board,
     claude_usage,
+    config,
     feed,
     graph,
     health,
@@ -45,6 +46,7 @@ app.include_router(issues_cost.router)
 app.include_router(logs.router)
 app.include_router(scanner_state.router)
 app.include_router(slos.router)
+app.include_router(config.router)
 
 if os.path.isdir("static/dist"):
     app.mount("/v2", StaticFiles(directory="static/dist", html=True), name="dist")

--- a/server/roles.py
+++ b/server/roles.py
@@ -1,0 +1,105 @@
+"""Role / event vocabulary loader.
+
+The dashboard displays a configurable list of roles (pipeline stages). Loaded
+at import time from yaml; if no config is present, falls back to the built-in
+Loop defaults so existing deployments keep working without action.
+
+See `config/roles.yaml.example` for the file format.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import TypedDict
+
+logger = logging.getLogger(__name__)
+
+_REPO_ROOT = Path(__file__).parent.parent
+
+VALID_COLORS = {"violet", "blue", "cyan", "amber", "pink", "green", "indigo", "red", "gray"}
+
+
+class Role(TypedDict):
+    id: str
+    label: str
+    color: str
+
+
+# Built-in Loop defaults — used when no config file exists.
+DEFAULT_ROLES: list[Role] = [
+    {"id": "po",       "label": "PO",       "color": "violet"},
+    {"id": "dev",      "label": "Dev",      "color": "blue"},
+    {"id": "qa",       "label": "QA",       "color": "amber"},
+    {"id": "reviewer", "label": "Reviewer", "color": "pink"},
+    {"id": "merge",    "label": "Merge",    "color": "green"},
+    {"id": "judge",    "label": "Judge",    "color": "indigo"},
+]
+
+
+def _candidate_config_paths() -> list[Path]:
+    env_override = os.environ.get("LOOP_MONITOR_ROLES_CONFIG")
+    if env_override:
+        return [Path(env_override)]
+    return [_REPO_ROOT / "config" / "roles.yaml"]
+
+
+def _load_roles() -> list[Role]:
+    """Load the role vocabulary from yaml. Returns DEFAULT_ROLES on any
+    failure (missing file, bad parse, malformed entries) so the server
+    always boots with something usable."""
+    try:
+        import yaml
+    except ImportError:
+        logger.warning("pyyaml not installed — using built-in role defaults")
+        return list(DEFAULT_ROLES)
+
+    for path in _candidate_config_paths():
+        if not path.is_file():
+            continue
+        try:
+            data = yaml.safe_load(path.read_text()) or {}
+        except yaml.YAMLError as exc:
+            logger.error("failed to parse %s: %s — using defaults", path, exc)
+            return list(DEFAULT_ROLES)
+
+        raw = data.get("roles") if isinstance(data, dict) else None
+        if not isinstance(raw, list):
+            logger.warning("%s missing top-level `roles:` list — using defaults", path)
+            return list(DEFAULT_ROLES)
+
+        result: list[Role] = []
+        seen_ids: set[str] = set()
+        for entry in raw:
+            if not isinstance(entry, dict):
+                logger.warning("skipping non-mapping role entry: %r", entry)
+                continue
+            rid = entry.get("id")
+            label = entry.get("label") or rid
+            color = entry.get("color", "gray")
+            if not isinstance(rid, str) or not rid:
+                logger.warning("skipping role with missing/invalid id: %r", entry)
+                continue
+            if rid in seen_ids:
+                logger.warning("duplicate role id %r — keeping first occurrence", rid)
+                continue
+            if color not in VALID_COLORS:
+                logger.warning(
+                    "role %r has unknown color %r — falling back to gray", rid, color
+                )
+                color = "gray"
+            seen_ids.add(rid)
+            result.append({"id": rid, "label": str(label), "color": color})
+
+        if not result:
+            logger.warning("%s yielded zero valid roles — using defaults", path)
+            return list(DEFAULT_ROLES)
+
+        logger.info("loaded %d roles from %s", len(result), path)
+        return result
+
+    return list(DEFAULT_ROLES)
+
+
+ROLES: list[Role] = _load_roles()

--- a/server/routes/config.py
+++ b/server/routes/config.py
@@ -1,0 +1,33 @@
+"""Runtime configuration endpoints — projects, roles, etc.
+
+These surfaces let the dashboard render an operator-customized vocabulary
+without rebuilding the frontend. The values are loaded at server import
+time from yaml config; restart the server to pick up changes.
+"""
+
+from fastapi import APIRouter
+
+from server.constants import PROJECTS
+from server.roles import ROLES
+
+router = APIRouter()
+
+
+@router.get("/api/config/roles")
+def get_roles() -> dict:
+    """Return the operator-configured role vocabulary."""
+    return {"roles": ROLES}
+
+
+@router.get("/api/config/projects")
+def get_projects() -> dict:
+    """Return the operator-configured project registry.
+
+    Frontend uses this to derive GitHub links and to render the project
+    switcher — no more hardcoded project lists in the React bundle.
+    """
+    return {
+        "projects": [
+            {"slug": slug, "repo": repo} for slug, repo in sorted(PROJECTS.items())
+        ]
+    }

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,0 +1,107 @@
+"""Tests for the role-vocabulary loader."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+
+def _reload_roles_with_config(monkeypatch, config_path: Path | None) -> list:
+    if config_path is None:
+        monkeypatch.delenv("LOOP_MONITOR_ROLES_CONFIG", raising=False)
+    else:
+        monkeypatch.setenv("LOOP_MONITOR_ROLES_CONFIG", str(config_path))
+    sys.modules.pop("server.roles", None)
+    mod = importlib.import_module("server.roles")
+    return mod.ROLES
+
+
+def test_loads_well_formed_yaml(tmp_path, monkeypatch):
+    cfg = tmp_path / "roles.yaml"
+    cfg.write_text(dedent("""\
+        roles:
+          - id: lint
+            label: Lint
+            color: cyan
+          - id: build
+            label: Build
+            color: blue
+    """))
+    roles = _reload_roles_with_config(monkeypatch, cfg)
+    assert roles == [
+        {"id": "lint",  "label": "Lint",  "color": "cyan"},
+        {"id": "build", "label": "Build", "color": "blue"},
+    ]
+
+
+def test_invalid_color_falls_back_to_gray(tmp_path, monkeypatch):
+    cfg = tmp_path / "roles.yaml"
+    cfg.write_text(dedent("""\
+        roles:
+          - id: test
+            label: Test
+            color: chartreuse
+    """))
+    roles = _reload_roles_with_config(monkeypatch, cfg)
+    assert roles == [{"id": "test", "label": "Test", "color": "gray"}]
+
+
+def test_duplicate_ids_kept_first(tmp_path, monkeypatch):
+    cfg = tmp_path / "roles.yaml"
+    cfg.write_text(dedent("""\
+        roles:
+          - id: dev
+            label: First
+            color: blue
+          - id: dev
+            label: Second
+            color: pink
+    """))
+    roles = _reload_roles_with_config(monkeypatch, cfg)
+    assert len(roles) == 1
+    assert roles[0]["label"] == "First"
+
+
+def test_missing_id_skipped(tmp_path, monkeypatch):
+    cfg = tmp_path / "roles.yaml"
+    cfg.write_text(dedent("""\
+        roles:
+          - label: NoId
+            color: red
+          - id: ok
+            label: OK
+            color: green
+    """))
+    roles = _reload_roles_with_config(monkeypatch, cfg)
+    assert [r["id"] for r in roles] == ["ok"]
+
+
+def test_missing_file_returns_defaults(tmp_path, monkeypatch):
+    nonexistent = tmp_path / "absent.yaml"
+    roles = _reload_roles_with_config(monkeypatch, nonexistent)
+    # Built-in Loop defaults: po, dev, qa, reviewer, merge, judge
+    ids = [r["id"] for r in roles]
+    assert ids == ["po", "dev", "qa", "reviewer", "merge", "judge"]
+
+
+def test_label_defaults_to_id(tmp_path, monkeypatch):
+    cfg = tmp_path / "roles.yaml"
+    cfg.write_text(dedent("""\
+        roles:
+          - id: solo
+            color: violet
+    """))
+    roles = _reload_roles_with_config(monkeypatch, cfg)
+    assert roles == [{"id": "solo", "label": "solo", "color": "violet"}]
+
+
+def test_config_endpoint_shape():
+    """Smoke-test that /api/config/roles returns the right shape."""
+    from server.routes.config import get_roles
+    result = get_roles()
+    assert "roles" in result
+    assert isinstance(result["roles"], list)
+    for r in result["roles"]:
+        assert {"id", "label", "color"} <= r.keys()

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -135,6 +135,34 @@ export async function fetchScannerState(): Promise<ScannerState> {
   return get<ScannerState>('/api/scanner_state');
 }
 
+// Operator-configured role vocabulary. Pipeline-agnostic — the server reads
+// config/roles.yaml (if present) and returns the list here. Falls back to the
+// Loop defaults (po/dev/qa/reviewer/merge/judge) when no config exists.
+export interface RoleConfig {
+  id: string;
+  label: string;
+  color: string;
+}
+
+export const DEFAULT_ROLES: RoleConfig[] = [
+  { id: 'po',       label: 'PO',       color: 'violet' },
+  { id: 'dev',      label: 'Dev',      color: 'blue' },
+  { id: 'qa',       label: 'QA',       color: 'amber' },
+  { id: 'reviewer', label: 'Reviewer', color: 'pink' },
+  { id: 'merge',    label: 'Merge',    color: 'green' },
+  { id: 'judge',    label: 'Judge',    color: 'indigo' },
+];
+
+export async function fetchRoles(): Promise<RoleConfig[]> {
+  if (isFixtureMode()) return DEFAULT_ROLES;
+  try {
+    const data = await get<{ roles: RoleConfig[] }>('/api/config/roles');
+    return data.roles?.length ? data.roles : DEFAULT_ROLES;
+  } catch {
+    return DEFAULT_ROLES;
+  }
+}
+
 export interface IssuesCostParams {
   project?: string;
   since?: string;


### PR DESCRIPTION
## Summary

Blocker 3 of the reusability track. Adds operator-driven role customization so loop-monitor works for any pipeline, not just Loop. With #236 (project config) + #237 (frontend hardcode strip) + this PR, the dashboard is genuinely deployable elsewhere with **zero source patches** for the common case.

## Problem

The role vocabulary (po, dev, qa, reviewer, merge, judge) was baked into multiple frontend files (Activity24h, ActivityFeed, transforms, EventGlyph, tokens.css). Anyone running a different pipeline (lint/build/deploy) saw a dashboard built for someone else's vocabulary.

## What this PR ships

### Backend (foundation, complete)

- config/roles.yaml.example documents format + allowed colors
- server/roles.py loads vocab at import time: env override > ./config/roles.yaml > built-in Loop defaults. Malformed entries skipped with a warning; never empty, never crashes.
- server/routes/config.py exposes /api/config/roles and /api/config/projects so the frontend reads operator config at runtime — no rebuild required.

### Frontend (hook)

- web/src/lib/api.ts exports RoleConfig type, DEFAULT_ROLES constant, and fetchRoles() helper that always returns something sensible. Fixture mode returns defaults too.

### Tests

tests/test_roles.py covers loader behavior + endpoint shape (7 tests, all pass).

### Docs

README has 'Customize the role vocabulary' section with worked CI/CD example.

## What's NOT in this PR (intentional follow-up)

Frontend has 6 files with hardcoded role lists. Migrating them all in one PR = 200+ line diff. Safer split:

1. **This PR** — backend foundation + hook. Existing hardcodes still work (backwards-compatible defaults).
2. **Follow-up** — migrate transforms.ts::KNOWN_ROLES, Activity24h::ROLE_ORDER, ActivityFeed::ROLES to use fetchRoles() via useRoles() hook.
3. **Further follow-up** — dynamic CSS role colors.

## Test plan

- pytest tests/test_roles.py tests/test_constants.py tests/test_issues_cost.py — 18/18 pass
- ruff check server/ — clean
- Manual /api/config/roles + /api/config/projects via TestClient — returns expected payloads
- Web typecheck — only pre-existing errors (URLSearchParams.size in api.ts, WorkerDetail.tsx) confirmed on main

## Reusability scorecard

After #236 + #237 + this PR:
- Project list → yaml ✓
- GitHub URLs → derived ✓
- Role vocabulary → configurable foundation ✓
- README polish — next PR (blocker 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)