### PR TITLE
ci: auto-label external PRs (external-pr + needs-review)

### DIFF
--- a/.github/workflows/auto-label-external.yml
+++ b/.github/workflows/auto-label-external.yml
@@ -1,0 +1,43 @@
+name: Auto-label external PRs
+
+# Auto-labels PRs opened by non-operator accounts so the autonomous pipeline
+# treats them under the operator-review gate (see CONTRIBUTING.md).
+#
+# Labels applied: external-pr + needs-review (NOT needs-triage anymore —
+# the AI reviewer runs first, then the operator decides on the verdict).
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  label:
+    if: github.event.pull_request.user.login != 'svv2014'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: ['external-pr', 'needs-review'],
+            });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: [
+                "Thanks for the contribution.",
+                "",
+                "This PR has been labeled `external-pr` + `needs-review`. The autonomous review pipeline will read the diff and post a verdict comment automatically. After that, the operator (the single maintainer account this project is gated to) reviews the verdict and your diff, and merges manually if everything looks good.",
+                "",
+                "See [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) for the full process.",
+              ].join("\n"),
+            });


### PR DESCRIPTION
## Summary

Adds .github/workflows/auto-label-external.yml. When a non-operator account opens a PR, GitHub Actions auto-applies external-pr + needs-review labels and posts a welcome comment pointing at CONTRIBUTING.md.

## Why needs-review (not needs-triage)

Original plan was external-pr + needs-triage so operator triages first. Updated: external-pr + needs-review so loop's review-handler runs the AI review automatically. Operator only acts after the verdict is in. Less friction; safer because review-handler is text-only (reads diff, posts comment, no code execution).

## Flow

```
External PR opens
  → GitHub Action labels external-pr + needs-review (within ~1 min)
  → Loop's review-handler runs (when scanner is enabled)
  → Posts verdict comment
  → Labels external-review-pass or external-review-fail (loop change in companion PR)
  → Operator notified via LOOP_NOTIFY
  → Operator reads verdict + diff, manually merges or closes
```

## Test plan

After merge, the workflow fires on the next external PR opened on this repo. Until then, can verify the yaml is valid by tab-completing in GitHub Actions UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)