### PR TITLE
[LM-257] Decouple service from pipeline working tree; add redeploy script + stale SHA banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,35 @@ cp config/projects.yaml.example config/projects.yaml   # then edit
 
 Open http://127.0.0.1:18792.
 
+## Running as a macOS LaunchAgent (dedicated checkout)
+
+For production use, run the service from a dedicated clone so the autonomous
+pipeline's working tree never affects the running dashboard.
+
+### One-time bootstrap
+
+```bash
+git clone https://github.com/svv2014/loop-monitor.git \
+    ~/.openclaw/workspace/services/loop-monitor
+cd ~/.openclaw/workspace/services/loop-monitor
+pip install -r requirements.txt
+cd web && npm ci && npm run build && cd ..
+cp scripts/com.user.loop-watch.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.user.loop-watch.plist
+```
+
+### Updating the service
+
+Run `scripts/redeploy.sh` from the **services** checkout to pull latest main,
+rebuild the frontend, and restart the LaunchAgent:
+
+```bash
+bash ~/.openclaw/workspace/services/loop-monitor/scripts/redeploy.sh
+```
+
+The dashboard shows a warning banner when the running commit differs from the
+latest `main` commit. Dismiss the banner after redeploying.
+
 ## Bring your own pipeline
 
 loop-monitor is wire-compatible with any system that can POST a small JSON payload per stage transition. Three configuration files cover the common reuse cases:

--- a/scripts/com.user.loop-watch.plist
+++ b/scripts/com.user.loop-watch.plist
@@ -4,6 +4,10 @@
   Install:  cp scripts/com.user.loop-watch.plist ~/Library/LaunchAgents/
             launchctl load ~/Library/LaunchAgents/com.user.loop-watch.plist
   Disable:  launchctl unload ~/Library/LaunchAgents/com.user.loop-watch.plist
+  Redeploy: bash ~/.openclaw/workspace/services/loop-monitor/scripts/redeploy.sh
+  Bootstrap (one-time):
+            git clone https://github.com/svv2014/loop-monitor.git \
+                ~/.openclaw/workspace/services/loop-monitor
 -->
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -11,9 +15,12 @@
     <key>Label</key>
     <string>com.user.loop-watch</string>
 
+    <key>WorkingDirectory</key>
+    <string>/Users/vadim/.openclaw/workspace/services/loop-monitor</string>
+
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/vadim/.openclaw/workspace/projects/loop-monitor/scripts/loop-watch.sh</string>
+        <string>/Users/vadim/.openclaw/workspace/services/loop-monitor/scripts/loop-watch.sh</string>
     </array>
 
     <key>StartInterval</key>

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# redeploy.sh — pull latest main to the dedicated service checkout and restart the service.
+#
+# One-time bootstrap (run once, not by this script):
+#   git clone https://github.com/svv2014/loop-monitor.git \
+#       ~/.openclaw/workspace/services/loop-monitor
+#
+# Then to redeploy:
+#   bash scripts/redeploy.sh
+#
+# Idempotent — safe to run repeatedly.
+
+set -euo pipefail
+
+SERVICE_DIR="${HOME}/.openclaw/workspace/services/loop-monitor"
+PLIST_LABEL="com.user.loop-watch"
+
+if [[ ! -d "$SERVICE_DIR/.git" ]]; then
+    echo "ERROR: Service checkout not found at $SERVICE_DIR" >&2
+    echo "Bootstrap it first:" >&2
+    echo "  git clone https://github.com/svv2014/loop-monitor.git $SERVICE_DIR" >&2
+    exit 1
+fi
+
+cd "$SERVICE_DIR"
+
+echo "[redeploy] Fetching latest main..."
+git fetch origin
+git reset --hard origin/main
+
+if [[ -f requirements.txt ]]; then
+    echo "[redeploy] Installing Python dependencies..."
+    pip install -r requirements.txt --quiet
+fi
+
+echo "[redeploy] Building frontend..."
+cd web
+npm ci --silent
+npm run build
+
+cd "$SERVICE_DIR"
+
+echo "[redeploy] Restarting service (label: ${PLIST_LABEL})..."
+launchctl kickstart -k "gui/$(id -u)/${PLIST_LABEL}"
+
+echo "[redeploy] Done."

--- a/server/routes/health.py
+++ b/server/routes/health.py
@@ -1,5 +1,7 @@
 import sqlite3
 import subprocess
+import threading
+import time
 from pathlib import Path
 
 from fastapi import APIRouter, Depends
@@ -10,6 +12,11 @@ from server.db import db_dep
 router = APIRouter()
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_lms_lock = threading.Lock()
+_lms_sha: str | None = None
+_lms_at: float = 0.0
+_LMS_TTL = 60.0
 
 
 def _git_sha() -> str:
@@ -29,6 +36,28 @@ def _git_sha() -> str:
     return sha or "unknown"
 
 
+def _latest_main_sha() -> str | None:
+    global _lms_sha, _lms_at
+    with _lms_lock:
+        if time.monotonic() - _lms_at < _LMS_TTL:
+            return _lms_sha
+    try:
+        result = subprocess.run(
+            ["git", "ls-remote", "https://github.com/svv2014/loop-monitor.git", "refs/heads/main"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        line = result.stdout.strip()
+        sha = line.split()[0][:7] if result.returncode == 0 and line else None
+    except Exception:
+        sha = None
+    with _lms_lock:
+        _lms_sha = sha
+        _lms_at = time.monotonic()
+    return sha
+
+
 @router.get("/api/health")
 def health(conn: sqlite3.Connection = Depends(db_dep)):
     rows = conn.execute(
@@ -43,6 +72,7 @@ def health(conn: sqlite3.Connection = Depends(db_dep)):
         "status": "ok",
         "monitor_version": MONITOR_VERSION,
         "git_sha": _git_sha(),
+        "latest_main_sha": _latest_main_sha(),
         "supported_bounty_api": f"{SUPPORTED_API_MAJOR}.x",
         "core_version_counts": core_version_counts,
         "loop_ids": loop_ids,

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -98,3 +98,12 @@ def test_health_loop_ids_empty_db(isolated_client):
     data = resp.json()
     assert "loop_ids" in data
     assert data["loop_ids"] == []
+
+
+def test_health_latest_main_sha_field(isolated_client):
+    resp = isolated_client.get("/api/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "latest_main_sha" in data
+    sha = data["latest_main_sha"]
+    assert sha is None or re.match(r"^[0-9a-f]{7}$", sha)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import Logo from './components/Logo';
 import NavRail from './components/NavRail';
 import TopBar from './components/TopBar';
+import StaleBanner from './components/StaleBanner';
 import Overview from './screens/Overview';
 import Logs from './screens/Logs';
 import ProjectDetail from './screens/ProjectDetail';
@@ -103,11 +104,19 @@ export default function App() {
   }));
   const online = !activeQuery.isError;
   const version = healthQuery.data?.monitor_version ?? '…';
+  const runningSha = healthQuery.data?.git_sha ?? null;
+  const latestSha = healthQuery.data?.latest_main_sha ?? null;
+  const isStale =
+    runningSha != null &&
+    latestSha != null &&
+    runningSha !== 'unknown' &&
+    latestSha !== runningSha;
 
   return (
     <div className="app">
       <Logo />
       <TopBar events={events} online={online} version={version} />
+      {isStale && <StaleBanner runningSha={runningSha!} latestSha={latestSha!} />}
       <NavRail screen={isProjectDetail ? 'projects' : navScreen} setScreen={handleNavChange} />
       <main className="main">
         {showCost ? (

--- a/web/src/components/StaleBanner.tsx
+++ b/web/src/components/StaleBanner.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+
+interface StaleBannerProps {
+  runningSha: string;
+  latestSha: string;
+}
+
+export default function StaleBanner({ runningSha, latestSha }: StaleBannerProps) {
+  const [dismissed, setDismissed] = useState(false);
+
+  if (dismissed) return null;
+
+  return (
+    <div
+      style={{
+        gridArea: 'topbar',
+        marginTop: 'var(--topbar-h, 36px)',
+        background: 'var(--amber, #d97706)',
+        color: '#fff',
+        padding: '4px 12px',
+        fontSize: 12,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        zIndex: 10,
+        position: 'relative',
+      }}
+    >
+      <span className="mono" style={{ flex: 1 }}>
+        Running <strong>{runningSha}</strong> — main is at <strong>{latestSha}</strong>. Run{' '}
+        <code>scripts/redeploy.sh</code> to update.
+      </span>
+      <button
+        onClick={() => setDismissed(true)}
+        style={{
+          background: 'transparent',
+          border: '1px solid rgba(255,255,255,0.5)',
+          color: '#fff',
+          borderRadius: 3,
+          padding: '1px 8px',
+          cursor: 'pointer',
+          fontSize: 11,
+        }}
+      >
+        dismiss
+      </button>
+    </div>
+  );
+}

--- a/web/src/lib/fixtures.ts
+++ b/web/src/lib/fixtures.ts
@@ -287,6 +287,7 @@ export function getFixtureHealth(): Health {
     status: 'ok',
     monitor_version: '0.0.0-fixture',
     git_sha: 'c0ffee0',
+    latest_main_sha: 'abc1234',
     supported_bounty_api: '1.x',
     core_version_counts: { '1.0': 300, '1.1': 45 },
     loop_ids: ['loop-001', 'loop-002'],

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -135,6 +135,7 @@ export interface Health {
   status: string;
   monitor_version: string;
   git_sha: string;
+  latest_main_sha: string | null;
   supported_bounty_api: string;
   core_version_counts: Record<string, number>;
   loop_ids: string[];


### PR DESCRIPTION
Closes #257

> Note: CLAUDE.md is absent from this repo — implementation derived from issue body, repo inspection, and existing code patterns.

## Changes

**`scripts/redeploy.sh`** (new, executable)
- Pulls `origin/main` into the dedicated service checkout at `~/.openclaw/workspace/services/loop-monitor`
- Runs `pip install -r requirements.txt`, `npm ci && npm run build`
- Restarts the LaunchAgent via `launchctl kickstart -k gui/$(id -u)/com.user.loop-watch`
- Guards against missing service checkout with a clear error message
- Idempotent and exits non-zero on any failed step (`set -euo pipefail`)

**`scripts/com.user.loop-watch.plist`** (updated)
- Adds `WorkingDirectory` key pointing to `~/.openclaw/workspace/services/loop-monitor`
- Updates `ProgramArguments` path to the services checkout so the launchd process is fully decoupled from the pipeline working tree
- Keeps label `com.user.loop-watch` unchanged
- Adds redeploy/bootstrap instructions in the header comment

**`server/routes/health.py`** (updated)
- Adds `_latest_main_sha()` — calls `git ls-remote https://github.com/svv2014/loop-monitor.git refs/heads/main`, takes first 7 chars of the returned SHA
- Caches result for 60 s using a module-level lock + monotonic timestamp (stays under 200 ms when cache is warm; avoids GitHub rate limits)
- Returns `latest_main_sha` (string or null) in the `/api/health` response alongside the existing `git_sha`

**`web/src/lib/types.ts`** — adds `latest_main_sha: string | null` to `Health`

**`web/src/lib/fixtures.ts`** — adds `latest_main_sha: 'abc1234'` to fixture health response

**`web/src/components/StaleBanner.tsx`** (new)
- Amber warning banner rendered when `git_sha !== latest_main_sha` (and both are non-null/non-unknown)
- Shows running SHA vs latest main SHA and the `scripts/redeploy.sh` command
- Dismiss button hides the banner for the current session; reappears on next page load if still stale

**`web/src/App.tsx`** — imports and conditionally renders `<StaleBanner>` between TopBar and NavRail

**`tests/test_health.py`** — adds `test_health_latest_main_sha_field`: asserts field is present and is either null or a 7-char hex string

**`README.md`** — new "Running as a macOS LaunchAgent" section with one-time bootstrap steps and redeploy instructions

## Test Plan
- [ ] `ruff check .` — passes
- [ ] `tsc --noEmit` — passes
- [ ] `npm run build` — passes
- [ ] `pytest tests/test_health.py -v` — all 8 tests pass (Python 3.13)
- [ ] Manual: bootstrap services checkout, run `scripts/redeploy.sh`, confirm service restarts from latest main
- [ ] Manual: verify `/api/health` returns both `git_sha` and `latest_main_sha`
- [ ] Manual: with a stale checkout, dashboard shows the amber stale banner; dismiss clears it for the session