### PR TITLE
[LM-220] add AGENTS.md at repo root pointing to design standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# Agent guidance — loop-monitor
+
+## UI changes (`web/src/`)
+
+Read `design/DESIGN_STANDARDS.md` before writing any React code.
+It defines color tokens, aesthetic rules, layout grid, and a do/don't list.
+Use existing tokens — no inventing colors, paddings, or font sizes.
+Justify any deviation explicitly in the PR description.
+
+Visual regression CI (`tests/visual/`) catches major drift, but subtle drift
+(wrong padding, hand-rolled link styling, off-token colors) won't fail CI.
+Read the standards.
+
+Future UI tickets filed by the operator should include a reference to
+`design/DESIGN_STANDARDS.md` in the ticket body so every PR starts from the
+same design baseline.
+
+## Server changes (`server/`)
+
+Follow existing route module patterns in `server/routes/`.
+Add tests to the appropriate per-area `tests/test_<area>_routes.py` file.
+
+## Schema changes (`bounty.db`)
+
+Document the change in `docs/` and include a backfill / forward-compat note
+in the PR description.


### PR DESCRIPTION
Closes #220

## Changes

- Added `AGENTS.md` at the repo root (26 lines, under the 50-line limit).
- Points to `design/DESIGN_STANDARDS.md` for any UI changes under `web/src/`.
- Documents the server route module convention (`server/routes/`) and per-area test pattern.
- Documents the schema-change doc + backfill note requirement for `bounty.db`.
- Notes the convention that future UI tickets should reference the standards.
- No code changes to `web/src/` or `server/` — purely meta/docs.

Side action: posted the design-standards reminder comment on issues #214, #215, #216, #217, #218, #219.

Note: CLAUDE.md is absent from the project root — AGENTS.md is the correct convention here (both loop handlers and Claude Code check it).

## Test Plan

- Verify `AGENTS.md` exists at the repo root and is under 50 lines.
- Verify it references `design/DESIGN_STANDARDS.md`, `server/routes/`, per-area test files, and `bounty.db` schema docs.
- Verify issues #214–#219 each have the new comment.
- Verify no changes to `web/src/`, `server/`, `design/DESIGN_STANDARDS.md`, or any test/CI file.