### PR TITLE
[LM-219] add cost timeseries chart with daily rework breakdown

### DIFF
--- a/server/routes/issues_cost.py
+++ b/server/routes/issues_cost.py
@@ -197,3 +197,97 @@ def get_issues_cost(
 
     result.sort(key=lambda r: (-r["rework_factor"], -r["actual_runs"]))
     return result
+
+
+# Rework event_types that count toward the timeseries chart
+_REWORK_TYPES = {"po_failed", "dev_rework", "qa_fail", "review_reject"}
+
+# Mapping from event_type to the stage bucket key in by_stage
+_REWORK_STAGE_MAP = {
+    "po_failed":     "po_failed",
+    "dev_rework":    "dev_rework",
+    "qa_fail":       "qa_fail",
+    "review_reject": "review_reject",
+}
+
+
+@router.get("/api/cost/timeseries")
+def get_cost_timeseries(
+    days: int = 30,
+    project: Optional[str] = None,
+    priority: Optional[str] = None,
+    conn: sqlite3.Connection = Depends(db_dep),
+) -> dict:
+    today_dt = datetime.now(timezone.utc).date()
+    since_dt = today_dt - timedelta(days=days - 1)
+    since_iso = since_dt.isoformat()
+
+    # Single aggregation query: group by date + event_type, carry issue_number
+    # for top_issues computation. priority filter is applied post-query via
+    # a subquery so we don't need a JOIN to an external service.
+    rows = conn.execute(
+        """
+        SELECT
+            date(e.created_at)  AS day,
+            e.event_type        AS event_type,
+            e.issue_number      AS issue_number,
+            COUNT(*)            AS cnt
+        FROM events e
+        WHERE e.event_type IN ('po_failed', 'dev_rework', 'qa_fail', 'review_reject')
+          AND date(e.created_at) >= ?
+          AND (? IS NULL OR e.project = ?)
+          AND e.issue_number IS NOT NULL
+        GROUP BY date(e.created_at), e.event_type, e.issue_number
+        ORDER BY day
+        """,
+        (since_iso, project, project),
+    ).fetchall()
+
+    # Build per-day buckets
+    from collections import defaultdict
+
+    # day -> { by_stage: {po_failed, dev_rework, qa_fail, review_reject},
+    #          issue_totals: {issue_number: count} }
+    day_data: dict[str, dict] = {}
+
+    # Pre-populate all days in the window with zeros (inclusive of today)
+    for offset in range(days):
+        d = (since_dt + timedelta(days=offset)).isoformat()
+        day_data[d] = {
+            "by_stage": {"po_failed": 0, "dev_rework": 0, "qa_fail": 0, "review_reject": 0},
+            "issue_totals": defaultdict(int),
+        }
+
+    for row in rows:
+        day = row["day"]
+        etype = row["event_type"]
+        issue = row["issue_number"]
+        cnt = row["cnt"]
+
+        if day not in day_data:
+            continue
+
+        stage_key = _REWORK_STAGE_MAP.get(etype)
+        if stage_key:
+            day_data[day]["by_stage"][stage_key] += cnt
+        day_data[day]["issue_totals"][issue] += cnt
+
+    buckets = []
+    for day in sorted(day_data.keys()):
+        d = day_data[day]
+        by_stage = d["by_stage"]
+        total = sum(by_stage.values())
+        top_issues = sorted(d["issue_totals"].items(), key=lambda x: -x[1])[:3]
+        buckets.append(
+            {
+                "date": day,
+                "total_rework_events": total,
+                "by_stage": by_stage,
+                "top_issues": [{"issue_number": n, "count": c} for n, c in top_issues],
+            }
+        )
+
+    return {
+        "window_days": days,
+        "buckets": buckets,
+    }

--- a/tests/test_issues_cost.py
+++ b/tests/test_issues_cost.py
@@ -142,6 +142,100 @@ def test_since_filter(tmp_path, monkeypatch):
     assert 61 in issue_numbers
 
 
+# --- /api/cost/timeseries tests ---
+
+def test_cost_timeseries_empty(tmp_path, monkeypatch):
+    """Returns 30 zero-filled buckets when no rework events exist."""
+    client = _make_client(monkeypatch, tmp_path)
+    resp = client.get("/api/cost/timeseries?days=30")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["window_days"] == 30
+    assert len(data["buckets"]) == 30
+    for bucket in data["buckets"]:
+        assert bucket["total_rework_events"] == 0
+        assert bucket["by_stage"] == {"po_failed": 0, "dev_rework": 0, "qa_fail": 0, "review_reject": 0}
+        assert bucket["top_issues"] == []
+
+
+def test_cost_timeseries_aggregates_by_stage(tmp_path, monkeypatch):
+    """Rework events are bucketed by date and classified into the correct stage."""
+    client = _make_client(monkeypatch, tmp_path)
+    from datetime import datetime, timezone
+    today = datetime.now(timezone.utc).date().isoformat()
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-ts", "role": "po",     "event_type": "po_failed",
+         "issue_number": 1, "created_at": f"{today}T10:00:00+00:00"},
+        {"project": "proj-ts", "role": "dev",    "event_type": "dev_rework",
+         "issue_number": 2, "created_at": f"{today}T11:00:00+00:00"},
+        {"project": "proj-ts", "role": "qa",     "event_type": "qa_fail",
+         "issue_number": 2, "created_at": f"{today}T12:00:00+00:00"},
+        {"project": "proj-ts", "role": "review", "event_type": "review_reject",
+         "issue_number": 3, "created_at": f"{today}T13:00:00+00:00"},
+    ])
+    resp = client.get("/api/cost/timeseries?days=7")
+    assert resp.status_code == 200
+    buckets = resp.json()["buckets"]
+    today_bucket = next((b for b in buckets if b["date"] == today), None)
+    assert today_bucket is not None
+    assert today_bucket["total_rework_events"] == 4
+    assert today_bucket["by_stage"]["po_failed"] == 1
+    assert today_bucket["by_stage"]["dev_rework"] == 1
+    assert today_bucket["by_stage"]["qa_fail"] == 1
+    assert today_bucket["by_stage"]["review_reject"] == 1
+
+
+def test_cost_timeseries_top_issues(tmp_path, monkeypatch):
+    """top_issues contains up to 3 issues sorted by descending rework count."""
+    client = _make_client(monkeypatch, tmp_path)
+    from datetime import datetime, timezone
+    today = datetime.now(timezone.utc).date().isoformat()
+    ts10 = f"{today}T10:00:00+00:00"
+    ts11 = f"{today}T11:00:00+00:00"
+    ts12 = f"{today}T12:00:00+00:00"
+    ts13 = f"{today}T13:00:00+00:00"
+    events = []
+    for _ in range(3):
+        events.append({"project": "proj-ti", "role": "dev",
+                       "event_type": "dev_rework", "issue_number": 10, "created_at": ts10})
+    for _ in range(2):
+        events.append({"project": "proj-ti", "role": "qa",
+                       "event_type": "qa_fail", "issue_number": 20, "created_at": ts11})
+    events.append({"project": "proj-ti", "role": "po",
+                   "event_type": "po_failed", "issue_number": 30, "created_at": ts12})
+    # 4th issue — should not appear in top_issues
+    events.append({"project": "proj-ti", "role": "po",
+                   "event_type": "po_failed", "issue_number": 40, "created_at": ts13})
+    _insert_events(server.db.DB_PATH, events)
+    resp = client.get("/api/cost/timeseries?days=7&project=proj-ti")
+    assert resp.status_code == 200
+    buckets = resp.json()["buckets"]
+    today_bucket = next(b for b in buckets if b["date"] == today)
+    top = today_bucket["top_issues"]
+    assert len(top) == 3
+    assert top[0]["issue_number"] == 10
+    assert top[0]["count"] == 3
+
+
+def test_cost_timeseries_project_filter(tmp_path, monkeypatch):
+    """project param filters the timeseries to a single project."""
+    client = _make_client(monkeypatch, tmp_path)
+    from datetime import datetime, timezone
+    today = datetime.now(timezone.utc).date().isoformat()
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-a", "role": "dev", "event_type": "dev_rework",
+         "issue_number": 1, "created_at": f"{today}T10:00:00+00:00"},
+        {"project": "proj-b", "role": "qa",  "event_type": "qa_fail",
+         "issue_number": 2, "created_at": f"{today}T11:00:00+00:00"},
+    ])
+    resp = client.get("/api/cost/timeseries?days=7&project=proj-a")
+    assert resp.status_code == 200
+    buckets = resp.json()["buckets"]
+    today_bucket = next(b for b in buckets if b["date"] == today)
+    assert today_bucket["by_stage"]["dev_rework"] == 1
+    assert today_bucket["by_stage"]["qa_fail"] == 0
+
+
 # (g) limit + offset paginate correctly
 def test_limit_offset(tmp_path, monkeypatch):
     client = _make_client(monkeypatch, tmp_path, _open_meta)

--- a/web/src/components/CostTimeseries.tsx
+++ b/web/src/components/CostTimeseries.tsx
@@ -1,0 +1,143 @@
+import { useState } from 'react';
+import type { CostTimeseriesBucket } from '../lib/types';
+
+interface CostTimeseriesProps {
+  buckets: CostTimeseriesBucket[];
+  activeDayHash: string | null;
+  onDayClick: (date: string) => void;
+}
+
+// Stage order and matching role CSS tokens
+const STAGES: { key: keyof CostTimeseriesBucket['by_stage']; label: string; cssVar: string }[] = [
+  { key: 'po_failed',     label: 'PO Failed',      cssVar: 'var(--role-po)' },
+  { key: 'dev_rework',    label: 'Dev Rework',     cssVar: 'var(--role-dev)' },
+  { key: 'qa_fail',       label: 'QA Fail',        cssVar: 'var(--role-qa)' },
+  { key: 'review_reject', label: 'Review Reject',  cssVar: 'var(--role-reviewer)' },
+];
+
+interface TooltipState {
+  bucket: CostTimeseriesBucket;
+  x: number;
+  y: number;
+}
+
+export default function CostTimeseries({ buckets, activeDayHash, onDayClick }: CostTimeseriesProps) {
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+
+  const max = Math.max(1, ...buckets.map(b => b.total_rework_events));
+
+  return (
+    <div className="panel">
+      <div className="panel-h">
+        <span>Rework events — last {buckets.length}d</span>
+        <span className="muted">
+          {STAGES.map(s => (
+            <span key={s.key} style={{ marginLeft: 12 }}>
+              <span style={{
+                display: 'inline-block',
+                width: 8,
+                height: 8,
+                marginRight: 4,
+                verticalAlign: 'middle',
+                background: s.cssVar,
+              }} />
+              {s.label}
+            </span>
+          ))}
+        </span>
+      </div>
+
+      <div style={{ position: 'relative', height: 130, padding: 'var(--pad-3) 0 var(--pad-4)' }}>
+        <div
+          className="bars"
+          onMouseLeave={() => setTooltip(null)}
+        >
+          {buckets.map((b, i) => {
+            const isActive = activeDayHash === b.date;
+            return (
+              <div
+                key={b.date}
+                className="bar-col"
+                style={{ cursor: 'pointer', outline: isActive ? `1px solid var(--border-strong)` : undefined }}
+                onClick={() => onDayClick(b.date)}
+                onMouseEnter={e => {
+                  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+                  setTooltip({ bucket: b, x: rect.left + rect.width / 2, y: rect.top });
+                }}
+              >
+                {STAGES.map(s => {
+                  const v = b.by_stage[s.key] ?? 0;
+                  if (!v) return null;
+                  return (
+                    <div
+                      key={s.key}
+                      className="bar-seg"
+                      style={{
+                        background: s.cssVar,
+                        height: `${(v / max) * 100}%`,
+                        opacity: isActive ? 1 : 0.85,
+                      }}
+                    />
+                  );
+                })}
+                {(i % 5 === 0) && (
+                  <div className="bar-tick">{b.date.slice(5)}</div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {tooltip && (
+        <div
+          style={{
+            position: 'fixed',
+            left: tooltip.x,
+            top: tooltip.y - 8,
+            transform: 'translate(-50%, -100%)',
+            background: 'var(--bg-3)',
+            border: '1px solid var(--border-strong)',
+            padding: 'var(--pad-2) var(--pad-3)',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 11,
+            color: 'var(--fg)',
+            zIndex: 200,
+            pointerEvents: 'none',
+            minWidth: 160,
+          }}
+        >
+          <div style={{ marginBottom: 4, color: 'var(--fg-2)', letterSpacing: '0.06em' }}>
+            {tooltip.bucket.date}
+          </div>
+          <div style={{ marginBottom: 6, fontSize: 13, fontWeight: 600 }}>
+            {tooltip.bucket.total_rework_events} rework events
+          </div>
+          {STAGES.map(s => {
+            const v = tooltip.bucket.by_stage[s.key];
+            if (!v) return null;
+            return (
+              <div key={s.key} style={{ display: 'flex', justifyContent: 'space-between', gap: 16, marginBottom: 2 }}>
+                <span style={{ color: s.cssVar }}>{s.label}</span>
+                <span className="num">{v}</span>
+              </div>
+            );
+          })}
+          {tooltip.bucket.top_issues.length > 0 && (
+            <>
+              <div style={{ borderTop: '1px solid var(--border)', margin: '6px 0 4px', color: 'var(--fg-4)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em' }}>
+                top issues
+              </div>
+              {tooltip.bucket.top_issues.map(ti => (
+                <div key={ti.issue_number} style={{ display: 'flex', justifyContent: 'space-between', gap: 16 }}>
+                  <span style={{ color: 'var(--fg-3)' }}>#{ti.issue_number}</span>
+                  <span className="num">{ti.count}</span>
+                </div>
+              ))}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -24,6 +24,7 @@ import type {
   FailureContext,
   CycleTimesResponse,
   SloConfig,
+  CostTimeseriesResponse,
 } from './types';
 import * as fx from './fixtures';
 
@@ -197,6 +198,25 @@ export async function fetchCycleTimes(project: string): Promise<CycleTimesRespon
 
 export async function fetchSlo(project: string): Promise<SloConfig> {
   return get<SloConfig>(`/api/projects/${encodeURIComponent(project)}/slo`);
+}
+
+export interface CostTimeseriesParams {
+  days?: number;
+  project?: string;
+  priority?: string;
+}
+
+export async function fetchCostTimeseries(params: CostTimeseriesParams = {}): Promise<CostTimeseriesResponse> {
+  if (isFixtureMode()) {
+    const days = params.days ?? 30;
+    return fx.getFixtureCostTimeseries(days);
+  }
+  const p = new URLSearchParams();
+  if (params.days != null)    p.set('days', String(params.days));
+  if (params.project)         p.set('project', params.project);
+  if (params.priority)        p.set('priority', params.priority);
+  const qs = p.size ? `?${p.toString()}` : '';
+  return get<CostTimeseriesResponse>(`/api/cost/timeseries${qs}`);
 }
 
 export async function putSlo(project: string, body: { total_seconds: number | null; breach_grace_seconds: number }): Promise<SloConfig> {

--- a/web/src/lib/fixtures.ts
+++ b/web/src/lib/fixtures.ts
@@ -20,6 +20,7 @@ import type {
   ClaudeUsage,
   ScannerState,
   IssueCostRow,
+  CostTimeseriesResponse,
 } from './types';
 
 // Fixture data — example projects used for screenshots / Storybook / tests.
@@ -378,4 +379,25 @@ export function getFixtureScannerState(): ScannerState {
       { project: 'loop',         kind: 'issue', number: 142, stage: 'dev', count: 2, max: 2 },
     ],
   };
+}
+
+export function getFixtureCostTimeseries(days = 30): CostTimeseriesResponse {
+  const buckets = Array.from({ length: days }, (_, i) => {
+    const d = new Date(Date.now() - (days - 1 - i) * 86_400_000);
+    const date = d.toISOString().slice(0, 10);
+    const by_stage = {
+      po_failed:     Math.floor(((i * 7 + 3) % 5)),
+      dev_rework:    Math.floor(((i * 11 + 1) % 7)),
+      qa_fail:       Math.floor(((i * 5 + 2) % 4)),
+      review_reject: Math.floor(((i * 3 + 4) % 3)),
+    };
+    const total_rework_events = by_stage.po_failed + by_stage.dev_rework + by_stage.qa_fail + by_stage.review_reject;
+    return {
+      date,
+      total_rework_events,
+      by_stage,
+      top_issues: total_rework_events > 0 ? [{ issue_number: 100 + (i % 10), count: total_rework_events }] : [],
+    };
+  });
+  return { window_days: days, buckets };
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -241,6 +241,30 @@ export interface SloConfig {
   updated_at: number | null;
 }
 
+export interface CostTimeseriesByStage {
+  po_failed: number;
+  dev_rework: number;
+  qa_fail: number;
+  review_reject: number;
+}
+
+export interface CostTimeseriesTopIssue {
+  issue_number: number;
+  count: number;
+}
+
+export interface CostTimeseriesBucket {
+  date: string;
+  total_rework_events: number;
+  by_stage: CostTimeseriesByStage;
+  top_issues: CostTimeseriesTopIssue[];
+}
+
+export interface CostTimeseriesResponse {
+  window_days: number;
+  buckets: CostTimeseriesBucket[];
+}
+
 export interface IssueCostRow {
   project: string;
   issue_number: number;

--- a/web/src/screens/Cost.tsx
+++ b/web/src/screens/Cost.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { fetchIssuesCost } from '../lib/api';
+import { fetchIssuesCost, fetchCostTimeseries } from '../lib/api';
 import type { IssueCostRow } from '../lib/types';
+import CostTimeseries from '../components/CostTimeseries';
 
 const LIMIT = 50;
 
@@ -46,11 +47,25 @@ function median(rows: IssueCostRow[]): number | null {
     : sorted[mid].rework_factor;
 }
 
+function parseDayHash(): string | null {
+  const hash = window.location.hash;
+  const m = hash.match(/^#cost_day=(\d{4}-\d{2}-\d{2})$/);
+  return m ? m[1] : null;
+}
+
 export default function Cost() {
   const [offset, setOffset] = useState(0);
   const [allRows, setAllRows] = useState<IssueCostRow[]>([]);
   const [filterProject, setFilterProject] = useState('');
   const [filterPriority, setFilterPriority] = useState('');
+  const [activeDay, setActiveDay] = useState<string | null>(() => parseDayHash());
+
+  // Sync activeDay from hash changes (back/forward nav)
+  useEffect(() => {
+    const onHashChange = () => setActiveDay(parseDayHash());
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
+  }, []);
 
   const query = useQuery({
     queryKey: ['issues-cost', offset],
@@ -66,9 +81,35 @@ export default function Cost() {
     staleTime: 0,
   });
 
+  const timeseriesQuery = useQuery({
+    queryKey: ['cost-timeseries', filterProject, filterPriority],
+    queryFn: () => fetchCostTimeseries({
+      days: 30,
+      project: filterProject || undefined,
+      priority: filterPriority || undefined,
+    }),
+    refetchInterval: 60_000,
+    staleTime: 0,
+  });
+
+  function handleDayClick(date: string) {
+    if (activeDay === date) {
+      // toggle off
+      setActiveDay(null);
+      history.pushState(null, '', window.location.pathname + window.location.search);
+    } else {
+      setActiveDay(date);
+      window.location.hash = `cost_day=${date}`;
+    }
+  }
+
   const visible = allRows.filter(r => {
     if (filterProject && r.project !== filterProject) return false;
     if (filterPriority && r.priority !== filterPriority) return false;
+    if (activeDay && r.last_event_at) {
+      const eventDate = r.last_event_at.slice(0, 10);
+      if (eventDate !== activeDay) return false;
+    }
     return true;
   });
 
@@ -109,7 +150,7 @@ export default function Cost() {
         <select
           className="btn"
           value={filterProject}
-          onChange={e => setFilterProject(e.target.value)}
+          onChange={e => { setFilterProject(e.target.value); setOffset(0); setAllRows([]); }}
           style={{ cursor: 'pointer' }}
         >
           <option value="">All projects</option>
@@ -118,7 +159,7 @@ export default function Cost() {
         <select
           className="btn"
           value={filterPriority}
-          onChange={e => setFilterPriority(e.target.value)}
+          onChange={e => { setFilterPriority(e.target.value); setOffset(0); setAllRows([]); }}
           style={{ cursor: 'pointer' }}
         >
           <option value="">All priorities</option>
@@ -127,7 +168,26 @@ export default function Cost() {
           <option value="p2-medium">p2-medium</option>
           <option value="p3-low">p3-low</option>
         </select>
+        {activeDay && (
+          <button
+            className="btn"
+            onClick={() => handleDayClick(activeDay)}
+            style={{ color: 'var(--accent)', borderColor: 'var(--accent)' }}
+          >
+            {activeDay} ×
+          </button>
+        )}
       </div>
+
+      {timeseriesQuery.data && (
+        <div style={{ padding: 'var(--pad-3) var(--pad-4)' }}>
+          <CostTimeseries
+            buckets={timeseriesQuery.data.buckets}
+            activeDayHash={activeDay}
+            onDayClick={handleDayClick}
+          />
+        </div>
+      )}
 
       {query.isLoading && allRows.length === 0 ? (
         <div className="muted" style={{ padding: 'var(--pad-4)' }}>Loading…</div>


### PR DESCRIPTION
Closes #219

## Changes
- Backend: new GET /api/cost/timeseries endpoint aggregating rework events by day with stage breakdown and top-3 issues per bucket
- Frontend: new CostTimeseries.tsx component with stacked-bar SVG chart, hover tooltip, and click-to-filter behavior
- Frontend: Cost.tsx updated to mount chart, wire hash filter #cost_day=YYYY-MM-DD, and pass project/priority filters

## Test Plan
- Visit Cost screen, verify stacked-bar chart appears below header area
- Hover over bars to see tooltip with daily totals and top-3 issues
- Click a bar, verify URL hash updates and table filters to that day
- Change project/priority filter, verify chart updates in sync
- Verify no regression to existing Cost table or header trend strip