### PR TITLE
fix(web): set vite base to / after Phase 5 cutover (#259 follow-up)

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
-  base: '/v2/',
+  base: '/',
   build: {
     outDir: '../static/dist',
     emptyOutDir: true,


### PR DESCRIPTION
## Summary

PR #259 changed the server mount to serve `static/dist` at `/` and deleted vanilla JS, but missed flipping `web/vite.config.ts` `base` from `'/v2/'` to `'/'`. Rebuild produced `/v2/assets/...` URLs that no longer exist — every asset 404'd via SPA fallback to index.html. UI was broken on `/` until `vite.config.ts` was updated locally.

This PR closes that gap upstream.

## Test plan

- [x] `grep base web/vite.config.ts` → `base: '/'`
- [x] `npm run build && curl localhost:18792/` → HTML references `/assets/...`
- [x] Asset URL loads with HTTP 200 + correct content-length

🤖 Generated with [Claude Code](https://claude.com/claude-code)