### PR TITLE
[LM-248] Analytics Quality panel + GET /api/analytics/quality

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -18,6 +18,7 @@ app = FastAPI(title="Loop Monitor", lifespan=lifespan)
 
 from server.routes import (  # noqa: E402
     action_queue,
+    analytics,
     board,
     claude_usage,
     config,
@@ -47,6 +48,7 @@ app.include_router(logs.router)
 app.include_router(scanner_state.router)
 app.include_router(slos.router)
 app.include_router(config.router)
+app.include_router(analytics.router)
 
 if os.path.isdir("static/dist"):
     app.mount("/v2", StaticFiles(directory="static/dist", html=True), name="dist")

--- a/server/routes/analytics.py
+++ b/server/routes/analytics.py
@@ -1,0 +1,176 @@
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends
+
+from server.db import db_dep
+
+router = APIRouter()
+
+_STAGES = ["po", "dev", "review", "qa", "merge"]
+_HAPPY_PATH = 5  # happy-path run count assuming no child issues
+_BUCKET_LABELS = ["≤1", "1–1.5", "1.5–2", "2–3", "3–4", ">4"]
+
+
+def _empty_buckets() -> list[dict]:
+    return [{"label": lbl, "count": 0} for lbl in _BUCKET_LABELS]
+
+
+def _compute_rework_dist(sorted_factors: list[float]) -> dict:
+    n = len(sorted_factors)
+    if n == 0:
+        return {"p50": 0.0, "p75": 0.0, "p95": 0.0, "buckets": _empty_buckets()}
+
+    def pct(p: float) -> float:
+        return sorted_factors[int(p * (n - 1))]
+
+    buckets = _empty_buckets()
+    for v in sorted_factors:
+        if v <= 1.0:
+            buckets[0]["count"] += 1
+        elif v <= 1.5:
+            buckets[1]["count"] += 1
+        elif v <= 2.0:
+            buckets[2]["count"] += 1
+        elif v <= 3.0:
+            buckets[3]["count"] += 1
+        elif v <= 4.0:
+            buckets[4]["count"] += 1
+        else:
+            buckets[5]["count"] += 1
+
+    return {"p50": pct(0.50), "p75": pct(0.75), "p95": pct(0.95), "buckets": buckets}
+
+
+@router.get("/api/analytics/quality")
+def get_quality(
+    days: int = 30,
+    conn: sqlite3.Connection = Depends(db_dep),
+) -> dict:
+    since_dt = datetime.now(timezone.utc) - timedelta(days=days)
+    since_iso = since_dt.isoformat()
+
+    # Verdict mix from verdicts table (categorise by points)
+    verdict_rows = conn.execute(
+        "SELECT points FROM verdicts WHERE created_at >= ?",
+        (since_iso,),
+    ).fetchall()
+    verdicts: dict[str, int] = {"clean": 0, "light_rework": 0, "heavy_rework": 0, "blocked": 0}
+    for row in verdict_rows:
+        pts = row["points"] or 0
+        if pts <= 0:
+            verdicts["blocked"] += 1
+        elif pts < 4:
+            verdicts["heavy_rework"] += 1
+        elif pts < 8:
+            verdicts["light_rework"] += 1
+        else:
+            verdicts["clean"] += 1
+
+    # QA pass rate overall
+    qa_agg = conn.execute(
+        """
+        SELECT
+            SUM(CASE WHEN event_type = 'qa_start'                     THEN 1 ELSE 0 END) AS qa_starts,
+            SUM(CASE WHEN event_type IN ('qa_failed', 'qa_fail')      THEN 1 ELSE 0 END) AS qa_fails
+        FROM events
+        WHERE created_at >= ?
+        """,
+        (since_iso,),
+    ).fetchone()
+    qa_starts = qa_agg["qa_starts"] or 0
+    qa_fails = qa_agg["qa_fails"] or 0
+    qa_pass_rate = round(1.0 - qa_fails / qa_starts, 4) if qa_starts > 0 else 0.0
+
+    # QA pass rate per day
+    daily_rows = conn.execute(
+        """
+        SELECT
+            DATE(created_at) AS day,
+            SUM(CASE WHEN event_type = 'qa_start'                THEN 1 ELSE 0 END) AS s,
+            SUM(CASE WHEN event_type IN ('qa_failed', 'qa_fail') THEN 1 ELSE 0 END) AS f
+        FROM events
+        WHERE created_at >= ?
+          AND event_type IN ('qa_start', 'qa_failed', 'qa_fail')
+        GROUP BY day
+        ORDER BY day
+        """,
+        (since_iso,),
+    ).fetchall()
+    qa_pass_rate_daily = [
+        {"date": r["day"], "rate": round(1.0 - (r["f"] or 0) / r["s"], 4) if (r["s"] or 0) > 0 else 0.0}
+        for r in daily_rows
+    ]
+
+    # Per-stage failure rate
+    stage_failure = []
+    for stage in _STAGES:
+        row = conn.execute(
+            """
+            SELECT
+                SUM(CASE WHEN event_type = ? THEN 1 ELSE 0 END) AS starts,
+                SUM(CASE WHEN event_type = ? THEN 1 ELSE 0 END) AS fails
+            FROM events
+            WHERE created_at >= ?
+            """,
+            (f"{stage}_start", f"{stage}_failed", since_iso),
+        ).fetchone()
+        starts = row["starts"] or 0
+        fails = row["fails"] or 0
+        stage_failure.append({
+            "stage": stage,
+            "fail_rate": round(fails / starts, 4) if starts > 0 else 0.0,
+            "sample": starts,
+        })
+
+    # Rework-factor distribution (happy_path=5, no GH call needed for aggregate)
+    rf_rows = conn.execute(
+        """
+        WITH agg AS (
+            SELECT
+                project,
+                issue_number,
+                SUM(CASE WHEN event_type LIKE '%_start' THEN 1 ELSE 0 END) AS actual_runs
+            FROM events
+            WHERE issue_number IS NOT NULL
+              AND created_at >= ?
+            GROUP BY project, issue_number
+            HAVING actual_runs > 0
+        )
+        SELECT actual_runs FROM agg ORDER BY actual_runs
+        """,
+        (since_iso,),
+    ).fetchall()
+    sorted_factors = sorted(round(r["actual_runs"] / _HAPPY_PATH, 2) for r in rf_rows)
+    rework_dist = _compute_rework_dist(sorted_factors)
+
+    # Failure type counts
+    ft = conn.execute(
+        """
+        SELECT
+            SUM(CASE WHEN event_type = 'po_failed'                    THEN 1 ELSE 0 END) AS po_failed,
+            SUM(CASE WHEN event_type = 'dev_failed'                   THEN 1 ELSE 0 END) AS dev_failed,
+            SUM(CASE WHEN event_type IN ('qa_failed', 'qa_fail')      THEN 1 ELSE 0 END) AS qa_fail,
+            SUM(CASE WHEN event_type = 'review_failed'                THEN 1 ELSE 0 END) AS review_failed,
+            SUM(CASE WHEN event_type = 'merge_failed'                 THEN 1 ELSE 0 END) AS merge_failed
+        FROM events
+        WHERE created_at >= ?
+        """,
+        (since_iso,),
+    ).fetchone()
+    failure_types = {
+        "po_failed":     ft["po_failed"] or 0,
+        "dev_failed":    ft["dev_failed"] or 0,
+        "qa_fail":       ft["qa_fail"] or 0,
+        "review_failed": ft["review_failed"] or 0,
+        "merge_failed":  ft["merge_failed"] or 0,
+    }
+
+    return {
+        "verdicts": verdicts,
+        "qa_pass_rate": qa_pass_rate,
+        "qa_pass_rate_daily": qa_pass_rate_daily,
+        "stage_failure": stage_failure,
+        "rework_dist": rework_dist,
+        "failure_types": failure_types,
+    }

--- a/tests/test_analytics_quality.py
+++ b/tests/test_analytics_quality.py
@@ -1,0 +1,181 @@
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+import server
+import server.db
+
+
+def _make_client(monkeypatch, tmp_path) -> TestClient:
+    monkeypatch.setattr(server.db, "DB_PATH", str(tmp_path / "test.db"))
+    server.db.apply_pending_migrations()
+    return TestClient(server.app)
+
+
+def _insert_events(db_path: str, events: list) -> None:
+    conn = sqlite3.connect(db_path)
+    for ev in events:
+        conn.execute(
+            "INSERT INTO events (project, role, event_type, issue_number, created_at) VALUES (?,?,?,?,?)",
+            (ev["project"], ev["role"], ev["event_type"], ev.get("issue_number"), ev["created_at"]),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _insert_verdicts(db_path: str, verdicts: list) -> None:
+    conn = sqlite3.connect(db_path)
+    for v in verdicts:
+        conn.execute(
+            "INSERT INTO verdicts (project, role, points, created_at) VALUES (?,?,?,?)",
+            (v["project"], v["role"], v["points"], v["created_at"]),
+        )
+    conn.commit()
+    conn.close()
+
+
+RECENT = "2026-05-01T12:00:00+00:00"
+
+
+def test_empty_db_returns_zeros(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    resp = client.get("/api/analytics/quality?days=30")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["verdicts"] == {"clean": 0, "light_rework": 0, "heavy_rework": 0, "blocked": 0}
+    assert data["qa_pass_rate"] == 0.0
+    assert data["qa_pass_rate_daily"] == []
+    assert len(data["stage_failure"]) == 5
+    for sf in data["stage_failure"]:
+        assert sf["fail_rate"] == 0.0
+        assert sf["sample"] == 0
+    assert data["rework_dist"]["p50"] == 0.0
+    assert data["failure_types"] == {
+        "po_failed": 0, "dev_failed": 0, "qa_fail": 0,
+        "review_failed": 0, "merge_failed": 0,
+    }
+
+
+def test_verdict_mix_categorisation(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    _insert_verdicts(server.db.DB_PATH, [
+        {"project": "p", "role": "judge", "points": 10, "created_at": RECENT},  # clean
+        {"project": "p", "role": "judge", "points": 5,  "created_at": RECENT},  # light_rework
+        {"project": "p", "role": "judge", "points": 2,  "created_at": RECENT},  # heavy_rework
+        {"project": "p", "role": "judge", "points": 0,  "created_at": RECENT},  # blocked
+        {"project": "p", "role": "judge", "points": -1, "created_at": RECENT},  # blocked
+    ])
+    resp = client.get("/api/analytics/quality?days=30")
+    assert resp.status_code == 200
+    v = resp.json()["verdicts"]
+    assert v["clean"] == 1
+    assert v["light_rework"] == 1
+    assert v["heavy_rework"] == 1
+    assert v["blocked"] == 2
+
+
+def test_qa_pass_rate(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "p", "role": "qa", "event_type": "qa_start",  "issue_number": 1, "created_at": RECENT},
+        {"project": "p", "role": "qa", "event_type": "qa_start",  "issue_number": 2, "created_at": RECENT},
+        {"project": "p", "role": "qa", "event_type": "qa_start",  "issue_number": 3, "created_at": RECENT},
+        {"project": "p", "role": "qa", "event_type": "qa_start",  "issue_number": 4, "created_at": RECENT},
+        {"project": "p", "role": "qa", "event_type": "qa_failed", "issue_number": 1, "created_at": RECENT},
+    ])
+    resp = client.get("/api/analytics/quality?days=30")
+    assert resp.status_code == 200
+    data = resp.json()
+    # 1 fail out of 4 starts → 75% pass rate
+    assert abs(data["qa_pass_rate"] - 0.75) < 0.001
+
+
+def test_stage_failure_rate(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "p", "role": "dev", "event_type": "dev_start",  "issue_number": 1, "created_at": RECENT},
+        {"project": "p", "role": "dev", "event_type": "dev_start",  "issue_number": 2, "created_at": RECENT},
+        {"project": "p", "role": "dev", "event_type": "dev_failed", "issue_number": 1, "created_at": RECENT},
+    ])
+    resp = client.get("/api/analytics/quality?days=30")
+    assert resp.status_code == 200
+    sf = {s["stage"]: s for s in resp.json()["stage_failure"]}
+    assert sf["dev"]["sample"] == 2
+    assert abs(sf["dev"]["fail_rate"] - 0.5) < 0.001
+    assert sf["po"]["sample"] == 0
+    assert sf["po"]["fail_rate"] == 0.0
+
+
+def test_rework_dist_percentiles(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    # Insert 4 issues: 5, 10, 15, 20 actual_runs → rework factors 1.0, 2.0, 3.0, 4.0
+    # With 4 elements, int(p*(n-1)): p50→idx1=2.0, p75→idx2=3.0, p95→idx2=3.0
+    for issue, starts in [(1, 5), (2, 10), (3, 15), (4, 20)]:
+        for _ in range(starts):
+            _insert_events(server.db.DB_PATH, [
+                {"project": "p", "role": "dev", "event_type": "dev_start",
+                 "issue_number": issue, "created_at": RECENT},
+            ])
+    resp = client.get("/api/analytics/quality?days=30")
+    assert resp.status_code == 200
+    rd = resp.json()["rework_dist"]
+    assert rd["p50"] == 2.0
+    assert rd["p75"] == 3.0
+    assert rd["p95"] == 3.0
+
+
+def test_failure_types_counts(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "p", "role": "po",     "event_type": "po_failed",     "issue_number": 1, "created_at": RECENT},
+        {"project": "p", "role": "dev",    "event_type": "dev_failed",    "issue_number": 1, "created_at": RECENT},
+        {"project": "p", "role": "dev",    "event_type": "dev_failed",    "issue_number": 2, "created_at": RECENT},
+        {"project": "p", "role": "qa",     "event_type": "qa_failed",     "issue_number": 1, "created_at": RECENT},
+        {"project": "p", "role": "qa",     "event_type": "qa_fail",       "issue_number": 2, "created_at": RECENT},
+        {"project": "p", "role": "review", "event_type": "review_failed", "issue_number": 1, "created_at": RECENT},
+        {"project": "p", "role": "merge",  "event_type": "merge_failed",  "issue_number": 1, "created_at": RECENT},
+    ])
+    resp = client.get("/api/analytics/quality?days=30")
+    assert resp.status_code == 200
+    ft = resp.json()["failure_types"]
+    assert ft["po_failed"] == 1
+    assert ft["dev_failed"] == 2
+    assert ft["qa_fail"] == 2       # qa_failed + qa_fail
+    assert ft["review_failed"] == 1
+    assert ft["merge_failed"] == 1
+
+
+def test_days_filter_excludes_old_events(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    old_ts = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+    _insert_events(server.db.DB_PATH, [
+        {"project": "p", "role": "dev", "event_type": "dev_failed", "issue_number": 1, "created_at": old_ts},
+    ])
+    _insert_verdicts(server.db.DB_PATH, [
+        {"project": "p", "role": "judge", "points": 10, "created_at": old_ts},
+    ])
+    resp = client.get("/api/analytics/quality?days=30")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["failure_types"]["dev_failed"] == 0
+    assert data["verdicts"]["clean"] == 0
+
+
+def test_qa_pass_rate_daily_grouping(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path)
+    day1 = "2026-05-10T10:00:00+00:00"
+    day2 = "2026-05-11T10:00:00+00:00"
+    _insert_events(server.db.DB_PATH, [
+        {"project": "p", "role": "qa", "event_type": "qa_start",  "issue_number": 1, "created_at": day1},
+        {"project": "p", "role": "qa", "event_type": "qa_start",  "issue_number": 2, "created_at": day1},
+        {"project": "p", "role": "qa", "event_type": "qa_failed", "issue_number": 1, "created_at": day1},
+        {"project": "p", "role": "qa", "event_type": "qa_start",  "issue_number": 3, "created_at": day2},
+    ])
+    resp = client.get("/api/analytics/quality?days=30")
+    assert resp.status_code == 200
+    daily = {d["date"]: d["rate"] for d in resp.json()["qa_pass_rate_daily"]}
+    assert "2026-05-10" in daily
+    assert abs(daily["2026-05-10"] - 0.5) < 0.001
+    assert "2026-05-11" in daily
+    assert abs(daily["2026-05-11"] - 1.0) < 0.001

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import Logs from './screens/Logs';
 import ProjectDetail from './screens/ProjectDetail';
 import Queue from './screens/Queue';
 import WorkerDetail from './screens/WorkerDetail';
+import Analytics from './screens/Analytics';
 import Cost from './screens/Cost';
 import { useHashRoute } from './router';
 import { fetchActive, fetchHealth } from './lib/api';
@@ -19,18 +20,20 @@ const SCREEN_KEYS: Record<string, string> = {
   '4': 'workers',
   '5': 'logs',
   '6': 'cost',
+  '7': 'analytics',
 };
 
 export default function App() {
   const { screen: hashScreen, projectId: hashProjectId, navigateTo } = useHashRoute();
 
-  // 'cost' is local-only — not stored in the hash — so we track it separately.
+  // 'cost' and 'analytics' are local-only — not stored in the hash.
   const [showCost, setShowCost] = useState(false);
+  const [showAnalytics, setShowAnalytics] = useState(false);
 
   // Derive nav screen from hash. 'project' is a sub-state of 'projects' nav item.
   const hashNavScreen = hashScreen === 'project' ? 'projects' : hashScreen;
-  // When cost is active, override; otherwise use hash-derived value.
-  const navScreen = showCost ? 'cost' : hashNavScreen;
+  // When cost or analytics is active, override; otherwise use hash-derived value.
+  const navScreen = showCost ? 'cost' : showAnalytics ? 'analytics' : hashNavScreen;
   const projectId = hashProjectId;
 
   const [allProjectIds, setAllProjectIds] = useState<string[]>([]);
@@ -46,16 +49,22 @@ export default function App() {
       .catch(() => undefined);
   }, []);
 
-  // When hash changes externally (back/forward), clear cost overlay
+  // When hash changes externally (back/forward), clear local overlays
   useEffect(() => {
     setShowCost(false);
+    setShowAnalytics(false);
   }, [hashScreen]);
 
   function handleNavChange(s: string) {
     if (s === 'cost') {
       setShowCost(true);
+      setShowAnalytics(false);
+    } else if (s === 'analytics') {
+      setShowAnalytics(true);
+      setShowCost(false);
     } else {
       setShowCost(false);
+      setShowAnalytics(false);
       navigateTo(s as 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs', null, {
         drawer: null,
         pushState: true,
@@ -65,11 +74,13 @@ export default function App() {
 
   function handleProjectChange(id: string) {
     setShowCost(false);
+    setShowAnalytics(false);
     navigateTo('project', id, { drawer: null, pushState: true });
   }
 
   function handleBack() {
     setShowCost(false);
+    setShowAnalytics(false);
     navigateTo('overview', null, { pushState: true });
   }
 
@@ -110,7 +121,9 @@ export default function App() {
       <TopBar events={events} online={online} version={version} />
       <NavRail screen={isProjectDetail ? 'projects' : navScreen} setScreen={handleNavChange} />
       <main className="main">
-        {showCost ? (
+        {showAnalytics ? (
+          <Analytics />
+        ) : showCost ? (
           <Cost />
         ) : isProjectDetail && projectId != null ? (
           <ProjectDetail

--- a/web/src/components/NavRail.tsx
+++ b/web/src/components/NavRail.tsx
@@ -40,6 +40,12 @@ const NAV_ICONS: Record<string, ReactNode> = {
       <rect x="17" y="4" width="4" height="17"/>
     </svg>
   ),
+  analytics: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <circle cx="12" cy="12" r="3"/><path d="M12 2v3M12 19v3M2 12h3M19 12h3"/>
+      <path d="M5.6 5.6l2.1 2.1M16.3 16.3l2.1 2.1M5.6 18.4l2.1-2.1M16.3 7.7l2.1-2.1"/>
+    </svg>
+  ),
   settings: (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
       <circle cx="12" cy="12" r="3"/>
@@ -50,12 +56,13 @@ const NAV_ICONS: Record<string, ReactNode> = {
 
 export default function NavRail({ screen, setScreen }: NavRailProps) {
   const items = [
-    { id: 'overview', label: 'Overview' },
-    { id: 'queue',    label: 'Action Queue' },
-    { id: 'projects', label: 'Projects' },
-    { id: 'workers',  label: 'Workers' },
-    { id: 'logs',     label: 'Logs' },
-    { id: 'cost',     label: 'Cost' },
+    { id: 'overview',   label: 'Overview' },
+    { id: 'queue',      label: 'Action Queue' },
+    { id: 'projects',   label: 'Projects' },
+    { id: 'workers',    label: 'Workers' },
+    { id: 'logs',       label: 'Logs' },
+    { id: 'cost',       label: 'Cost' },
+    { id: 'analytics',  label: 'Analytics' },
   ];
   return (
     <div className="nav">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -21,6 +21,7 @@ import type {
   ScannerState,
   LogsResponse,
   IssueCostRow,
+  AnalyticsQuality,
   FailureContext,
   CycleTimesResponse,
   SloConfig,
@@ -179,6 +180,10 @@ export async function fetchIssuesCost(params: IssuesCostParams = {}): Promise<Is
   if (params.offset != null) p.set('offset', String(params.offset));
   const qs = p.size ? `?${p.toString()}` : '';
   return get<IssueCostRow[]>(`/api/issues/cost${qs}`);
+}
+
+export async function fetchAnalyticsQuality(days = 30): Promise<AnalyticsQuality> {
+  return get<AnalyticsQuality>(`/api/analytics/quality?days=${days}`);
 }
 
 export async function fetchFailureContext(

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -241,6 +241,20 @@ export interface SloConfig {
   updated_at: number | null;
 }
 
+export interface AnalyticsQualityBucket {
+  label: string;
+  count: number;
+}
+
+export interface AnalyticsQuality {
+  verdicts: { clean: number; light_rework: number; heavy_rework: number; blocked: number };
+  qa_pass_rate: number;
+  qa_pass_rate_daily: { date: string; rate: number }[];
+  stage_failure: { stage: string; fail_rate: number; sample: number }[];
+  rework_dist: { p50: number; p75: number; p95: number; buckets: AnalyticsQualityBucket[] };
+  failure_types: { po_failed: number; dev_failed: number; qa_fail: number; review_failed: number; merge_failed: number };
+}
+
 export interface IssueCostRow {
   project: string;
   issue_number: number;

--- a/web/src/panels/Quality.tsx
+++ b/web/src/panels/Quality.tsx
@@ -1,0 +1,222 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer,
+  LineChart, Line, PieChart, Pie, Cell,
+} from 'recharts';
+import { fetchAnalyticsQuality } from '../lib/api';
+import type { AnalyticsQuality } from '../lib/types';
+
+const C = {
+  accent:       'oklch(0.82 0.18 145)',
+  dev:          'oklch(0.78 0.13 210)',
+  qa:           'oklch(0.82 0.15 75)',
+  warn:         'oklch(0.82 0.16 80)',
+  err:          'oklch(0.72 0.20 25)',
+  muted:        'oklch(0.42 0.008 250)',
+  bg2:          'oklch(0.205 0.007 250)',
+  border:       'oklch(0.275 0.008 250)',
+  fg3:          'oklch(0.58 0.008 250)',
+  clean:        'oklch(0.72 0.18 145)',
+  light_rework: 'oklch(0.82 0.15 75)',
+  heavy_rework: 'oklch(0.80 0.20 55)',
+  blocked:      'oklch(0.65 0.20 25)',
+};
+
+const TOOLTIP_STYLE = {
+  background: C.bg2,
+  border: `1px solid ${C.border}`,
+  borderRadius: 2,
+  fontSize: 11,
+  fontFamily: 'var(--font-mono)',
+  color: 'oklch(0.96 0.005 250)',
+};
+
+function SubPanel({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="panel">
+      <div className="panel-h"><span>{title}</span></div>
+      <div style={{ padding: 'var(--pad-2) var(--pad-3) var(--pad-3)' }}>{children}</div>
+    </div>
+  );
+}
+
+function Placeholder({ height = 180 }: { height?: number }) {
+  return <div style={{ height, display: 'flex', alignItems: 'center', color: C.fg3, fontSize: 11 }}>Loading…</div>;
+}
+
+function VerdictDonut({ data }: { data: AnalyticsQuality['verdicts'] }) {
+  const entries = [
+    { name: 'Clean',        value: data.clean,        fill: C.clean },
+    { name: 'Light rework', value: data.light_rework,  fill: C.light_rework },
+    { name: 'Heavy rework', value: data.heavy_rework,  fill: C.heavy_rework },
+    { name: 'Blocked',      value: data.blocked,       fill: C.blocked },
+  ].filter(e => e.value > 0);
+
+  const total = entries.reduce((s, e) => s + e.value, 0);
+  if (total === 0) {
+    return <div style={{ height: 180, display: 'flex', alignItems: 'center', color: C.fg3, fontSize: 11 }}>No verdicts yet</div>;
+  }
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--pad-3)' }}>
+      <PieChart width={140} height={140}>
+        <Pie data={entries} dataKey="value" cx={65} cy={65} innerRadius={38} outerRadius={60} strokeWidth={0}>
+          {entries.map(e => <Cell key={e.name} fill={e.fill} />)}
+        </Pie>
+        <Tooltip contentStyle={TOOLTIP_STYLE} formatter={(v) => { const n = Number(v); return [`${n} (${((n / total) * 100).toFixed(0)}%)`, ''] as [string, string]; }} />
+      </PieChart>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {entries.map(e => (
+          <div key={e.name} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <div style={{ width: 8, height: 8, borderRadius: 2, background: e.fill, flexShrink: 0 }} />
+            <span style={{ fontSize: 11, fontFamily: 'var(--font-mono)', color: 'oklch(0.96 0.005 250)' }}>
+              {e.name}
+            </span>
+            <span style={{ fontSize: 11, fontFamily: 'var(--font-mono)', color: C.fg3, marginLeft: 4 }}>
+              {e.value}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function QASparkline({ daily }: { daily: AnalyticsQuality['qa_pass_rate_daily'] }) {
+  if (daily.length === 0) {
+    return <div style={{ height: 140, display: 'flex', alignItems: 'center', color: C.fg3, fontSize: 11 }}>No QA data</div>;
+  }
+  const chartData = daily.map(d => ({ date: d.date.slice(5), rate: Math.round(d.rate * 100) }));
+  return (
+    <ResponsiveContainer width="100%" height={140}>
+      <LineChart data={chartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+        <XAxis dataKey="date" tick={{ fill: C.fg3, fontSize: 9 }} axisLine={false} tickLine={false} />
+        <YAxis domain={[0, 100]} tick={{ fill: C.fg3, fontSize: 9 }} axisLine={false} tickLine={false} unit="%" />
+        <Tooltip contentStyle={TOOLTIP_STYLE} formatter={(v) => [`${v}%`, 'QA pass rate'] as [string, string]} />
+        <Line type="monotone" dataKey="rate" stroke={C.accent} strokeWidth={1.5} dot={false} />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}
+
+function StageFailureChart({ data }: { data: AnalyticsQuality['stage_failure'] }) {
+  const chartData = data.map(d => ({ stage: d.stage, pct: Math.round(d.fail_rate * 100), sample: d.sample }));
+  return (
+    <ResponsiveContainer width="100%" height={160}>
+      <BarChart data={chartData} layout="vertical" margin={{ top: 0, right: 8, left: 0, bottom: 0 }}>
+        <XAxis type="number" domain={[0, 100]} tick={{ fill: C.fg3, fontSize: 9 }} axisLine={false} tickLine={false} unit="%" />
+        <YAxis type="category" dataKey="stage" tick={{ fill: C.fg3, fontSize: 9 }} axisLine={false} tickLine={false} width={48} />
+        <Tooltip contentStyle={TOOLTIP_STYLE} formatter={(v, _n, p) => [`${v}% (n=${(p.payload as { sample: number }).sample})`, 'Fail rate'] as [string, string]} />
+        <Bar dataKey="pct" name="Fail %" fill={C.warn} radius={[0, 2, 2, 0]} maxBarSize={14} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+function ReworkHistogram({ data }: { data: AnalyticsQuality['rework_dist'] }) {
+  return (
+    <div>
+      <div style={{ display: 'flex', gap: 16, marginBottom: 8 }}>
+        {(['p50', 'p75', 'p95'] as const).map(k => (
+          <div key={k} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <span style={{ fontSize: 14, fontFamily: 'var(--font-mono)', fontWeight: 600, color: 'oklch(0.96 0.005 250)' }}>
+              {data[k].toFixed(1)}×
+            </span>
+            <span style={{ fontSize: 9, color: C.fg3, textTransform: 'uppercase', letterSpacing: '0.06em' }}>{k}</span>
+          </div>
+        ))}
+      </div>
+      <ResponsiveContainer width="100%" height={120}>
+        <BarChart data={data.buckets} margin={{ top: 0, right: 4, left: -20, bottom: 0 }}>
+          <XAxis dataKey="label" tick={{ fill: C.fg3, fontSize: 9 }} axisLine={false} tickLine={false} />
+          <YAxis tick={{ fill: C.fg3, fontSize: 9 }} axisLine={false} tickLine={false} />
+          <Tooltip contentStyle={TOOLTIP_STYLE} formatter={(v) => [v, 'Issues'] as [typeof v, string]} />
+          <Bar dataKey="count" name="Issues" fill={C.dev} radius={[2, 2, 0, 0]} maxBarSize={32} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+function FailureTypesRow({ data }: { data: AnalyticsQuality['failure_types'] }) {
+  const items: { label: string; value: number; color: string }[] = [
+    { label: 'PO',     value: data.po_failed,     color: 'oklch(0.74 0.16 295)' },
+    { label: 'Dev',    value: data.dev_failed,     color: C.dev },
+    { label: 'QA',     value: data.qa_fail,        color: C.qa },
+    { label: 'Review', value: data.review_failed,  color: 'oklch(0.74 0.16 0)' },
+    { label: 'Merge',  value: data.merge_failed,   color: C.accent },
+  ];
+  return (
+    <div style={{ display: 'flex', gap: 'var(--pad-3)', flexWrap: 'wrap' }}>
+      {items.map(it => (
+        <div key={it.label} style={{
+          flex: '1 1 0',
+          minWidth: 72,
+          padding: 'var(--pad-2) var(--pad-3)',
+          background: C.bg2,
+          border: `1px solid ${C.border}`,
+          borderRadius: 4,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 2,
+        }}>
+          <span style={{ fontSize: 18, fontFamily: 'var(--font-mono)', fontWeight: 600, color: it.color }}>
+            {it.value}
+          </span>
+          <span style={{ fontSize: 9, color: C.fg3, textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+            {it.label}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function Quality() {
+  const q = useQuery({
+    queryKey: ['analytics-quality'],
+    queryFn: () => fetchAnalyticsQuality(30),
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+
+  const data = q.data;
+  const loading = q.isLoading;
+
+  return (
+    <div style={{ display: 'grid', gap: 'var(--pad-3)', gridTemplateColumns: '1fr 1fr' }}>
+      <SubPanel title="Verdict Mix">
+        {loading || !data ? <Placeholder /> : <VerdictDonut data={data.verdicts} />}
+      </SubPanel>
+
+      <SubPanel title="QA Pass Rate (30d)">
+        {loading || !data ? <Placeholder height={140} /> : (
+          <div>
+            <div style={{ marginBottom: 6 }}>
+              <span style={{ fontSize: 22, fontFamily: 'var(--font-mono)', fontWeight: 600, color: C.accent }}>
+                {(data.qa_pass_rate * 100).toFixed(1)}%
+              </span>
+              <span style={{ fontSize: 9, color: C.fg3, marginLeft: 6, textTransform: 'uppercase', letterSpacing: '0.06em' }}>overall</span>
+            </div>
+            <QASparkline daily={data.qa_pass_rate_daily} />
+          </div>
+        )}
+      </SubPanel>
+
+      <SubPanel title="Stage Failure Rate">
+        {loading || !data ? <Placeholder height={160} /> : <StageFailureChart data={data.stage_failure} />}
+      </SubPanel>
+
+      <SubPanel title="Rework Factor Distribution">
+        {loading || !data ? <Placeholder height={160} /> : <ReworkHistogram data={data.rework_dist} />}
+      </SubPanel>
+
+      <div style={{ gridColumn: '1 / -1' }}>
+        <SubPanel title="Failures by Type">
+          {loading || !data ? <Placeholder height={60} /> : <FailureTypesRow data={data.failure_types} />}
+        </SubPanel>
+      </div>
+    </div>
+  );
+}

--- a/web/src/screens/Analytics.tsx
+++ b/web/src/screens/Analytics.tsx
@@ -1,0 +1,18 @@
+import Quality from '../panels/Quality';
+
+export default function Analytics() {
+  return (
+    <div>
+      <div className="screen-h">
+        <h1>Analytics</h1>
+      </div>
+      <div style={{ padding: 'var(--pad-3) var(--pad-4)' }}>
+        <div id="quality">
+          <Quality />
+        </div>
+        {/* capacity slot — Phase 2 */}
+        {/* flow slot — Phase 2 */}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #248

## Changes

**Backend — `server/routes/analytics.py`**
- New `GET /api/analytics/quality?days=30` endpoint returning verdict mix, QA pass rate (overall + daily), per-stage failure rates, rework-factor distribution (p50/p75/p95 + histogram), and failure-type counts.
- Verdict categories (clean/light_rework/heavy_rework/blocked) derived from `verdicts.points` thresholds (0/4/8).
- Rework-factor SQL re-uses the same `actual_runs / happy_path_runs` formula as the Cost screen (happy_path=5 for aggregate, no GH API call needed).
- Both `qa_failed` and `qa_fail` event types counted to handle both naming conventions.

**Frontend — `web/src/panels/Quality.tsx`**
- Verdict donut (PieChart) with legend
- QA pass rate: large number + daily sparkline (LineChart)
- Per-stage failure rate: horizontal BarChart
- Rework-factor histogram: p50/p75/p95 callouts + BarChart buckets
- Failure-types row: stat cards per stage

**Frontend — `web/src/screens/Analytics.tsx`**
- New screen mounting the `quality` slot; capacity/flow slots left as Phase 2 placeholders.

**Wiring**
- `server/app.py`: registered `analytics.router`
- `web/src/lib/types.ts`: added `AnalyticsQuality` / `AnalyticsQualityBucket`
- `web/src/lib/api.ts`: added `fetchAnalyticsQuality(days)`
- `web/src/App.tsx`: added `analytics` screen (key `7`), local state alongside `showCost`
- `web/src/components/NavRail.tsx`: added Analytics nav item with icon

**Tests — `tests/test_analytics_quality.py`**
- 8 tests covering: empty DB zeros, verdict categorisation, QA pass rate, stage failure rate, rework percentiles, failure type counts, days filter, daily QA grouping.

## Test Plan
- `ruff check .` — passes
- `cd web && npm run typecheck` — passes
- `cd web && npm run build` — passes (build warning about chunk size is pre-existing)
- `python3 -m pytest tests/test_analytics_quality.py -v` — 8/8 pass
- Navigate to Analytics (key `7` or nav rail) to see Quality panel