### PR TITLE
[LM-218] add cost trend strip: median rework factor + 7d/30d delta + sparkline

### DIFF
--- a/server/routes/issues_cost.py
+++ b/server/routes/issues_cost.py
@@ -3,7 +3,7 @@ import re
 import sqlite3
 import subprocess
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Any, Optional
 
 from fastapi import APIRouter, Depends
 
@@ -197,3 +197,160 @@ def get_issues_cost(
 
     result.sort(key=lambda r: (-r["rework_factor"], -r["actual_runs"]))
     return result
+
+
+def _median(values: list[float]) -> Optional[float]:
+    """Compute median of a list of floats. Returns None for empty list."""
+    if not values:
+        return None
+    s = sorted(values)
+    n = len(s)
+    mid = n // 2
+    if n % 2 == 0:
+        return round((s[mid - 1] + s[mid]) / 2, 4)
+    return round(s[mid], 4)
+
+
+def _linear_trend_slope(values: list[float]) -> float:
+    """Return slope from simple linear regression over evenly-spaced points."""
+    n = len(values)
+    if n < 2:
+        return 0.0
+    xs = list(range(n))
+    x_mean = sum(xs) / n
+    y_mean = sum(values) / n
+    num = sum((xs[i] - x_mean) * (values[i] - y_mean) for i in range(n))
+    den = sum((xs[i] - x_mean) ** 2 for i in range(n))
+    return num / den if den != 0 else 0.0
+
+
+@router.get("/api/cost/trend")
+def get_cost_trend(
+    days: int = 30,
+    project: Optional[str] = None,
+    priority: Optional[str] = None,
+    conn: sqlite3.Connection = Depends(db_dep),
+) -> dict[str, Any]:
+    since_dt = datetime.now(timezone.utc) - timedelta(days=days)
+    since_iso = since_dt.isoformat()
+
+    # Fetch all events in the window to compute per-issue rework factors per day
+    rows = conn.execute(
+        """
+        SELECT
+            date(created_at)   AS day,
+            project,
+            issue_number,
+            SUM(CASE WHEN event_type LIKE '%_start' THEN 1 ELSE 0 END) AS actual_runs
+        FROM events
+        WHERE issue_number IS NOT NULL
+          AND created_at >= ?
+          AND (? IS NULL OR project = ?)
+        GROUP BY day, project, issue_number
+        HAVING actual_runs > 0
+        """,
+        (since_iso, project, project),
+    ).fetchall()
+
+    # Build a map of day -> list of rework_factors
+    # rework_factor per (day, issue) = actual_runs_that_day / 5  (simplified happy path = 5, no child info here)
+    # We use the same formula as _build_row but without child_count (would require GH API per day per issue)
+    day_factors: dict[str, list[float]] = {}
+    for row in rows:
+        day: str = row["day"]
+        actual: int = row["actual_runs"] or 0
+        if actual == 0:
+            continue
+        # simple rework factor without child lookup (consistent for trend)
+        rf = round(actual / 5, 4)
+        day_factors.setdefault(day, []).append(rf)
+
+    # Apply priority filter if given — we need to know which (project, issue_number) have that priority
+    # We fetch all issues in window and then filter by priority via GH meta
+    if priority:
+        # collect all unique (project, issue_number) in the window
+        meta_rows = conn.execute(
+            """
+            SELECT DISTINCT project, issue_number
+            FROM events
+            WHERE issue_number IS NOT NULL
+              AND created_at >= ?
+              AND (? IS NULL OR project = ?)
+            """,
+            (since_iso, project, project),
+        ).fetchall()
+        allowed: set[tuple[str, int]] = set()
+        for mr in meta_rows:
+            meta = _fetch_gh_meta(mr["project"], mr["issue_number"])
+            if meta.get("priority") == priority:
+                allowed.add((mr["project"], mr["issue_number"]))
+
+        # rebuild day_factors filtered to allowed issues
+        day_factors = {}
+        for row in rows:
+            key = (row["project"], row["issue_number"])
+            if key not in allowed:
+                continue
+            day: str = row["day"]
+            actual = row["actual_runs"] or 0
+            if actual == 0:
+                continue
+            rf = round(actual / 5, 4)
+            day_factors.setdefault(day, []).append(rf)
+
+    # Build sorted list of days in the window
+    today_dt = datetime.now(timezone.utc).date()
+    all_days = [(today_dt - timedelta(days=i)).isoformat() for i in range(days - 1, -1, -1)]
+
+    buckets: list[dict[str, Any]] = []
+    for d in all_days:
+        factors = day_factors.get(d, [])
+        med = _median(factors)
+        buckets.append({
+            "date": d,
+            "median_rework_factor": med,
+            "issue_count": len(factors),
+        })
+
+    # today's stats
+    today_factors = day_factors.get(today_dt.isoformat(), [])
+    today_median = _median(today_factors)
+    today_count = len(today_factors)
+
+    # comparison helpers
+    def _median_for_day(offset_days: int) -> Optional[float]:
+        d = (today_dt - timedelta(days=offset_days)).isoformat()
+        return _median(day_factors.get(d, []))
+
+    def _delta(ref: Optional[float]) -> Optional[float]:
+        if today_median is None or ref is None:
+            return None
+        return round(today_median - ref, 4)
+
+    vs_7d = _delta(_median_for_day(7))
+    vs_30d = _delta(_median_for_day(30))
+
+    # trend from linear regression on last 14 buckets that have data
+    recent_medians = [b["median_rework_factor"] for b in buckets[-14:] if b["median_rework_factor"] is not None]
+    if len(recent_medians) >= 3:
+        slope = _linear_trend_slope(recent_medians)
+        if slope < -0.01:
+            trend = "improving"
+        elif slope > 0.01:
+            trend = "degrading"
+        else:
+            trend = "stable"
+    else:
+        trend = "stable"
+
+    return {
+        "window_days": days,
+        "today": {
+            "median_rework_factor": today_median,
+            "issue_count": today_count,
+        },
+        "vs_7d": vs_7d,
+        "vs_30d": vs_30d,
+        "trend": trend,
+        "buckets": buckets,
+    }

--- a/tests/test_cost_trend.py
+++ b/tests/test_cost_trend.py
@@ -1,0 +1,178 @@
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+import server
+import server.db
+import server.routes.issues_cost as issues_cost_module
+from server.routes.issues_cost import _linear_trend_slope, _median
+
+
+def _make_client(monkeypatch, tmp_path, gh_meta_fn=None):
+    monkeypatch.setattr(server.db, "DB_PATH", str(tmp_path / "test.db"))
+    server.db.apply_pending_migrations()
+    issues_cost_module._gh_cache.clear()
+    if gh_meta_fn is not None:
+        monkeypatch.setattr(issues_cost_module, "_fetch_gh_meta", gh_meta_fn)
+    return TestClient(server.app)
+
+
+def _open_meta(project, issue_number):
+    return {"title": f"Issue {issue_number}", "state": "open", "priority": None, "body": "", "merged": False}
+
+
+def _insert_events(db_path: str, events: list) -> None:
+    conn = sqlite3.connect(db_path)
+    for ev in events:
+        conn.execute(
+            "INSERT INTO events (project, role, event_type, issue_number, created_at) VALUES (?,?,?,?,?)",
+            (ev["project"], ev["role"], ev["event_type"], ev["issue_number"], ev["created_at"]),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _ts(offset_days: int = 0) -> str:
+    dt = datetime.now(timezone.utc) - timedelta(days=offset_days)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+
+
+# ── _median ───────────────────────────────────────────────────────────────────
+
+def test_median_empty():
+    assert _median([]) is None
+
+
+def test_median_single():
+    assert _median([3.0]) == 3.0
+
+
+def test_median_odd():
+    assert _median([3.0, 1.0, 2.0]) == 2.0
+
+
+def test_median_even():
+    assert _median([1.0, 2.0, 3.0, 4.0]) == 2.5
+
+
+def test_median_rounded_to_4dp():
+    result = _median([1.0, 2.0])
+    assert result == round(1.5, 4)
+
+
+# ── _linear_trend_slope ───────────────────────────────────────────────────────
+
+def test_slope_single_value():
+    assert _linear_trend_slope([5.0]) == 0.0
+
+
+def test_slope_flat():
+    assert _linear_trend_slope([2.0, 2.0, 2.0, 2.0]) == 0.0
+
+
+def test_slope_strictly_increasing():
+    assert _linear_trend_slope([1.0, 2.0, 3.0, 4.0]) > 0
+
+
+def test_slope_strictly_decreasing():
+    assert _linear_trend_slope([4.0, 3.0, 2.0, 1.0]) < 0
+
+
+# ── GET /api/cost/trend ───────────────────────────────────────────────────────
+
+def test_trend_response_shape(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    resp = client.get("/api/cost/trend")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "window_days" in data
+    assert "today" in data
+    assert "median_rework_factor" in data["today"]
+    assert "issue_count" in data["today"]
+    assert "vs_7d" in data
+    assert "vs_30d" in data
+    assert "trend" in data
+    assert "buckets" in data
+    assert isinstance(data["buckets"], list)
+
+
+def test_trend_default_30_buckets(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    resp = client.get("/api/cost/trend")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["window_days"] == 30
+    assert len(data["buckets"]) == 30
+
+
+def test_trend_days_param(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    resp = client.get("/api/cost/trend?days=7")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["window_days"] == 7
+    assert len(data["buckets"]) == 7
+
+
+def test_trend_today_median_computed(tmp_path, monkeypatch):
+    """10 _start events for one issue today → rf = 10/5 = 2.0."""
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    events = [
+        {"project": "p", "role": "dev", "event_type": "dev_start",
+         "issue_number": 1, "created_at": _ts(0)}
+        for _ in range(10)
+    ]
+    _insert_events(server.db.DB_PATH, events)
+    resp = client.get("/api/cost/trend")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["today"]["median_rework_factor"] == 2.0
+    assert data["today"]["issue_count"] == 1
+
+
+def test_trend_project_filter_isolates(tmp_path, monkeypatch):
+    """Only proj-a events counted when project=proj-a."""
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    today = _ts(0)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-a", "role": "dev", "event_type": "dev_start",
+         "issue_number": 10, "created_at": today},
+        {"project": "proj-b", "role": "dev", "event_type": "dev_start",
+         "issue_number": 20, "created_at": today},
+        {"project": "proj-b", "role": "dev", "event_type": "dev_start",
+         "issue_number": 20, "created_at": today},
+    ])
+    resp = client.get("/api/cost/trend?project=proj-a")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["today"]["issue_count"] == 1
+    assert data["today"]["median_rework_factor"] == round(1 / 5, 4)
+
+
+def test_trend_field_values(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    resp = client.get("/api/cost/trend")
+    assert resp.status_code == 200
+    assert resp.json()["trend"] in ("improving", "degrading", "stable")
+
+
+def test_trend_bucket_schema(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    resp = client.get("/api/cost/trend")
+    assert resp.status_code == 200
+    for bucket in resp.json()["buckets"]:
+        assert "date" in bucket
+        assert "median_rework_factor" in bucket
+        assert "issue_count" in bucket
+
+
+def test_trend_empty_db_returns_nulls(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    resp = client.get("/api/cost/trend")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["today"]["median_rework_factor"] is None
+    assert data["vs_7d"] is None
+    assert data["vs_30d"] is None
+    assert all(b["median_rework_factor"] is None for b in data["buckets"])

--- a/web/src/components/CostTrendStrip.tsx
+++ b/web/src/components/CostTrendStrip.tsx
@@ -1,0 +1,213 @@
+import type { CostTrend, CostTrendBucket } from '../lib/types';
+
+interface CostTrendStripProps {
+  today: CostTrend['today'];
+  vs_7d: number | null;
+  vs_30d: number | null;
+  buckets: CostTrendBucket[];
+}
+
+function reworkColor(v: number): string {
+  if (v <= 1.0) return 'var(--role-ok)';
+  if (v < 2.0)  return 'var(--fg-2)';
+  if (v < 4.0)  return 'var(--role-warn)';
+  return 'var(--role-err)';
+}
+
+/**
+ * Color for a delta value (negative = improving = green, positive = degrading = red,
+ * within ±5% relative to a baseline is treated as gray/stable).
+ */
+function deltaColor(delta: number | null, baseline: number | null): string {
+  if (delta == null) return 'var(--fg-3)';
+  const threshold = baseline != null && baseline !== 0 ? Math.abs(baseline) * 0.05 : 0.05;
+  if (Math.abs(delta) <= threshold) return 'var(--fg-3)';
+  return delta < 0 ? 'var(--pass)' : 'var(--fail)';
+}
+
+function formatDelta(delta: number | null): string {
+  if (delta == null) return '—';
+  const sign = delta > 0 ? '+' : '';
+  return `${sign}${delta.toFixed(2)}`;
+}
+
+interface SparklineProps {
+  buckets: CostTrendBucket[];
+  width?: number;
+  height?: number;
+}
+
+function Sparkline({ buckets, width = 120, height = 32 }: SparklineProps) {
+  const withData = buckets.filter(b => b.median_rework_factor != null);
+  if (withData.length < 2) {
+    return (
+      <svg
+        width={width}
+        height={height}
+        aria-label="Sparkline — not enough data"
+        style={{ display: 'block', flexShrink: 0 }}
+      >
+        <line
+          x1={0} y1={height / 2}
+          x2={width} y2={height / 2}
+          stroke="var(--border)"
+          strokeWidth={1}
+          strokeDasharray="2 3"
+        />
+      </svg>
+    );
+  }
+
+  const values = withData.map(b => b.median_rework_factor as number);
+  const minVal = Math.min(...values);
+  const maxVal = Math.max(...values);
+  const range = maxVal - minVal || 1;
+
+  const pad = 2;
+  const innerW = width - pad * 2;
+  const innerH = height - pad * 2;
+
+  const toX = (i: number) => pad + (i / (withData.length - 1)) * innerW;
+  const toY = (v: number) => pad + innerH - ((v - minVal) / range) * innerH;
+
+  const points = withData.map((b, i) => `${toX(i)},${toY(b.median_rework_factor as number)}`).join(' ');
+
+  const minIdx = values.indexOf(minVal);
+  const maxIdx = values.indexOf(maxVal);
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      aria-label="30-day median rework factor sparkline"
+      style={{ display: 'block', flexShrink: 0, overflow: 'visible' }}
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke="var(--fg-3)"
+        strokeWidth={1}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      {withData.map((b, i) => {
+        const isMin = i === minIdx;
+        const isMax = i === maxIdx;
+        if (!isMin && !isMax) return null;
+        const cx = toX(i);
+        const cy = toY(b.median_rework_factor as number);
+        const dotColor = isMax ? 'var(--fail)' : 'var(--pass)';
+        return (
+          <circle key={b.date} cx={cx} cy={cy} r={2.5} fill={dotColor}>
+            <title>{`${b.date}: ${(b.median_rework_factor as number).toFixed(2)}`}</title>
+          </circle>
+        );
+      })}
+    </svg>
+  );
+}
+
+export default function CostTrendStrip({ today, vs_7d, vs_30d, buckets }: CostTrendStripProps) {
+  const med = today.median_rework_factor;
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--pad-4)',
+        padding: 'var(--pad-3) var(--pad-4)',
+        borderBottom: '1px solid var(--border)',
+        background: 'var(--bg-1)',
+        flexWrap: 'wrap',
+      }}
+    >
+      {/* Today's median */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 2, minWidth: 80 }}>
+        <span
+          className="muted mono"
+          style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em' }}
+        >
+          today median
+        </span>
+        <span
+          className="num"
+          style={{
+            fontSize: 28,
+            fontFamily: 'var(--font-mono)',
+            fontWeight: 600,
+            color: med != null ? reworkColor(med) : 'var(--fg-3)',
+            lineHeight: 1,
+          }}
+        >
+          {med != null ? med.toFixed(2) : '—'}
+        </span>
+        {today.issue_count > 0 && (
+          <span className="muted mono" style={{ fontSize: 10, color: 'var(--fg-3)' }}>
+            {today.issue_count} issue{today.issue_count !== 1 ? 's' : ''}
+          </span>
+        )}
+      </div>
+
+      {/* Separator */}
+      <div style={{ width: 1, height: 40, background: 'var(--border)', flexShrink: 0 }} />
+
+      {/* Deltas */}
+      <div style={{ display: 'flex', gap: 'var(--pad-3)' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <span
+            className="muted mono"
+            style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em' }}
+          >
+            vs 7d
+          </span>
+          <span
+            className="num"
+            style={{
+              fontSize: 16,
+              fontFamily: 'var(--font-mono)',
+              fontWeight: 500,
+              color: deltaColor(vs_7d, med),
+            }}
+          >
+            {formatDelta(vs_7d)}
+          </span>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <span
+            className="muted mono"
+            style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em' }}
+          >
+            vs 30d
+          </span>
+          <span
+            className="num"
+            style={{
+              fontSize: 16,
+              fontFamily: 'var(--font-mono)',
+              fontWeight: 500,
+              color: deltaColor(vs_30d, med),
+            }}
+          >
+            {formatDelta(vs_30d)}
+          </span>
+        </div>
+      </div>
+
+      {/* Separator */}
+      <div style={{ width: 1, height: 40, background: 'var(--border)', flexShrink: 0 }} />
+
+      {/* Sparkline */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+        <span
+          className="muted mono"
+          style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em' }}
+        >
+          30d trend
+        </span>
+        <Sparkline buckets={buckets} width={120} height={32} />
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -24,6 +24,7 @@ import type {
   FailureContext,
   CycleTimesResponse,
   SloConfig,
+  CostTrend,
 } from './types';
 import * as fx from './fixtures';
 
@@ -168,6 +169,15 @@ export interface IssuesCostParams {
   since?: string;
   limit?: number;
   offset?: number;
+}
+
+export async function fetchCostTrend(params: { days?: number; project?: string; priority?: string } = {}): Promise<CostTrend> {
+  const p = new URLSearchParams();
+  if (params.days != null)    p.set('days', String(params.days));
+  if (params.project)         p.set('project', params.project);
+  if (params.priority)        p.set('priority', params.priority);
+  const qs = p.size ? `?${p.toString()}` : '';
+  return get<CostTrend>(`/api/cost/trend${qs}`);
 }
 
 export async function fetchIssuesCost(params: IssuesCostParams = {}): Promise<IssueCostRow[]> {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -253,3 +253,21 @@ export interface IssueCostRow {
   last_event_at: string | null;
   github_url: string | null;
 }
+
+export interface CostTrendBucket {
+  date: string;
+  median_rework_factor: number | null;
+  issue_count: number;
+}
+
+export interface CostTrend {
+  window_days: number;
+  today: {
+    median_rework_factor: number | null;
+    issue_count: number;
+  };
+  vs_7d: number | null;
+  vs_30d: number | null;
+  trend: 'improving' | 'degrading' | 'stable';
+  buckets: CostTrendBucket[];
+}

--- a/web/src/screens/Cost.tsx
+++ b/web/src/screens/Cost.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { fetchIssuesCost } from '../lib/api';
+import { fetchIssuesCost, fetchCostTrend } from '../lib/api';
 import type { IssueCostRow } from '../lib/types';
+import CostTrendStrip from '../components/CostTrendStrip';
 
 const LIMIT = 50;
 
@@ -66,6 +67,17 @@ export default function Cost() {
     staleTime: 0,
   });
 
+  const trendQuery = useQuery({
+    queryKey: ['cost-trend', filterProject, filterPriority],
+    queryFn: () => fetchCostTrend({
+      days: 30,
+      project: filterProject || undefined,
+      priority: filterPriority || undefined,
+    }),
+    refetchInterval: 60_000,
+    staleTime: 0,
+  });
+
   const visible = allRows.filter(r => {
     if (filterProject && r.project !== filterProject) return false;
     if (filterPriority && r.priority !== filterPriority) return false;
@@ -104,6 +116,15 @@ export default function Cost() {
           </div>
         )}
       </div>
+
+      {trendQuery.data && (
+        <CostTrendStrip
+          today={trendQuery.data.today}
+          vs_7d={trendQuery.data.vs_7d}
+          vs_30d={trendQuery.data.vs_30d}
+          buckets={trendQuery.data.buckets}
+        />
+      )}
 
       <div style={{ display: 'flex', gap: 'var(--pad-2)', padding: 'var(--pad-3) var(--pad-4)', borderBottom: '1px solid var(--border)', alignItems: 'center' }}>
         <select


### PR DESCRIPTION
Closes #218

## Changes
- `server/routes/issues_cost.py`: added `GET /api/cost/trend` endpoint with `days`/`project`/`priority` params; computes per-day median rework factor in Python; returns today median, vs_7d/vs_30d deltas, trend (linear regression on last 14 buckets), and full 30-day bucket array
- `web/src/lib/types.ts`: added `CostTrend` and `CostTrendBucket` interfaces
- `web/src/lib/api.ts`: added `fetchCostTrend()` function
- `web/src/components/CostTrendStrip.tsx`: new component — big-number today median, color-coded deltas (green/red/gray), 120px inline-SVG sparkline with `<title>` tooltips; uses design token CSS variables only
- `web/src/screens/Cost.tsx`: imports CostTrendStrip; fetches `/api/cost/trend` alongside the table; re-fetches on filter change; renders strip above the filter row

## Test Plan
- Load Cost screen; verify trend strip appears above filter row with today median, two delta badges, and sparkline
- Change project/priority filters; verify strip updates in sync with table
- Check delta color-coding: negative delta green, positive red, within ±5% gray
- Hover sparkline points; verify tooltip shows date + median
- Verify no regression in Cost table pagination and filters' behavior