### PR TITLE
[LM-221] Fix action queue: inference helper + updated stage vocabulary

### DIFF
--- a/server/routes/action_queue.py
+++ b/server/routes/action_queue.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sqlite3
 from datetime import datetime, timezone
@@ -12,28 +13,88 @@ from server.helpers.timeline import parse_ts
 
 router = APIRouter()
 
-STUCK_STAGES = {"blocked", "needs-clarification"}
-TIMEOUT_STAGES = {"in-progress", "in-review", "in-rework", "needs-qa", "needs-review", "ready-for-qa"}
-QA_FAIL_STAGE = "qa-fail"
+STUCK_STAGES = {"blocked", "needs-clarification", "loop:result:blocked"}
+TIMEOUT_STAGES = {
+    "in-dev", "in-review", "in-qa",
+    "loop:active:dev", "loop:active:review", "loop:active:qa",
+    "needs-review", "needs-qa", "needs-dev",
+    "loop:action:review", "loop:action:qa", "loop:action:dev",
+}
+QA_FAIL_STAGES = {"qa-fail", "loop:result:qa-fail"}
 QA_FAIL_RETRY_THRESHOLD = 3
 
 STAGE_THRESHOLD_ENV = {
-    "in-progress":  "HANDLER_TIMEOUT_DEV",
-    "in-rework":    "HANDLER_TIMEOUT_DEV",
-    "in-review":    "HANDLER_TIMEOUT_REVIEW",
-    "needs-review": "HANDLER_TIMEOUT_REVIEW",
-    "needs-qa":     "HANDLER_TIMEOUT_QA",
-    "ready-for-qa": "HANDLER_TIMEOUT_QA",
+    "in-dev":             "HANDLER_TIMEOUT_DEV",
+    "needs-dev":          "HANDLER_TIMEOUT_DEV",
+    "loop:active:dev":    "HANDLER_TIMEOUT_DEV",
+    "loop:action:dev":    "HANDLER_TIMEOUT_DEV",
+    "in-review":          "HANDLER_TIMEOUT_REVIEW",
+    "needs-review":       "HANDLER_TIMEOUT_REVIEW",
+    "loop:active:review": "HANDLER_TIMEOUT_REVIEW",
+    "loop:action:review": "HANDLER_TIMEOUT_REVIEW",
+    "in-qa":              "HANDLER_TIMEOUT_QA",
+    "needs-qa":           "HANDLER_TIMEOUT_QA",
+    "loop:active:qa":     "HANDLER_TIMEOUT_QA",
+    "loop:action:qa":     "HANDLER_TIMEOUT_QA",
 }
 
 STAGE_DEFAULTS = {
-    "in-progress":  7200,
-    "in-rework":    7200,
-    "in-review":    1800,
-    "needs-review": 1800,
-    "needs-qa":     3600,
-    "ready-for-qa": 3600,
+    "in-dev":             7200,
+    "needs-dev":          7200,
+    "loop:active:dev":    7200,
+    "loop:action:dev":    7200,
+    "in-review":          1800,
+    "needs-review":       1800,
+    "loop:active:review": 1800,
+    "loop:action:review": 1800,
+    "in-qa":              3600,
+    "needs-qa":           3600,
+    "loop:active:qa":     3600,
+    "loop:action:qa":     3600,
 }
+
+# Maps the latest event_type to a canonical stage label; None = no action needed.
+_INFERENCE_MAP: dict[str, Optional[str]] = {
+    "dev_start":      "in-dev",
+    "rework_start":   "in-dev",
+    "review_start":   "in-review",
+    "qa_start":       "in-qa",
+    "qa_fail":        "qa-fail",
+    "po_done":        "needs-dev",
+    "dev_done":       "needs-review",
+    "rework_done":    "needs-review",
+    "review_done":    "needs-qa",
+    "qa_pass":        None,
+    "merge_done":     None,
+    "po_failed":      "blocked",
+    "dev_failed":     "blocked",
+    "review_failed":  "blocked",
+    "merge_failed":   "blocked",
+    "merge_conflict": "blocked",
+    "rework_failed":  "blocked",
+}
+
+_ALL_KNOWN_STAGES = STUCK_STAGES | TIMEOUT_STAGES | QA_FAIL_STAGES
+
+
+def _infer_stage(role: str, event_type: str, payload: Optional[str] = None) -> Optional[str]:
+    """Infer the canonical stage label from the latest event for a ticket.
+
+    Temporary stop-gap; superseded once the `current_labels` table lands (see Option 1 in #221).
+    """
+    et = (event_type or "").lower()
+    if et in _INFERENCE_MAP:
+        return _INFERENCE_MAP[et]
+    if et == "label_transition" and payload:
+        try:
+            p = json.loads(payload) if isinstance(payload, str) else payload
+            after_labels = p.get("after_labels", []) if isinstance(p, dict) else []
+            for label in after_labels:
+                if label in _ALL_KNOWN_STAGES:
+                    return label
+        except (json.JSONDecodeError, TypeError):
+            pass
+    return None
 
 
 def _handler_timeout_seconds() -> int:
@@ -61,7 +122,7 @@ def _action_queue_reason(
         return "stuck_label"
     if stage in TIMEOUT_STAGES and age_seconds > threshold:
         return "timeout"
-    if stage == QA_FAIL_STAGE and retry_count >= QA_FAIL_RETRY_THRESHOLD:
+    if stage in QA_FAIL_STAGES and retry_count >= QA_FAIL_RETRY_THRESHOLD:
         return "qa_fail_repeated"
     return None
 
@@ -75,7 +136,7 @@ def action_queue(conn: sqlite3.Connection = Depends(db_dep)):
     rows = conn.execute(
         """
         SELECT e.project, e.role, e.event_type, e.issue_number, e.pr_number,
-               e.detail, e.loop_id, e.created_at,
+               e.detail, e.payload, e.loop_id, e.created_at,
                COALESCE(h.rework_count, 0) AS rework_count,
                COALESCE(r.title, '') AS title
         FROM events e
@@ -105,7 +166,9 @@ def action_queue(conn: sqlite3.Connection = Depends(db_dep)):
     now = datetime.now(timezone.utc)
     result = []
     for r in rows:
-        stage = (r["event_type"] or "").lower()
+        stage = _infer_stage(r["role"], r["event_type"], r["payload"])
+        if stage is None:
+            continue
         created = parse_ts(r["created_at"])
         age_seconds = int((now - created).total_seconds()) if created else 0
         threshold = _threshold_for_stage(stage)

--- a/tests/test_action_queue.py
+++ b/tests/test_action_queue.py
@@ -13,9 +13,11 @@ def test_action_queue_empty(isolated_client):
     assert resp.json() == []
 
 
-def test_action_queue_blocked_label(isolated_client):
+def test_action_queue_blocked_label(isolated_client, monkeypatch):
+    # dev_failed → inferred stage = "blocked"
+    monkeypatch.setitem(server.PROJECTS, "boba-event", "svv2014/boba-event")
     server._insert_event(server.ReportPayload(
-        project="boba-event", role="dev", event_type="blocked", issue_number=42,
+        project="boba-event", role="dev", event_type="dev_failed", issue_number=42,
         detail="needs human"
     ))
     resp = isolated_client.get("/api/action_queue")
@@ -31,8 +33,17 @@ def test_action_queue_blocked_label(isolated_client):
 
 
 def test_action_queue_needs_clarification(isolated_client):
+    # label_transition with after_labels containing "needs-clarification"
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="needs-clarification", issue_number=7
+        project="loop", role="dev", event_type="label_transition", issue_number=7,
+        payload={
+            "target_kind": "issue",
+            "number": 7,
+            "before_labels": [],
+            "after_labels": ["needs-clarification"],
+            "op": "add",
+            "source": "loop",
+        }
     ))
     resp = isolated_client.get("/api/action_queue")
     data = resp.json()
@@ -41,8 +52,9 @@ def test_action_queue_needs_clarification(isolated_client):
 
 def test_action_queue_timeout_threshold(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "200")
+    # dev_start → inferred stage = "in-dev"
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="in-progress", issue_number=11
+        project="loop", role="dev", event_type="dev_start", issue_number=11
     ))
     # backdate created_at to 300s ago — exceeds 200s threshold
     conn = sqlite3.connect(server.db.DB_PATH)
@@ -55,14 +67,15 @@ def test_action_queue_timeout_threshold(isolated_client, monkeypatch):
     data = resp.json()
     timeout_items = [it for it in data if it["reason"] == "timeout" and it["number"] == 11]
     assert len(timeout_items) == 1
-    assert timeout_items[0]["stage"] == "in-progress"
+    assert timeout_items[0]["stage"] == "in-dev"
     assert timeout_items[0]["age_seconds"] >= 200
 
 
 def test_action_queue_in_progress_below_threshold_excluded(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "3600")
+    # dev_start → "in-dev"; below threshold so excluded
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="in-progress", issue_number=13
+        project="loop", role="dev", event_type="dev_start", issue_number=13
     ))
     resp = isolated_client.get("/api/action_queue")
     data = resp.json()
@@ -71,11 +84,12 @@ def test_action_queue_in_progress_below_threshold_excluded(isolated_client, monk
 
 def test_action_queue_sorted_by_age_desc(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "100")
+    # dev_failed → "blocked" (stuck, always surfaces)
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="blocked", issue_number=200
+        project="loop", role="dev", event_type="dev_failed", issue_number=200
     ))
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="blocked", issue_number=201
+        project="loop", role="dev", event_type="dev_failed", issue_number=201
     ))
     conn = sqlite3.connect(server.db.DB_PATH)
     conn.execute(
@@ -91,8 +105,9 @@ def test_action_queue_sorted_by_age_desc(isolated_client, monkeypatch):
 
 def test_action_queue_per_stage_threshold_dev_override(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "500")
+    # dev_start → "in-dev"
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="in-progress", issue_number=300
+        project="loop", role="dev", event_type="dev_start", issue_number=300
     ))
     conn = sqlite3.connect(server.db.DB_PATH)
     conn.execute(
@@ -109,8 +124,9 @@ def test_action_queue_per_stage_threshold_dev_override(isolated_client, monkeypa
 
 def test_action_queue_needs_qa_past_threshold(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_QA", "60")
+    # review_done → "needs-qa"
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="needs-qa", issue_number=301
+        project="loop", role="dev", event_type="review_done", issue_number=301
     ))
     conn = sqlite3.connect(server.db.DB_PATH)
     conn.execute(
@@ -128,8 +144,9 @@ def test_action_queue_needs_qa_past_threshold(isolated_client, monkeypatch):
 
 def test_action_queue_needs_qa_under_threshold_excluded(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_QA", "3600")
+    # review_done → "needs-qa"; below threshold so excluded
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="needs-qa", issue_number=302
+        project="loop", role="dev", event_type="review_done", issue_number=302
     ))
     resp = isolated_client.get("/api/action_queue")
     data = resp.json()
@@ -138,11 +155,12 @@ def test_action_queue_needs_qa_under_threshold_excluded(isolated_client, monkeyp
 
 def test_action_queue_threshold_seconds_field(isolated_client, monkeypatch):
     monkeypatch.setenv("HANDLER_TIMEOUT_QA", "60")
+    # review_done → "needs-qa"; dev_failed → "blocked"
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="needs-qa", issue_number=303
+        project="loop", role="dev", event_type="review_done", issue_number=303
     ))
     server._insert_event(server.ReportPayload(
-        project="loop", role="dev", event_type="blocked", issue_number=304
+        project="loop", role="dev", event_type="dev_failed", issue_number=304
     ))
     conn = sqlite3.connect(server.db.DB_PATH)
     conn.execute(
@@ -160,6 +178,95 @@ def test_action_queue_threshold_seconds_field(isolated_client, monkeypatch):
     assert stuck_item is not None
     assert stuck_item["reason"] == "stuck_label"
     assert stuck_item["threshold_seconds"] is None
+
+
+# ── AC tests (issue #221) ─────────────────────────────────────────────────────
+
+
+def test_infer_dev_start_timeout(isolated_client, monkeypatch):
+    """AC1: dev_start older than dev threshold → stage=in-dev, reason=timeout."""
+    monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "200")
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="dev_start", issue_number=400
+    ))
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        "UPDATE events SET created_at = datetime('now', '-300 seconds') WHERE issue_number = 400"
+    )
+    conn.commit()
+    conn.close()
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    items = [it for it in data if it["number"] == 400]
+    assert len(items) == 1
+    assert items[0]["stage"] == "in-dev"
+    assert items[0]["reason"] == "timeout"
+    assert items[0]["age_seconds"] >= 200
+
+
+def test_infer_dev_failed_blocked(isolated_client):
+    """AC2: dev_failed → stage=blocked, reason=stuck_label."""
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="dev_failed", issue_number=401
+    ))
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    items = [it for it in data if it["number"] == 401]
+    assert len(items) == 1
+    assert items[0]["stage"] == "blocked"
+    assert items[0]["reason"] == "stuck_label"
+
+
+def test_infer_qa_fail_repeated(isolated_client):
+    """AC3: qa_fail with rework_count >= 3 → reason=qa_fail_repeated."""
+    server._insert_event(server.ReportPayload(
+        project="loop", role="qa", event_type="qa_fail", issue_number=402,
+        rework_count=3
+    ))
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    items = [it for it in data if it["number"] == 402]
+    assert len(items) == 1
+    assert items[0]["stage"] == "qa-fail"
+    assert items[0]["reason"] == "qa_fail_repeated"
+
+
+def test_infer_dev_done_not_returned(isolated_client):
+    """AC4: dev_done (work finished, nothing pending) → NOT returned."""
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="dev_done", issue_number=403
+    ))
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    assert all(it["number"] != 403 for it in data)
+
+
+def test_infer_label_transition_loop_active_dev(isolated_client, monkeypatch):
+    """AC5: label_transition with loop:active:dev → reason=timeout if older than threshold."""
+    monkeypatch.setenv("HANDLER_TIMEOUT_DEV", "200")
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="label_transition", issue_number=404,
+        payload={
+            "target_kind": "issue",
+            "number": 404,
+            "before_labels": [],
+            "after_labels": ["loop:active:dev"],
+            "op": "add",
+            "source": "loop",
+        }
+    ))
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        "UPDATE events SET created_at = datetime('now', '-300 seconds') WHERE issue_number = 404"
+    )
+    conn.commit()
+    conn.close()
+    resp = isolated_client.get("/api/action_queue")
+    data = resp.json()
+    items = [it for it in data if it["number"] == 404]
+    assert len(items) == 1
+    assert items[0]["stage"] == "loop:active:dev"
+    assert items[0]["reason"] == "timeout"
 
 
 # ── Failure-context endpoint ──────────────────────────────────────────────────
@@ -207,6 +314,7 @@ def test_failure_endpoint_no_comment(isolated_client, monkeypatch):
 
 def test_failure_endpoint_with_marker(isolated_client, monkeypatch):
     """Returns parsed payload when a failure-context comment exists."""
+    monkeypatch.setitem(server.PROJECTS, "loop", "svv2014/loop")
     gh_helper._FAILURE_CACHE.clear()
 
     mock_result = MagicMock()


### PR DESCRIPTION
Closes #221

## Changes

### `server/routes/action_queue.py`
- Added `_infer_stage(role, event_type, payload)` helper that maps the latest `event_type` per ticket to a canonical stage label via a lookup table. Handles `label_transition` events by parsing `after_labels` from the JSON payload. Returns `None` for events that imply no action needed (e.g. `dev_done`, `qa_pass`).
- Updated stage vocabulary:
  - `STUCK_STAGES`: added `loop:result:blocked`
  - `TIMEOUT_STAGES`: replaced deprecated names (`in-progress`, `in-rework`, `ready-for-qa`) with canonical names (`in-dev`, `in-review`, `in-qa`, `needs-dev`) and forward-compatible `loop:*` aliases
  - `QA_FAIL_STAGE` (string) → `QA_FAIL_STAGES` (set) covering `qa-fail` and `loop:result:qa-fail`
- `STAGE_THRESHOLD_ENV` / `STAGE_DEFAULTS` updated to cover all canonical names and `loop:*` aliases; deprecated keys removed
- `_action_queue_reason` updated to use `stage in QA_FAIL_STAGES`
- Main loop now calls `_infer_stage` instead of reading `event_type` directly; adds `e.payload` to the SQL SELECT

### `tests/test_action_queue.py`
- Updated existing tests to use real event types (`dev_failed` → blocked, `dev_start` → in-dev, `review_done` → needs-qa) and patched PROJECTS where github_url assertions needed it
- Added 5 new AC tests: dev_start timeout, dev_failed blocked, qa_fail repeated, dev_done not returned, label_transition with loop:active:dev
- Fixed pre-existing failure in `test_failure_endpoint_with_marker` (loop project wasn't registered in PROJECTS)

## Test Plan
- `pytest tests/test_action_queue.py` — 20 passed
- `ruff check .` — clean
- `npm run typecheck && npm run build` — clean