### PR TITLE
ci: skip bot welcome on PR reopen

### DIFF
--- a/.github/workflows/auto-label-external.yml
+++ b/.github/workflows/auto-label-external.yml
@@ -1,10 +1,12 @@
 name: Auto-label external PRs
 
 # Auto-labels PRs opened by non-operator accounts so the autonomous pipeline
-# treats them under the operator-review gate (see CONTRIBUTING.md).
+# treats them under the operator-review gate. The reviewer flow (loop's
+# review-handler) runs automatically; the operator decides on merge.
 #
-# Labels applied: external-pr + needs-review (NOT needs-triage anymore —
-# the AI reviewer runs first, then the operator decides on the verdict).
+# Comment-on-open posts only on the FIRST open. Reopens still re-apply
+# labels (idempotent) but skip the welcome comment so operator-driven
+# reopens don't leave a redundant bot greeting after a human reply.
 
 on:
   pull_request_target:
@@ -29,15 +31,15 @@ jobs:
               issue_number: pr.number,
               labels: ['external-pr', 'needs-review'],
             });
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-              body: [
-                "Thanks for the contribution.",
-                "",
-                "This PR has been labeled `external-pr` + `needs-review`. The autonomous review pipeline will read the diff and post a verdict comment automatically. After that, the operator (the single maintainer account this project is gated to) reviews the verdict and your diff, and merges manually if everything looks good.",
-                "",
-                "See [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) for the full process.",
-              ].join("\n"),
-            });
+            if (context.payload.action === 'opened') {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: [
+                  "Thanks for the contribution.",
+                  "",
+                  "This PR has been labeled `external-pr` + `needs-review`. The autonomous review pipeline will read the diff and post a verdict comment automatically. After that, the operator (the single maintainer account this project is gated to) reviews the verdict and your diff, and merges manually if everything looks good.",
+                ].join("\n"),
+              });
+            }


### PR DESCRIPTION
Reopens skip the welcome comment to avoid leaving a redundant bot greeting after a human reply. Label application remains idempotent on both opened and reopened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)