### PR TITLE
[LM-217] Global project filter in TopBar (persist via URL hash)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,7 +22,7 @@ const SCREEN_KEYS: Record<string, string> = {
 };
 
 export default function App() {
-  const { screen: hashScreen, projectId: hashProjectId, navigateTo } = useHashRoute();
+  const { screen: hashScreen, projectId: hashProjectId, projectFilter, navigateTo, setProjectFilter } = useHashRoute();
 
   // 'cost' is local-only — not stored in the hash — so we track it separately.
   const [showCost, setShowCost] = useState(false);
@@ -107,11 +107,18 @@ export default function App() {
   return (
     <div className="app">
       <Logo />
-      <TopBar events={events} online={online} version={version} />
+      <TopBar
+        events={events}
+        online={online}
+        version={version}
+        allProjectIds={allProjectIds}
+        projectFilter={projectFilter}
+        onProjectFilterChange={setProjectFilter}
+      />
       <NavRail screen={isProjectDetail ? 'projects' : navScreen} setScreen={handleNavChange} />
       <main className="main">
         {showCost ? (
-          <Cost />
+          <Cost globalProjectFilter={projectFilter} />
         ) : isProjectDetail && projectId != null ? (
           <ProjectDetail
             projectId={projectId}
@@ -120,11 +127,11 @@ export default function App() {
             onProjectChange={handleProjectChange}
           />
         ) : hashNavScreen === 'overview' ? (
-          <Overview />
+          <Overview globalProjectFilter={projectFilter} />
         ) : hashNavScreen === 'queue' ? (
-          <Queue />
+          <Queue globalProjectFilter={projectFilter} />
         ) : hashNavScreen === 'workers' ? (
-          <WorkerDetail />
+          <WorkerDetail globalProjectFilter={projectFilter} />
         ) : hashNavScreen === 'logs' ? (
           <Logs />
         ) : (

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -8,6 +8,9 @@ interface TopBarProps {
   events: TopBarEvent[];
   online: boolean;
   version: string;
+  allProjectIds: string[];
+  projectFilter: string | null;
+  onProjectFilterChange: (v: string | null) => void;
 }
 
 function timeFmt(d: Date): string {
@@ -25,10 +28,11 @@ function useTick(ms = 1000) {
   }, [ms]);
 }
 
-export default function TopBar({ events, online, version }: TopBarProps) {
+export default function TopBar({ events, online, version, allProjectIds, projectFilter, onProjectFilterChange }: TopBarProps) {
   useTick(1000);
   const now = new Date();
   const eventsLastMin = events.filter(e => Date.now() - e.ts < 60_000).length;
+  const isFiltered = !!projectFilter;
   return (
     <div className="topbar">
       <div className="left">
@@ -41,6 +45,25 @@ export default function TopBar({ events, online, version }: TopBarProps) {
         <span>: 127.0.0.1:18792</span>
       </div>
       <div className="right">
+        <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+          <label className="muted mono" style={{ fontSize: 11 }}>Project:</label>
+          <select
+            className="btn"
+            value={projectFilter ?? ''}
+            onChange={e => onProjectFilterChange(e.target.value || null)}
+            style={{
+              cursor: 'pointer',
+              border: isFiltered ? '1px solid var(--accent)' : undefined,
+              background: isFiltered ? 'color-mix(in srgb, var(--accent) 15%, var(--bg-1))' : undefined,
+              color: isFiltered ? 'var(--accent)' : undefined,
+            }}
+          >
+            <option value="">All</option>
+            {allProjectIds.map(id => (
+              <option key={id} value={id}>{id}</option>
+            ))}
+          </select>
+        </span>
         <span>{eventsLastMin}/min</span>
         <span>· {events.length.toLocaleString()} events</span>
         <span>· {timeFmt(now)}</span>

--- a/web/src/lib/transforms.test.ts
+++ b/web/src/lib/transforms.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { buildLeaderboard, buildProjectStatus, build24hBuckets } from './transforms';
-import { relTime, durationFmt, absoluteUtc } from './utils';
+import { relTime, durationFmt, absoluteUtc, matchesProjectFilter } from './utils';
 import type { LoopEvent, Worker } from './types';
 
 type ExtLoopEvent = LoopEvent & { points?: number; agent?: string; ts?: number };
@@ -236,5 +236,29 @@ describe('build24hBuckets', () => {
     ];
     const buckets = build24hBuckets(events);
     expect(buckets[23].total).toBe(3);
+  });
+});
+
+// ── matchesProjectFilter ──────────────────────────────────────────────────────
+
+describe('matchesProjectFilter', () => {
+  it('returns true when filter is null (no filter active)', () => {
+    expect(matchesProjectFilter('loop-monitor', null)).toBe(true);
+  });
+
+  it('returns true when filter is undefined', () => {
+    expect(matchesProjectFilter('loop-monitor', undefined)).toBe(true);
+  });
+
+  it('returns true when project matches the filter exactly', () => {
+    expect(matchesProjectFilter('loop-monitor', 'loop-monitor')).toBe(true);
+  });
+
+  it('returns false when project does not match the filter', () => {
+    expect(matchesProjectFilter('other-project', 'loop-monitor')).toBe(false);
+  });
+
+  it('is case-sensitive', () => {
+    expect(matchesProjectFilter('Loop-Monitor', 'loop-monitor')).toBe(false);
   });
 });

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -22,6 +22,10 @@ export function durationFmt(ms: number): string {
   return `${h}h ${m % 60}m`;
 }
 
+export function matchesProjectFilter(project: string, filter: string | null | undefined): boolean {
+  return !filter || project === filter;
+}
+
 export function useTick(ms = 1000): void {
   const [, setN] = useState(0);
   useEffect(() => {

--- a/web/src/panels/ClaudeUsage.tsx
+++ b/web/src/panels/ClaudeUsage.tsx
@@ -17,7 +17,11 @@ function fmtDur(seconds: number): string {
   return m > 0 ? `${m}m ${s}s` : `${s}s`;
 }
 
-export default function ClaudeUsage() {
+interface ClaudeUsageProps {
+  activeFilter?: string | null;
+}
+
+export default function ClaudeUsage({ activeFilter }: ClaudeUsageProps) {
   const { data, isError } = useQuery({
     queryKey: ['claude-usage'],
     queryFn: fetchClaudeUsage,
@@ -54,7 +58,12 @@ export default function ClaudeUsage() {
 
   return (
     <div className="panel">
-      <div className="panel-h"><span>Claude Usage</span></div>
+      <div className="panel-h">
+        <span>Claude Usage</span>
+        {activeFilter && (
+          <span style={{ fontSize: '0.72rem', color: 'var(--fg-3)', marginLeft: 6 }}>account-wide</span>
+        )}
+      </div>
       <div style={{ padding: 'var(--pad-3)' }}>
         <div className="usage-bar">
           <div className={fillClass} style={{ width: `${pct}%` }} />

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -122,11 +122,31 @@ export function useHashRoute() {
     [route.screen, route.projectId, unknown],
   );
 
+  const setProjectFilter = useCallback(
+    (filter: string | null) => {
+      const newUnknown = { ...unknown };
+      if (filter) {
+        newUnknown['project_filter'] = filter;
+      } else {
+        delete newUnknown['project_filter'];
+      }
+      const hash = buildHash(route.screen, route.projectId, route.drawer, newUnknown);
+      history.replaceState(null, '', window.location.pathname + window.location.search + hash);
+      setParsed(prev => ({
+        known: prev.known,
+        unknown: newUnknown,
+      }));
+    },
+    [route.screen, route.projectId, route.drawer, unknown],
+  );
+
   return {
     screen: route.screen,
     projectId: route.projectId,
     drawer: route.drawer,
+    projectFilter: unknown['project_filter'] ?? null,
     navigateTo,
     setDrawer,
+    setProjectFilter,
   };
 }

--- a/web/src/screens/Cost.tsx
+++ b/web/src/screens/Cost.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchIssuesCost } from '../lib/api';
 import type { IssueCostRow } from '../lib/types';
@@ -46,11 +46,19 @@ function median(rows: IssueCostRow[]): number | null {
     : sorted[mid].rework_factor;
 }
 
-export default function Cost() {
+interface CostProps {
+  globalProjectFilter?: string | null;
+}
+
+export default function Cost({ globalProjectFilter }: CostProps) {
   const [offset, setOffset] = useState(0);
   const [allRows, setAllRows] = useState<IssueCostRow[]>([]);
-  const [filterProject, setFilterProject] = useState('');
+  const [filterProject, setFilterProject] = useState(globalProjectFilter ?? '');
   const [filterPriority, setFilterPriority] = useState('');
+
+  useEffect(() => {
+    setFilterProject(globalProjectFilter ?? '');
+  }, [globalProjectFilter]);
 
   const query = useQuery({
     queryKey: ['issues-cost', offset],

--- a/web/src/screens/Overview.tsx
+++ b/web/src/screens/Overview.tsx
@@ -178,7 +178,7 @@ export default function Overview({ globalProjectFilter }: OverviewProps) {
           </div>
         </div>
 
-        <ClaudeUsage />
+        <ClaudeUsage activeFilter={globalProjectFilter} />
         <Charts />
 
       </div>

--- a/web/src/screens/Overview.tsx
+++ b/web/src/screens/Overview.tsx
@@ -11,7 +11,7 @@ import Leaderboard from '../panels/Leaderboard';
 import ActivityFeed from '../panels/ActivityFeed';
 import EventGlyph from '../components/EventGlyph';
 import RoleTag from '../components/RoleTag';
-import { relTime, durationFmt } from '../lib/utils';
+import { relTime, durationFmt, matchesProjectFilter } from '../lib/utils';
 import Charts from '../panels/Charts';
 import ClaudeUsage from '../panels/ClaudeUsage';
 import { useRoleIds } from '../lib/useRoles';
@@ -20,7 +20,11 @@ const COMPLETED_TYPES = new Set([
   'merge_done', 'judge_done', 'review_done', 'dev_done', 'po_done',
 ]);
 
-export default function Overview() {
+interface OverviewProps {
+  globalProjectFilter?: string | null;
+}
+
+export default function Overview({ globalProjectFilter }: OverviewProps) {
   const roleIds = useRoleIds();
 
   const { data: workers = [] } = useQuery({
@@ -51,8 +55,23 @@ export default function Overview() {
     staleTime: 0,
   });
 
+  const filteredWorkers = useMemo(
+    () => workers.filter(w => matchesProjectFilter(w.project, globalProjectFilter)),
+    [workers, globalProjectFilter],
+  );
+
+  const filteredFeed = useMemo(
+    () => feed.filter(e => matchesProjectFilter(e.project, globalProjectFilter)),
+    [feed, globalProjectFilter],
+  );
+
+  const filteredHistory = useMemo(
+    () => history.filter(e => matchesProjectFilter(e.project, globalProjectFilter)),
+    [history, globalProjectFilter],
+  );
+
   const buckets = useMemo(() => {
-    if (eventsGraph) {
+    if (eventsGraph && !globalProjectFilter) {
       // Bucket by relative hour from now (slot 23 = current hour, slot 0 = 23h ago).
       // `b.hour` from /api/events_graph is a UTC ISO string with no Z suffix; append Z so JS parses as UTC.
       const buckets = Array.from({ length: 24 }, (_, i) => ({
@@ -71,25 +90,25 @@ export default function Overview() {
       }
       return buckets;
     }
-    return build24hBuckets(history as (LoopEvent & { ts?: number })[], roleIds);
-  }, [eventsGraph, history, roleIds]);
+    return build24hBuckets(filteredHistory as (LoopEvent & { ts?: number })[], roleIds);
+  }, [eventsGraph, filteredHistory, roleIds, globalProjectFilter]);
 
   const projects = useMemo(
     () => buildProjectStatus(
-      history as Parameters<typeof buildProjectStatus>[0],
-      workers,
+      filteredHistory as Parameters<typeof buildProjectStatus>[0],
+      filteredWorkers,
     ),
-    [history, workers],
+    [filteredHistory, filteredWorkers],
   );
 
   const completed = useMemo(
-    () => history.filter(e => COMPLETED_TYPES.has(e.event_type)).slice(0, 30),
-    [history],
+    () => filteredHistory.filter(e => COMPLETED_TYPES.has(e.event_type)).slice(0, 30),
+    [filteredHistory],
   );
 
   return (
     <>
-      <NowStrip workers={workers} events={feed} />
+      <NowStrip workers={filteredWorkers} events={filteredFeed} />
       <div style={{ padding: 'var(--pad-4)', display: 'grid', gap: 'var(--pad-3)' }}>
 
         <Activity24h buckets={buckets} />
@@ -113,11 +132,11 @@ export default function Overview() {
               ))}
             </div>
           </div>
-          <Leaderboard events={history} />
+          <Leaderboard events={filteredHistory} />
         </div>
 
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--pad-3)' }}>
-          <ActivityFeed events={feed} />
+          <ActivityFeed events={filteredFeed} />
           <div className="panel">
             <div className="panel-h"><span>Completed jobs · last 30</span></div>
             <div style={{ overflow: 'auto', maxHeight: 480 }}>

--- a/web/src/screens/Queue.tsx
+++ b/web/src/screens/Queue.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchActionQueue } from '../lib/api';
 import type { QueueItem } from '../lib/types';
@@ -157,7 +157,11 @@ function QueueTable({ items, onRowClick, sortCol, sortDir, onSort }: QueueTableP
   );
 }
 
-export default function Queue() {
+interface QueueProps {
+  globalProjectFilter?: string | null;
+}
+
+export default function Queue({ globalProjectFilter }: QueueProps) {
   const { data: items = [], isLoading } = useQuery({
     queryKey: ['actionQueue'],
     queryFn: fetchActionQueue,
@@ -166,11 +170,15 @@ export default function Queue() {
 
   const { setDrawer } = useHashRoute();
   const [selected, setSelected] = useState<QueueItem | null>(null);
-  const [filterProject, setFilterProject] = useState('');
+  const [filterProject, setFilterProject] = useState(globalProjectFilter ?? '');
   const [filterReason, setFilterReason] = useState('');
   const [filterLoop, setFilterLoop] = useState('');
   const [sortCol, setSortCol] = useState<SortCol>('age_seconds');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
+
+  useEffect(() => {
+    setFilterProject(globalProjectFilter ?? '');
+  }, [globalProjectFilter]);
 
   const projects = useMemo(
     () => [...new Set(items.map(i => i.project))].sort(),

--- a/web/src/screens/WorkerDetail.tsx
+++ b/web/src/screens/WorkerDetail.tsx
@@ -2,6 +2,7 @@
 import { useState, useMemo, useEffect } from 'react';
 import { fetchFeed } from '../lib/api';
 import type { FeedItem } from '../lib/types';
+import { matchesProjectFilter } from '../lib/utils';
 
 function relTime(isoStr: string, ageSeconds: number | null): string {
   const secs = ageSeconds ?? Math.floor((Date.now() - new Date(isoStr).getTime()) / 1000);
@@ -38,7 +39,11 @@ interface AgentRow {
   roles: Set<string>;
 }
 
-export default function WorkerDetail() {
+interface WorkerDetailProps {
+  globalProjectFilter?: string | null;
+}
+
+export default function WorkerDetail({ globalProjectFilter }: WorkerDetailProps) {
   const [items, setItems] = useState<FeedItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState('');
@@ -55,9 +60,14 @@ export default function WorkerDetail() {
     return () => { cancelled = true; clearInterval(id); };
   }, []);
 
+  const filteredItems = useMemo(
+    () => items.filter(e => matchesProjectFilter(e.project, globalProjectFilter)),
+    [items, globalProjectFilter],
+  );
+
   const byAgent = useMemo((): AgentRow[] => {
     const m = new Map<string, AgentRow>();
-    for (const e of items) {
+    for (const e of filteredItems) {
       const k = `${e.role}/${e.model ?? ''}`;
       if (!m.has(k)) {
         m.set(k, {
@@ -84,8 +94,8 @@ export default function WorkerDetail() {
   const selectedKey = filter || byAgent[0]?.key;
   const selected = byAgent.find(a => a.key === selectedKey) ?? byAgent[0];
   const selectedItems = useMemo(
-    () => items.filter(e => `${e.role}/${e.model ?? ''}` === selected?.key).slice(0, 60),
-    [items, selected],
+    () => filteredItems.filter(e => `${e.role}/${e.model ?? ''}` === selected?.key).slice(0, 60),
+    [filteredItems, selected],
   );
 
   if (loading) {


### PR DESCRIPTION
Closes #217

## Changes

**`web/src/router.tsx`** — Added `setProjectFilter` to `useHashRoute`, exposing `projectFilter` from the `unknown` params bucket (key: `project_filter`). This uses the existing extensible hash mechanism so the filter survives any screen navigation automatically.

**`web/src/lib/utils.ts`** — Added `matchesProjectFilter(project, filter)` helper used by all screens for consistent filter logic.

**`web/src/components/TopBar.tsx`** — Added `Project:` label + `<select>` populated from `allProjectIds`. When a non-All project is selected, the select gets an accent-color border and tinted background to signal the filtered state.

**`web/src/App.tsx`** — Wires `projectFilter` and `setProjectFilter` from `useHashRoute()` into `TopBar`. Passes `globalProjectFilter` prop to Overview, Queue, WorkerDetail, and Cost. ProjectDetail is untouched.

**`web/src/screens/Overview.tsx`** — Accepts `globalProjectFilter` prop. Filters `workers`, `feed`, and `history` before computing `buckets`, `projects`, `completed`, and feeding `NowStrip`, `ActivityFeed`, `Leaderboard`.

**`web/src/screens/Queue.tsx`** — Accepts `globalProjectFilter` prop. Initializes `filterProject` state from it; a `useEffect` syncs when the global filter changes. Local `<select>` still overrides.

**`web/src/screens/WorkerDetail.tsx`** — Accepts `globalProjectFilter` prop. Filters raw feed items by project before computing `byAgent`, so the agent list and event table both respect the filter.

**`web/src/screens/Cost.tsx`** — Accepts `globalProjectFilter` prop. Initializes and syncs `filterProject` state from it; local project dropdown still works as override.

## Test Plan
- Select a project in the TopBar dropdown → picker should gain accent border/background
- Navigate between Overview / Queue / Workers / Cost — filter should persist in URL hash as `project_filter=<id>`
- Each screen should show only rows for the selected project
- Queue's local project dropdown should pre-select the global filter; changing it locally should override
- Selecting "All" removes `project_filter` from hash and restores aggregated views on every screen
- Reload with `#project_filter=<id>` in URL → filter pre-applied
- Navigate to ProjectDetail → unaffected (no globalProjectFilter prop passed)
- Existing `#project=<id>` routing to ProjectDetail still works independently