### PR TITLE
[LM-245] add Analytics screen shell + nav rail entry

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -121,7 +121,7 @@ export default function App() {
       <main className="main">
         {showCost ? (
           <Cost />
-        ) : showAnalytics ? (
+        ) : (showAnalytics || hashNavScreen === 'analytics') ? (
           <Analytics />
         ) : isProjectDetail && projectId != null ? (
           <ProjectDetail

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import ProjectDetail from './screens/ProjectDetail';
 import Queue from './screens/Queue';
 import WorkerDetail from './screens/WorkerDetail';
 import Cost from './screens/Cost';
+import Analytics from './screens/Analytics';
 import { useHashRoute } from './router';
 import { fetchActive, fetchHealth } from './lib/api';
 
@@ -19,18 +20,20 @@ const SCREEN_KEYS: Record<string, string> = {
   '4': 'workers',
   '5': 'logs',
   '6': 'cost',
+  '7': 'analytics',
 };
 
 export default function App() {
   const { screen: hashScreen, projectId: hashProjectId, navigateTo } = useHashRoute();
 
-  // 'cost' is local-only — not stored in the hash — so we track it separately.
+  // 'cost' and 'analytics' are local-only — not stored in the hash — so we track them separately.
   const [showCost, setShowCost] = useState(false);
+  const [showAnalytics, setShowAnalytics] = useState(false);
 
   // Derive nav screen from hash. 'project' is a sub-state of 'projects' nav item.
   const hashNavScreen = hashScreen === 'project' ? 'projects' : hashScreen;
-  // When cost is active, override; otherwise use hash-derived value.
-  const navScreen = showCost ? 'cost' : hashNavScreen;
+  // When cost or analytics is active, override; otherwise use hash-derived value.
+  const navScreen = showCost ? 'cost' : showAnalytics ? 'analytics' : hashNavScreen;
   const projectId = hashProjectId;
 
   const [allProjectIds, setAllProjectIds] = useState<string[]>([]);
@@ -46,16 +49,22 @@ export default function App() {
       .catch(() => undefined);
   }, []);
 
-  // When hash changes externally (back/forward), clear cost overlay
+  // When hash changes externally (back/forward), clear overlays
   useEffect(() => {
     setShowCost(false);
+    setShowAnalytics(false);
   }, [hashScreen]);
 
   function handleNavChange(s: string) {
     if (s === 'cost') {
       setShowCost(true);
+      setShowAnalytics(false);
+    } else if (s === 'analytics') {
+      setShowAnalytics(true);
+      setShowCost(false);
     } else {
       setShowCost(false);
+      setShowAnalytics(false);
       navigateTo(s as 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs', null, {
         drawer: null,
         pushState: true,
@@ -112,6 +121,8 @@ export default function App() {
       <main className="main">
         {showCost ? (
           <Cost />
+        ) : showAnalytics ? (
+          <Analytics />
         ) : isProjectDetail && projectId != null ? (
           <ProjectDetail
             projectId={projectId}

--- a/web/src/components/NavRail.tsx
+++ b/web/src/components/NavRail.tsx
@@ -40,6 +40,11 @@ const NAV_ICONS: Record<string, ReactNode> = {
       <rect x="17" y="4" width="4" height="17"/>
     </svg>
   ),
+  analytics: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <circle cx="12" cy="12" r="9"/><path d="M12 3v9l5 5"/>
+    </svg>
+  ),
   settings: (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
       <circle cx="12" cy="12" r="3"/>
@@ -55,7 +60,8 @@ export default function NavRail({ screen, setScreen }: NavRailProps) {
     { id: 'projects', label: 'Projects' },
     { id: 'workers',  label: 'Workers' },
     { id: 'logs',     label: 'Logs' },
-    { id: 'cost',     label: 'Cost' },
+    { id: 'cost',      label: 'Cost' },
+    { id: 'analytics', label: 'Analytics' },
   ];
   return (
     <div className="nav">

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
-export type Screen = 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs';
+export type Screen = 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs' | 'analytics';
 
 export interface HashRoute {
   screen: Screen;

--- a/web/src/screens/Analytics.tsx
+++ b/web/src/screens/Analytics.tsx
@@ -1,0 +1,50 @@
+export default function Analytics() {
+  return (
+    <div>
+      <div className="screen-h">
+        <h1>Analytics</h1>
+      </div>
+      <div style={{
+        padding: 'var(--pad-4)',
+        display: 'grid',
+        gridTemplateColumns: '1fr 1fr',
+        gap: 'var(--pad-3)',
+      }}>
+        <section className="panel" style={{ gridColumn: '1 / -1' }}>
+          <div className="panel-h"><span>Velocity</span></div>
+          <div style={{ padding: 'var(--pad-3) var(--pad-4)', color: 'var(--fg-4)', fontFamily: 'var(--font-mono)', fontSize: 12 }}>
+            Coming soon
+          </div>
+        </section>
+
+        <section className="panel">
+          <div className="panel-h"><span>Cycle time</span></div>
+          <div style={{ padding: 'var(--pad-3) var(--pad-4)', color: 'var(--fg-4)', fontFamily: 'var(--font-mono)', fontSize: 12 }}>
+            Coming soon
+          </div>
+        </section>
+
+        <section className="panel">
+          <div className="panel-h"><span>Quality</span></div>
+          <div style={{ padding: 'var(--pad-3) var(--pad-4)', color: 'var(--fg-4)', fontFamily: 'var(--font-mono)', fontSize: 12 }}>
+            Coming soon
+          </div>
+        </section>
+
+        <section className="panel">
+          <div className="panel-h"><span>Capacity</span></div>
+          <div style={{ padding: 'var(--pad-3) var(--pad-4)', color: 'var(--fg-4)', fontFamily: 'var(--font-mono)', fontSize: 12 }}>
+            Coming soon
+          </div>
+        </section>
+
+        <section className="panel">
+          <div className="panel-h"><span>Flow</span></div>
+          <div style={{ padding: 'var(--pad-3) var(--pad-4)', color: 'var(--fg-4)', fontFamily: 'var(--font-mono)', fontSize: 12 }}>
+            Coming soon
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #245

## Changes
- Add `web/src/screens/Analytics.tsx` — shell screen with 5 named slots (velocity, cycle-time, quality, capacity, flow), each an empty `<section>` with "Coming soon" placeholder. No data fetching, no state.
- Add `analytics` to the `Screen` type in `web/src/router.tsx`
- Add Analytics nav rail entry to `web/src/components/NavRail.tsx` (clock icon, key `7`)
- Wire Analytics into `web/src/App.tsx` alongside the existing cost overlay pattern

Layout matches existing Overview/Cost screens using existing spacing tokens and panel chrome from Activity24h. No new color tokens introduced.

## Test Plan
- Navigate to Analytics via nav rail — screen renders with 5 labelled slots
- Press `7` keyboard shortcut — Analytics screen activates
- Nav rail shows Analytics entry; highlights when active
- `npm run build` in web/ succeeds
- No regressions on other screens' navigation