### PR TITLE
[LM-246] Velocity panel + /api/analytics/velocity

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -18,6 +18,7 @@ app = FastAPI(title="Loop Monitor", lifespan=lifespan)
 
 from server.routes import (  # noqa: E402
     action_queue,
+    analytics_velocity,
     board,
     claude_usage,
     config,
@@ -35,6 +36,7 @@ from server.routes import (  # noqa: E402
 
 app.include_router(health.router)
 app.include_router(ingest.router)
+app.include_router(analytics_velocity.router)
 app.include_router(board.router)
 app.include_router(feed.router)
 app.include_router(runs.router)

--- a/server/routes/analytics_velocity.py
+++ b/server/routes/analytics_velocity.py
@@ -1,0 +1,136 @@
+import sqlite3
+from datetime import date, datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from server.db import db_dep
+
+router = APIRouter()
+
+
+def _utc_today() -> date:
+    return datetime.now(timezone.utc).date()
+
+
+def _date_range(start: date, days: int) -> list[date]:
+    """Return a list of `days` dates starting at `start` (inclusive)."""
+    return [start + timedelta(days=i) for i in range(days)]
+
+
+@router.get("/api/analytics/velocity")
+def get_velocity(
+    days: Optional[str] = Query(default="30", description="Window in days (1–365)"),
+    project: Optional[str] = Query(default=None, description="Filter by project slug"),
+    conn: sqlite3.Connection = Depends(db_dep),
+):
+    """Merge velocity metrics from pipeline_runs.
+
+    A run is counted as 'merged' when outcome = 'clean'.  This matches the
+    success_rate calculation in /api/stats which uses the same column/value.
+    Alternative: outcome = 'merged' if the pipeline writes that value — but
+    current ingest uses 'clean' for successfully merged issues.
+    """
+    # Validate and parse days: must be an integer string, else 400.
+    try:
+        days_int = int(days)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=400, detail="days must be an integer")
+
+    # Clamp to [1, 365]
+    days_int = max(1, min(365, days_int))
+
+    today = _utc_today()
+    window_start = today - timedelta(days=days_int - 1)  # inclusive
+
+    # ── daily counts within the requested window ──────────────────────────────
+    proj_filter = "AND project = ?" if project else ""
+    params_window: list = [str(window_start)]
+    if project:
+        params_window.append(project)
+
+    daily_rows = conn.execute(
+        f"""
+        SELECT DATE(completed_at) AS day, COUNT(*) AS cnt
+        FROM pipeline_runs
+        WHERE outcome = 'clean'
+          AND DATE(completed_at) >= ?
+          {proj_filter}
+        GROUP BY DATE(completed_at)
+        ORDER BY DATE(completed_at)
+        """,
+        params_window,
+    ).fetchall()
+
+    # Build a zero-filled dict for every date in the window
+    daily_map: dict[str, int] = {str(window_start + timedelta(days=i)): 0 for i in range(days_int)}
+    for row in daily_rows:
+        if row["day"] in daily_map:
+            daily_map[row["day"]] = row["cnt"]
+
+    daily_list = [{"date": d, "count": daily_map[d]} for d in sorted(daily_map)]
+
+    # ── scalar aggregates ──────────────────────────────────────────────────────
+    today_str = str(today)
+    today_count = daily_map.get(today_str, 0)
+
+    total_merged = sum(daily_map.values())
+    avg_per_day = round(total_merged / days_int, 2)
+
+    # Trend: compare last 7 days vs previous 7 days
+    last7_start = today - timedelta(days=6)
+    prev7_start = today - timedelta(days=13)
+    prev7_end   = today - timedelta(days=7)
+
+    last7 = sum(
+        cnt for d, cnt in daily_map.items()
+        if str(last7_start) <= d <= today_str
+    )
+    prev7 = sum(
+        cnt for d, cnt in daily_map.items()
+        if str(prev7_start) <= d <= str(prev7_end)
+    )
+
+    last7_avg = last7 / 7
+    prev7_avg = prev7 / 7
+
+    if prev7_avg == 0.0:
+        trend_pct = 0.0
+    else:
+        trend_pct = round(((last7_avg - prev7_avg) / prev7_avg) * 100, 1)
+
+    prev_period_avg = round(prev7_avg, 2)
+
+    # ── per-project breakdown ─────────────────────────────────────────────────
+    per_project: list[dict] = []
+    if not project:
+        proj_rows = conn.execute(
+            """
+            SELECT
+                project AS slug,
+                SUM(CASE WHEN DATE(completed_at) = ? THEN 1 ELSE 0 END) AS today_cnt,
+                COUNT(*) AS total_cnt
+            FROM pipeline_runs
+            WHERE outcome = 'clean'
+              AND DATE(completed_at) >= ?
+            GROUP BY project
+            ORDER BY total_cnt DESC
+            """,
+            [today_str, str(window_start)],
+        ).fetchall()
+
+        for r in proj_rows:
+            per_project.append({
+                "slug": r["slug"],
+                "today": r["today_cnt"],
+                "avg_per_day": round(r["total_cnt"] / days_int, 2),
+            })
+
+    return {
+        "today": today_count,
+        "avg_per_day": avg_per_day,
+        "prev_period_avg": prev_period_avg,
+        "trend_pct": trend_pct,
+        "daily": daily_list,
+        "per_project": per_project,
+    }

--- a/tests/test_analytics_velocity.py
+++ b/tests/test_analytics_velocity.py
@@ -1,0 +1,119 @@
+"""Tests for GET /api/analytics/velocity.
+
+Scenarios:
+  a) empty table → all-zero response, no div-by-zero
+  b) seeded rows → today, avg_per_day, daily, per_project reflect them
+  c) project=<slug> filter restricts count
+  d) invalid days param → 400
+"""
+import sqlite3
+from datetime import datetime, timezone
+
+import server.db
+
+
+def _insert_run(conn: sqlite3.Connection, project: str, completed_at: str, outcome: str = "clean") -> None:
+    conn.execute(
+        """INSERT INTO pipeline_runs (project, issue_number, outcome, completed_at, created_at)
+           VALUES (?, ?, ?, ?, ?)""",
+        (project, 1, outcome, completed_at, completed_at),
+    )
+    conn.commit()
+
+
+# ── a) empty table ────────────────────────────────────────────────────────────
+
+def test_velocity_empty_table(isolated_client):
+    """All-zero response when pipeline_runs is empty — no division by zero."""
+    resp = isolated_client.get("/api/analytics/velocity?days=30")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["today"] == 0
+    assert data["avg_per_day"] == 0.0
+    assert data["prev_period_avg"] == 0.0
+    assert data["trend_pct"] == 0.0
+    assert len(data["daily"]) == 30
+    assert data["per_project"] == []
+
+    # every daily bucket should be zero
+    for bucket in data["daily"]:
+        assert bucket["count"] == 0
+
+
+# ── b) seeded rows ────────────────────────────────────────────────────────────
+
+def test_velocity_with_seeded_rows(isolated_client):
+    """today count, avg_per_day, daily list, and per_project reflect inserted rows."""
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.row_factory = sqlite3.Row
+
+    # Use today's UTC date so the 'today' field is populated
+    today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    _insert_run(conn, "alpha", f"{today_str}T10:00:00")
+    _insert_run(conn, "alpha", f"{today_str}T11:00:00")
+    _insert_run(conn, "beta",  f"{today_str}T12:00:00")
+    conn.close()
+
+    resp = isolated_client.get("/api/analytics/velocity?days=30")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # 3 merged today across both projects
+    assert data["today"] == 3
+    # avg across 30 days = 3 / 30
+    assert data["avg_per_day"] == round(3 / 30, 2)
+
+    # daily list has 30 entries and the last entry (today) has count 3
+    assert len(data["daily"]) == 30
+    last_bucket = data["daily"][-1]
+    assert last_bucket["date"] == today_str
+    assert last_bucket["count"] == 3
+
+    # per_project: both projects present
+    slugs = {p["slug"] for p in data["per_project"]}
+    assert "alpha" in slugs
+    assert "beta" in slugs
+
+    alpha = next(p for p in data["per_project"] if p["slug"] == "alpha")
+    assert alpha["today"] == 2
+
+    beta = next(p for p in data["per_project"] if p["slug"] == "beta")
+    assert beta["today"] == 1
+
+
+# ── c) project filter ─────────────────────────────────────────────────────────
+
+def test_velocity_project_filter(isolated_client):
+    """project= query param restricts counts to that slug only."""
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.row_factory = sqlite3.Row
+
+    today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    _insert_run(conn, "proj-a", f"{today_str}T09:00:00")
+    _insert_run(conn, "proj-a", f"{today_str}T09:30:00")
+    _insert_run(conn, "proj-b", f"{today_str}T10:00:00")
+    conn.close()
+
+    # Filter to proj-a only
+    resp = isolated_client.get("/api/analytics/velocity?days=30&project=proj-a")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["today"] == 2
+    # per_project is empty when a project filter is active
+    assert data["per_project"] == []
+
+    # proj-b should not contribute
+    resp_b = isolated_client.get("/api/analytics/velocity?days=30&project=proj-b")
+    assert resp_b.status_code == 200
+    data_b = resp_b.json()
+    assert data_b["today"] == 1
+
+
+# ── d) invalid days param → 400 ───────────────────────────────────────────────
+
+def test_velocity_invalid_days_returns_400(isolated_client):
+    """Non-integer days value must return HTTP 400."""
+    resp = isolated_client.get("/api/analytics/velocity?days=abc")
+    assert resp.status_code == 400

--- a/web/src/panels/Velocity.tsx
+++ b/web/src/panels/Velocity.tsx
@@ -1,0 +1,258 @@
+import { useQuery } from '@tanstack/react-query';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface DailyBucket {
+  date: string;
+  count: number;
+}
+
+interface PerProjectVelocity {
+  slug: string;
+  today: number;
+  avg_per_day: number;
+}
+
+interface VelocityResponse {
+  today: number;
+  avg_per_day: number;
+  prev_period_avg: number;
+  trend_pct: number;
+  daily: DailyBucket[];
+  per_project: PerProjectVelocity[];
+}
+
+// ── API fetch ─────────────────────────────────────────────────────────────────
+
+async function fetchVelocity(days = 30, project?: string): Promise<VelocityResponse> {
+  const p = new URLSearchParams({ days: String(days) });
+  if (project) p.set('project', project);
+  const res = await fetch(`/api/analytics/velocity?${p.toString()}`);
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.json() as Promise<VelocityResponse>;
+}
+
+// ── Sparkline (inline SVG — no dependency) ────────────────────────────────────
+
+function Sparkline({ data }: { data: DailyBucket[] }) {
+  if (data.length < 2) return null;
+
+  const counts = data.map(d => d.count);
+  const max = Math.max(1, ...counts);
+  const W = 200;
+  const H = 36;
+  const step = W / (counts.length - 1);
+
+  const points = counts
+    .map((c, i) => `${i * step},${H - (c / max) * (H - 4)}`)
+    .join(' ');
+
+  return (
+    <svg
+      width={W}
+      height={H}
+      viewBox={`0 0 ${W} ${H}`}
+      aria-hidden="true"
+      style={{ display: 'block', overflow: 'visible' }}
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke="var(--accent)"
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+// ── Big-number KPI cell ───────────────────────────────────────────────────────
+
+function KpiCell({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: React.ReactNode;
+  sub?: React.ReactNode;
+}) {
+  return (
+    <div style={{ flex: 1, padding: 'var(--pad-3) var(--pad-4)', borderRight: '1px solid var(--border)' }}>
+      <div
+        style={{
+          fontSize: 10,
+          fontFamily: 'var(--font-mono)',
+          textTransform: 'uppercase',
+          letterSpacing: '0.1em',
+          color: 'var(--fg-3)',
+          marginBottom: 'var(--pad-1)',
+        }}
+      >
+        {label}
+      </div>
+      <div
+        className="num"
+        style={{
+          fontSize: 24,
+          fontFamily: 'var(--font-mono)',
+          fontVariantNumeric: 'tabular-nums',
+          color: 'var(--fg)',
+          lineHeight: 1,
+        }}
+      >
+        {value}
+      </div>
+      {sub != null && (
+        <div
+          style={{
+            fontSize: 10,
+            fontFamily: 'var(--font-mono)',
+            color: 'var(--fg-3)',
+            marginTop: 'var(--pad-1)',
+          }}
+        >
+          {sub}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Trend arrow + percentage ──────────────────────────────────────────────────
+
+function TrendBadge({ pct }: { pct: number }) {
+  if (pct === 0) {
+    return <span style={{ color: 'var(--fg-3)' }}>— 0%</span>;
+  }
+  const up = pct > 0;
+  return (
+    <span style={{ color: up ? 'var(--pass)' : 'var(--fail)' }}>
+      {up ? '▲' : '▼'} {Math.abs(pct)}%
+    </span>
+  );
+}
+
+// ── Props ─────────────────────────────────────────────────────────────────────
+
+interface VelocityProps {
+  days?: number;
+  project?: string;
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export default function Velocity({ days = 30, project }: VelocityProps) {
+  const { data, isLoading, isError } = useQuery<VelocityResponse>({
+    queryKey: ['analytics-velocity', days, project ?? ''],
+    queryFn: () => fetchVelocity(days, project),
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+
+  return (
+    <div className="panel">
+      <div className="panel-h">
+        <span>Merge velocity</span>
+        {project && (
+          <span className="muted" style={{ fontFamily: 'var(--font-mono)', fontSize: 10 }}>
+            {project}
+          </span>
+        )}
+      </div>
+
+      {isLoading && (
+        <div
+          style={{
+            padding: 'var(--pad-4)',
+            color: 'var(--fg-3)',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 11,
+          }}
+        >
+          Loading…
+        </div>
+      )}
+
+      {isError && (
+        <div
+          style={{
+            padding: 'var(--pad-4)',
+            color: 'var(--fail)',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 11,
+          }}
+        >
+          Failed to load velocity data
+        </div>
+      )}
+
+      {data && (
+        <>
+          {/* KPI strip */}
+          <div style={{ display: 'flex', borderBottom: '1px solid var(--border)' }}>
+            <KpiCell label="Today" value={data.today} />
+            <KpiCell
+              label="7-Day Avg"
+              value={(data.avg_per_day).toFixed(1)}
+              sub={`prev ${data.prev_period_avg.toFixed(1)}/day`}
+            />
+            <KpiCell
+              label="30-Day Trend"
+              value={<TrendBadge pct={data.trend_pct} />}
+              sub="vs prior 7 days"
+            />
+          </div>
+
+          {/* Sparkline */}
+          {data.daily.length > 1 && (
+            <div
+              style={{
+                padding: 'var(--pad-3) var(--pad-4)',
+                borderBottom: data.per_project.length > 0 ? '1px solid var(--border)' : undefined,
+              }}
+            >
+              <Sparkline data={data.daily} />
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  marginTop: 'var(--pad-1)',
+                  fontSize: 9,
+                  fontFamily: 'var(--font-mono)',
+                  color: 'var(--fg-4)',
+                }}
+              >
+                <span>{data.daily[0]?.date?.slice(5)}</span>
+                <span>{data.daily[data.daily.length - 1]?.date?.slice(5)}</span>
+              </div>
+            </div>
+          )}
+
+          {/* Per-project table */}
+          {data.per_project.length > 0 && (
+            <table className="t" style={{ width: '100%' }}>
+              <thead>
+                <tr>
+                  <th>Project</th>
+                  <th style={{ textAlign: 'right' }}>Today</th>
+                  <th style={{ textAlign: 'right' }}>Avg/day</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.per_project.map(p => (
+                  <tr key={p.slug}>
+                    <td style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>{p.slug}</td>
+                    <td className="num" style={{ textAlign: 'right' }}>{p.today}</td>
+                    <td className="num" style={{ textAlign: 'right' }}>{p.avg_per_day.toFixed(2)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/src/screens/Analytics.tsx
+++ b/web/src/screens/Analytics.tsx
@@ -1,0 +1,10 @@
+import Velocity from '../panels/Velocity';
+
+export default function Analytics() {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--pad-3)', padding: 'var(--pad-3)' }}>
+      {/* velocity slot */}
+      <Velocity />
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #246

## Changes
- New `GET /api/analytics/velocity` endpoint in `server/routes/analytics_velocity.py`: queries `pipeline_runs` using `outcome = 'clean'` (matching existing `stats.py` analytics), computes today count, 7-day/30-day averages, trend%, daily buckets, per-project breakdown
- Registered router in `server/app.py`
- New `web/src/panels/Velocity.tsx`: three big numbers (TODAY / 7-DAY AVG / 30-DAY TREND with arrow + %) + sparkline + per-project table, matching Activity24h density/typography
- Created `web/src/screens/Analytics.tsx` with `<Velocity />` in the velocity slot
- Backend pytest in `tests/test_analytics_velocity.py`: empty table, seeded rows, project filter, invalid days→400

## Test Plan
- `ruff check .` passes
- `cd web && npm run typecheck && npm run build` passes
- `pytest tests/test_analytics_velocity.py` passes (all 4 scenarios)
- Analytics dashboard shows Velocity panel with correct data