### PR TITLE
[LM-247] add cycle-time analytics endpoint + panel

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -18,6 +18,7 @@ app = FastAPI(title="Loop Monitor", lifespan=lifespan)
 
 from server.routes import (  # noqa: E402
     action_queue,
+    analytics,
     board,
     claude_usage,
     config,
@@ -33,6 +34,7 @@ from server.routes import (  # noqa: E402
     stats,
 )
 
+app.include_router(analytics.router)
 app.include_router(health.router)
 app.include_router(ingest.router)
 app.include_router(board.router)

--- a/server/routes/analytics.py
+++ b/server/routes/analytics.py
@@ -1,0 +1,112 @@
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+
+from server.db import db_dep
+from server.routes.stats import _compute_stage_durations, _parse_ts_unix
+
+router = APIRouter()
+
+# The 7 stage transitions defined in the analytics epic (#235).
+_STAGE_TRANSITIONS = [
+    "needs-po->in-po",
+    "in-po->needs-dev",
+    "in-dev->needs-review",
+    "needs-review->in-review",
+    "in-review->needs-qa",
+    "needs-qa->qa-pass",
+    "qa-pass->done",
+]
+
+
+def _since_iso(days: int) -> str:
+    dt = datetime.now(timezone.utc) - timedelta(days=days)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def _load_transitions_since(conn: sqlite3.Connection, since_iso: str) -> dict:
+    """Load all label_transition events across all projects since the given ISO timestamp."""
+    rows = conn.execute(
+        """SELECT project, issue_number, payload, created_at
+           FROM events
+           WHERE event_type = 'label_transition' AND issue_number IS NOT NULL
+             AND created_at >= ?
+           ORDER BY project, issue_number, created_at ASC""",
+        (since_iso,),
+    ).fetchall()
+
+    by_issue: dict = {}
+    for row in rows:
+        key = (row["project"], row["issue_number"])
+        if key not in by_issue:
+            by_issue[key] = []
+        try:
+            payload = json.loads(row["payload"]) if isinstance(row["payload"], str) else (row["payload"] or {})
+        except (json.JSONDecodeError, TypeError):
+            payload = {}
+        by_issue[key].append({"payload": payload, "created_at": row["created_at"]})
+
+    return by_issue
+
+
+def _pct_stats(values: list[float]) -> Optional[dict]:
+    """Compute p50/p75/p95/count.
+    Uses floor-based index — known small-sample underestimate; see issue #129."""
+    n = len(values)
+    if n == 0:
+        return None
+    sv = sorted(values)
+    return {
+        "p50": sv[int(0.50 * n)],
+        "p75": sv[int(0.75 * n)],
+        "p95": sv[int(0.95 * n)],
+        "count": n,
+    }
+
+
+def _compute_lead_times(by_issue: dict) -> list[float]:
+    """Compute full lead-time (needs-po added → done added) per issue."""
+    lead_times = []
+    for events in by_issue.values():
+        po_ts: Optional[float] = None
+        done_ts: Optional[float] = None
+        for ev in events:
+            payload = ev["payload"]
+            ts = _parse_ts_unix(ev["created_at"])
+            after = set(payload.get("after_labels") or [])
+            before = set(payload.get("before_labels") or [])
+            added = after - before
+            if "needs-po" in added and po_ts is None:
+                po_ts = ts
+            if "done" in added:
+                done_ts = ts
+        if po_ts is not None and done_ts is not None and done_ts > po_ts:
+            lead_times.append(done_ts - po_ts)
+    return lead_times
+
+
+@router.get("/api/analytics/cycle_time")
+def get_analytics_cycle_time(
+    days: int = Query(30, ge=1, le=365),
+    conn: sqlite3.Connection = Depends(db_dep),
+) -> dict:
+    since = _since_iso(days)
+    by_issue = _load_transitions_since(conn, since)
+
+    # _compute_stage_durations only iterates .values() so tuple keys are fine.
+    all_buckets = _compute_stage_durations(by_issue)
+
+    stages = []
+    for transition in _STAGE_TRANSITIONS:
+        durations = all_buckets.get(transition, [])
+        stats = _pct_stats(durations)
+        if stats is not None:
+            stages.append({"stage": transition, **stats})
+
+    lead_times = _compute_lead_times(by_issue)
+    lead_time = _pct_stats(lead_times)
+
+    return {"stages": stages, "lead_time": lead_time}

--- a/tests/test_analytics_cycle_time.py
+++ b/tests/test_analytics_cycle_time.py
@@ -1,0 +1,96 @@
+import json
+import sqlite3
+
+import pytest
+
+import server.db
+
+
+def _insert_transition(conn, project, issue_number, before_labels, after_labels, created_at):
+    payload = json.dumps({"before_labels": before_labels, "after_labels": after_labels})
+    conn.execute(
+        """INSERT INTO events (project, role, event_type, issue_number, payload, created_at)
+           VALUES (?, 'scanner', 'label_transition', ?, ?, ?)""",
+        (project, issue_number, payload, created_at),
+    )
+
+
+def test_cycle_time_empty(isolated_client):
+    resp = isolated_client.get("/api/analytics/cycle_time?days=30")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["stages"] == []
+    assert data["lead_time"] is None
+
+
+def test_cycle_time_stages(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.row_factory = sqlite3.Row
+
+    # Six issues each spending 1 hour in needs-po state.
+    for i in range(1, 7):
+        _insert_transition(conn, "proj-s", i, [], ["needs-po"], f"2026-01-{i:02d}T10:00:00")
+        _insert_transition(conn, "proj-s", i, ["needs-po"], ["in-po"], f"2026-01-{i:02d}T11:00:00")
+
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/analytics/cycle_time?days=365")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    stages_by_name = {s["stage"]: s for s in data["stages"]}
+
+    npo = stages_by_name.get("needs-po->in-po")
+    assert npo is not None
+    assert npo["count"] == 6
+    assert npo["p50"] == pytest.approx(3600, rel=0.01)
+    assert npo["p75"] >= npo["p50"]
+    assert npo["p95"] >= npo["p75"]
+    assert "p50" in npo and "p75" in npo and "p95" in npo
+
+
+def test_cycle_time_lead_time(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.row_factory = sqlite3.Row
+
+    # Five issues with lead times of 1d, 2d, 3d, 4d, 5d.
+    one_day = 86400
+    for i in range(1, 6):
+        _insert_transition(conn, "proj-lt", i, [], ["needs-po"], "2026-02-01T00:00:00")
+        _insert_transition(conn, "proj-lt", i, ["needs-po", "in-dev"], ["done"],
+                           f"2026-02-{1 + i:02d}T00:00:00")
+
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/analytics/cycle_time?days=365")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    lt = data["lead_time"]
+    assert lt is not None
+    assert lt["count"] == 5
+    # sorted: [1d, 2d, 3d, 4d, 5d]; floor(0.5 * 5) = 2 → index 2 → 3d
+    assert lt["p50"] == pytest.approx(3 * one_day, rel=0.01)
+    assert lt["p75"] >= lt["p50"]
+    assert lt["p95"] >= lt["p75"]
+
+
+def test_cycle_time_days_filter(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.row_factory = sqlite3.Row
+
+    # Transitions >60 days in the past — should be excluded when days=30.
+    for i in range(1, 7):
+        _insert_transition(conn, "proj-df", i, [], ["needs-po"], "2025-01-01T00:00:00")
+        _insert_transition(conn, "proj-df", i, ["needs-po"], ["in-po"], "2025-01-01T01:00:00")
+
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/analytics/cycle_time?days=30")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["stages"] == []
+    assert data["lead_time"] is None

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import ProjectDetail from './screens/ProjectDetail';
 import Queue from './screens/Queue';
 import WorkerDetail from './screens/WorkerDetail';
 import Cost from './screens/Cost';
+import Analytics from './screens/Analytics';
 import { useHashRoute } from './router';
 import { fetchActive, fetchHealth } from './lib/api';
 
@@ -127,6 +128,8 @@ export default function App() {
           <WorkerDetail />
         ) : hashNavScreen === 'logs' ? (
           <Logs />
+        ) : hashNavScreen === 'analytics' ? (
+          <Analytics />
         ) : (
           <div style={{ padding: 'var(--pad-4)' }}>
             <p className="muted mono" style={{ fontSize: 12 }}>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -23,6 +23,7 @@ import type {
   IssueCostRow,
   FailureContext,
   CycleTimesResponse,
+  CycleTimeAnalyticsResponse,
   SloConfig,
 } from './types';
 import * as fx from './fixtures';
@@ -193,6 +194,10 @@ export async function fetchFailureContext(
 
 export async function fetchCycleTimes(project: string): Promise<CycleTimesResponse> {
   return get<CycleTimesResponse>(`/api/projects/${encodeURIComponent(project)}/cycle_times`);
+}
+
+export async function fetchAnalyticsCycleTime(days = 30): Promise<CycleTimeAnalyticsResponse> {
+  return get<CycleTimeAnalyticsResponse>(`/api/analytics/cycle_time?days=${days}`);
 }
 
 export async function fetchSlo(project: string): Promise<SloConfig> {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -241,6 +241,26 @@ export interface SloConfig {
   updated_at: number | null;
 }
 
+export interface CycleTimeStage {
+  stage: string;
+  p50: number;
+  p75: number;
+  p95: number;
+  count: number;
+}
+
+export interface CycleTimePct {
+  p50: number;
+  p75: number;
+  p95: number;
+  count: number;
+}
+
+export interface CycleTimeAnalyticsResponse {
+  stages: CycleTimeStage[];
+  lead_time: CycleTimePct | null;
+}
+
 export interface IssueCostRow {
   project: string;
   issue_number: number;

--- a/web/src/panels/CycleTime.tsx
+++ b/web/src/panels/CycleTime.tsx
@@ -1,0 +1,102 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchAnalyticsCycleTime } from '../lib/api';
+import type { CycleTimeStage, CycleTimePct } from '../lib/types';
+
+function fmtSecs(secs: number): string {
+  if (secs < 60) return `${Math.round(secs)}s`;
+  if (secs < 3600) return `${Math.round(secs / 60)}m`;
+  if (secs < 86400) {
+    const h = Math.floor(secs / 3600);
+    const m = Math.round((secs % 3600) / 60);
+    return m > 0 ? `${h}h ${m}m` : `${h}h`;
+  }
+  const d = Math.floor(secs / 86400);
+  const h = Math.round((secs % 86400) / 3600);
+  return h > 0 ? `${d}d ${h}h` : `${d}d`;
+}
+
+function StageRow({ row }: { row: CycleTimeStage }) {
+  return (
+    <tr>
+      <td className="mono" style={{ fontSize: 11, color: 'var(--fg-2)' }}>{row.stage}</td>
+      <td className="num">{fmtSecs(row.p50)}</td>
+      <td className="num">{fmtSecs(row.p75)}</td>
+      <td className="num">{fmtSecs(row.p95)}</td>
+      <td className="num" style={{ color: 'var(--fg-3)', fontSize: 11 }}>{row.count}</td>
+    </tr>
+  );
+}
+
+function LeadTimeRow({ lt }: { lt: CycleTimePct }) {
+  return (
+    <tr style={{ borderTop: '1px solid var(--border)', fontWeight: 500 }}>
+      <td className="mono" style={{ fontSize: 11 }}>lead-time (end-to-end)</td>
+      <td className="num">{fmtSecs(lt.p50)}</td>
+      <td className="num">{fmtSecs(lt.p75)}</td>
+      <td className="num">{fmtSecs(lt.p95)}</td>
+      <td className="num" style={{ color: 'var(--fg-3)', fontSize: 11 }}>{lt.count}</td>
+    </tr>
+  );
+}
+
+interface CycleTimePanelProps {
+  days?: number;
+}
+
+export default function CycleTimePanel({ days = 30 }: CycleTimePanelProps) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['analytics-cycle-time', days],
+    queryFn: () => fetchAnalyticsCycleTime(days),
+    staleTime: 60_000,
+    refetchInterval: 300_000,
+  });
+
+  return (
+    <div className="panel" id="cycle-time">
+      <div className="panel-h">
+        <span>Cycle time · last {days}d</span>
+        {data && (
+          <span className="muted mono" style={{ fontSize: 10 }}>
+            {data.stages.length} stages · {data.lead_time?.count ?? 0} full runs
+          </span>
+        )}
+      </div>
+
+      {isLoading && (
+        <div className="muted" style={{ padding: 'var(--pad-3)' }}>Loading…</div>
+      )}
+
+      {isError && (
+        <div style={{ padding: 'var(--pad-3)', color: 'var(--role-err)', fontSize: 12 }}>
+          Failed to load cycle time data.
+        </div>
+      )}
+
+      {data && (data.stages.length > 0 || data.lead_time != null) ? (
+        <table className="t">
+          <thead>
+            <tr>
+              <th>Stage</th>
+              <th>p50</th>
+              <th>p75</th>
+              <th>p95</th>
+              <th>n</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.stages.map(s => (
+              <StageRow key={s.stage} row={s} />
+            ))}
+            {data.lead_time != null && <LeadTimeRow lt={data.lead_time} />}
+          </tbody>
+        </table>
+      ) : (
+        !isLoading && !isError && (
+          <div className="muted" style={{ padding: 'var(--pad-3)', fontSize: 12 }}>
+            No cycle time data in the last {days} days.
+          </div>
+        )
+      )}
+    </div>
+  );
+}

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
-export type Screen = 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs';
+export type Screen = 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs' | 'analytics';
 
 export interface HashRoute {
   screen: Screen;

--- a/web/src/screens/Analytics.tsx
+++ b/web/src/screens/Analytics.tsx
@@ -1,0 +1,14 @@
+import CycleTimePanel from '../panels/CycleTime';
+
+export default function Analytics() {
+  return (
+    <div>
+      <div className="screen-h">
+        <h1>Analytics</h1>
+      </div>
+      <div style={{ padding: 'var(--pad-4)', display: 'grid', gap: 'var(--pad-3)' }}>
+        <CycleTimePanel days={30} />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #247

## Changes
- **`server/routes/analytics.py`** — new `GET /api/analytics/cycle_time?days=30` endpoint returning `{stages: [{stage, p50, p75, p95, count}], lead_time: {p50, p75, p95, count}}`. Reuses `_compute_stage_durations` and `_parse_ts_unix` from `stats.py`; adds aggregate (all-project) transition loader filtered by `days`. Computes full lead-time (needs-po → done) per issue. Floor-based percentile indexing inherits the known small-sample caveat from #129 (noted in comment, not fixed here).
- **`server/app.py`** — registers the new analytics router.
- **`tests/test_analytics_cycle_time.py`** — 4 tests covering empty response, stage p50/p75/p95, lead-time distribution, and the `days` filter.
- **`web/src/lib/types.ts`** — adds `CycleTimeStage`, `CycleTimePct`, `CycleTimeAnalyticsResponse` types.
- **`web/src/lib/api.ts`** — adds `fetchAnalyticsCycleTime(days?)`.
- **`web/src/panels/CycleTime.tsx`** — stage table (Stage / p50 / p75 / p95 / count) + lead-time row at bottom.
- **`web/src/screens/Analytics.tsx`** — mounts the CycleTime panel in the cycle-time slot.
- **`web/src/App.tsx`** — routes `#screen=analytics` to the Analytics screen.
- **`web/src/router.tsx`** — adds `analytics` to the `Screen` union type.

CLAUDE.md was absent from the worktree; proceeded using best-judgment conventions consistent with the existing codebase.

## Test Plan
- `ruff check .` passes
- `pyright server/` — 0 errors
- `pytest tests/test_analytics_cycle_time.py` — 4/4 pass
- `npm run typecheck && npm run build` — clean
- Navigate to `#screen=analytics` to reach the Analytics screen with CycleTime panel