### PR TITLE
[LM-110] Add per-ticket timeline view (API + UI)

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -30,6 +30,7 @@ from server.routes import (  # noqa: E402
     scanner_state,
     slos,
     stats,
+    timeline,
 )
 
 app.include_router(health.router)
@@ -46,6 +47,7 @@ app.include_router(logs.router)
 app.include_router(scanner_state.router)
 app.include_router(slos.router)
 app.include_router(config.router)
+app.include_router(timeline.router)
 
 app.mount("/", StaticFiles(directory="static/dist", html=True), name="webapp")
 

--- a/server/routes/timeline.py
+++ b/server/routes/timeline.py
@@ -1,0 +1,51 @@
+import json
+import sqlite3
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from server.db import db_dep
+
+router = APIRouter()
+
+
+@router.get("/api/timeline")
+def timeline(
+    slug: str,
+    num: int,
+    skip_reconcile_skip: bool = True,
+    conn: sqlite3.Connection = Depends(db_dep),
+):
+    """Return all events for a single issue/PR in chronological order."""
+    if not slug or num <= 0:
+        raise HTTPException(status_code=422, detail="slug and num are required")
+
+    rows = conn.execute(
+        """
+        SELECT id, project, role, model, event_type, issue_number, pr_number,
+               detail, payload, loop_id, created_at
+        FROM events
+        WHERE project = ?
+          AND (issue_number = ? OR pr_number = ?)
+        ORDER BY created_at ASC, id ASC
+        """,
+        (slug, num, num),
+    ).fetchall()
+
+    result = []
+    for r in rows:
+        entry = dict(r)
+        if entry["payload"]:
+            try:
+                entry["payload"] = json.loads(entry["payload"])
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        # Filter out reconcile_check events where decision == 'skip'
+        if skip_reconcile_skip and entry.get("event_type") == "reconcile_check":
+            payload = entry.get("payload")
+            if isinstance(payload, dict) and payload.get("decision") == "skip":
+                continue
+
+        result.append(entry)
+
+    return {"events": result}

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,0 +1,118 @@
+import json
+import sqlite3
+
+import server
+import server.db
+
+
+def _insert_raw(
+    slug: str, issue_num: int | None, event_type: str,
+    payload: dict | None = None, pr_num: int | None = None,
+):
+    """Insert directly into the events table for precise test control."""
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        "INSERT INTO events (project, role, event_type, issue_number, pr_number, payload, created_at)"
+        " VALUES (?, ?, ?, ?, ?, ?, datetime('now'))",
+        (slug, "test-role", event_type, issue_num, pr_num, json.dumps(payload) if payload else None),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_timeline_happy_path(isolated_client):
+    """Events for a valid slug+num are returned in ascending order."""
+    _insert_raw("proj-a", 7, "dev_start")
+    _insert_raw("proj-a", 7, "dev_done")
+
+    resp = isolated_client.get("/api/timeline?slug=proj-a&num=7")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "events" in data
+    events = data["events"]
+    assert len(events) == 2
+    # Verify ascending order by checking event types sequence
+    types = [e["event_type"] for e in events]
+    assert types == ["dev_start", "dev_done"]
+
+
+def test_timeline_empty_result(isolated_client):
+    """Returns {events: []} with HTTP 200 when no events exist for the slug+num."""
+    resp = isolated_client.get("/api/timeline?slug=nonexistent-proj&num=999")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data == {"events": []}
+
+
+def test_timeline_skip_reconcile_skip_default(isolated_client):
+    """reconcile_check events with decision=skip are hidden by default."""
+    _insert_raw("proj-b", 3, "dev_start")
+    _insert_raw("proj-b", 3, "reconcile_check", payload={"decision": "skip", "reason": "no change"})
+    _insert_raw("proj-b", 3, "reconcile_check", payload={"decision": "act", "reason": "labels changed"})
+    _insert_raw("proj-b", 3, "dev_done")
+
+    # Default: skip_reconcile_skip=true → only 3 events
+    resp = isolated_client.get("/api/timeline?slug=proj-b&num=3")
+    assert resp.status_code == 200
+    data = resp.json()
+    events = data["events"]
+    assert "reconcile_check" not in [
+        e["event_type"] for e in events
+        if isinstance(e.get("payload"), dict) and e["payload"].get("decision") == "skip"
+    ]
+    # The act event should still be present
+    assert any(e["event_type"] == "reconcile_check" for e in events), "non-skip reconcile_check should survive"
+    assert len(events) == 3  # dev_start + reconcile_check(act) + dev_done
+
+
+def test_timeline_show_skipped_events_when_toggled(isolated_client):
+    """All events including reconcile_check/skip are returned when skip_reconcile_skip=false."""
+    _insert_raw("proj-c", 5, "dev_start")
+    _insert_raw("proj-c", 5, "reconcile_check", payload={"decision": "skip"})
+    _insert_raw("proj-c", 5, "dev_done")
+
+    resp = isolated_client.get("/api/timeline?slug=proj-c&num=5&skip_reconcile_skip=false")
+    assert resp.status_code == 200
+    data = resp.json()
+    events = data["events"]
+    assert len(events) == 3
+    skip_events = [e for e in events if e.get("event_type") == "reconcile_check"]
+    assert len(skip_events) == 1
+
+
+def test_timeline_filters_by_slug_and_num(isolated_client):
+    """Events from other projects or issue numbers are not included."""
+    _insert_raw("proj-d", 1, "po_done")
+    _insert_raw("proj-d", 2, "qa_pass")
+    _insert_raw("proj-e", 1, "merge_done")
+
+    resp = isolated_client.get("/api/timeline?slug=proj-d&num=1")
+    assert resp.status_code == 200
+    events = resp.json()["events"]
+    assert len(events) == 1
+    assert events[0]["event_type"] == "po_done"
+    assert events[0]["project"] == "proj-d"
+
+
+def test_timeline_includes_pr_number_events(isolated_client):
+    """Events matching by pr_number are also included."""
+    _insert_raw("proj-f", None, "merge_done", pr_num=42)
+
+    resp = isolated_client.get("/api/timeline?slug=proj-f&num=42")
+    assert resp.status_code == 200
+    events = resp.json()["events"]
+    assert len(events) == 1
+    assert events[0]["pr_number"] == 42
+
+
+def test_timeline_payload_decoded_as_json(isolated_client):
+    """Payload is returned as a decoded object, not a JSON string."""
+    _insert_raw("proj-g", 10, "label_change", payload={"label": "loop:stage:dev", "action": "added"})
+
+    resp = isolated_client.get("/api/timeline?slug=proj-g&num=10")
+    assert resp.status_code == 200
+    events = resp.json()["events"]
+    assert len(events) == 1
+    payload = events[0]["payload"]
+    assert isinstance(payload, dict)
+    assert payload["label"] == "loop:stage:dev"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import ProjectDetail from './screens/ProjectDetail';
 import Queue from './screens/Queue';
 import WorkerDetail from './screens/WorkerDetail';
 import Cost from './screens/Cost';
+import Timeline from './screens/Timeline';
 import { useHashRoute } from './router';
 import { fetchActive, fetchHealth } from './lib/api';
 
@@ -22,13 +23,14 @@ const SCREEN_KEYS: Record<string, string> = {
 };
 
 export default function App() {
-  const { screen: hashScreen, projectId: hashProjectId, navigateTo } = useHashRoute();
+  const { screen: hashScreen, projectId: hashProjectId, ticketNum: hashTicketNum, navigateTo } = useHashRoute();
 
   // 'cost' is local-only — not stored in the hash — so we track it separately.
   const [showCost, setShowCost] = useState(false);
 
   // Derive nav screen from hash. 'project' is a sub-state of 'projects' nav item.
-  const hashNavScreen = hashScreen === 'project' ? 'projects' : hashScreen;
+  // 'timeline' is also a sub-state of 'projects' nav item.
+  const hashNavScreen = (hashScreen === 'project' || hashScreen === 'timeline') ? 'projects' : hashScreen;
   // When cost is active, override; otherwise use hash-derived value.
   const navScreen = showCost ? 'cost' : hashNavScreen;
   const projectId = hashProjectId;
@@ -56,11 +58,17 @@ export default function App() {
       setShowCost(true);
     } else {
       setShowCost(false);
-      navigateTo(s as 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs', null, {
+      navigateTo(s as 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs' | 'timeline', null, {
         drawer: null,
+        ticketNum: null,
         pushState: true,
       });
     }
+  }
+
+  function handleTimelineOpen(slug: string, num: number) {
+    setShowCost(false);
+    navigateTo('timeline', slug, { ticketNum: num, drawer: null, pushState: true });
   }
 
   function handleProjectChange(id: string) {
@@ -73,7 +81,8 @@ export default function App() {
     navigateTo('overview', null, { pushState: true });
   }
 
-  const isProjectDetail = hashNavScreen === 'projects' && projectId != null;
+  const isProjectDetail = hashScreen === 'project' && projectId != null;
+  const isTimeline = hashScreen === 'timeline' && projectId != null && hashTicketNum != null;
 
   const activeQuery = useQuery({
     queryKey: ['active'],
@@ -108,16 +117,23 @@ export default function App() {
     <div className="app">
       <Logo />
       <TopBar events={events} online={online} version={version} />
-      <NavRail screen={isProjectDetail ? 'projects' : navScreen} setScreen={handleNavChange} />
+      <NavRail screen={(isProjectDetail || isTimeline) ? 'projects' : navScreen} setScreen={handleNavChange} />
       <main className="main">
         {showCost ? (
           <Cost />
+        ) : isTimeline && projectId != null && hashTicketNum != null ? (
+          <Timeline
+            slug={projectId}
+            num={hashTicketNum}
+            onBack={() => navigateTo('project', projectId, { drawer: null, ticketNum: null, pushState: true })}
+          />
         ) : isProjectDetail && projectId != null ? (
           <ProjectDetail
             projectId={projectId}
             allProjectIds={allProjectIds.length > 0 ? allProjectIds : [projectId]}
             onBack={handleBack}
             onProjectChange={handleProjectChange}
+            onTimelineOpen={handleTimelineOpen}
           />
         ) : hashNavScreen === 'overview' ? (
           <Overview />

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useState } from 'react';
 
-export type Screen = 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs';
+export type Screen = 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs' | 'timeline';
 
 export interface HashRoute {
   screen: Screen;
   projectId: string | null;
   drawer: string | null;
+  ticketNum: number | null;
 }
 
 function parseHash(hash: string): { known: HashRoute; unknown: Record<string, string> } {
@@ -13,7 +14,7 @@ function parseHash(hash: string): { known: HashRoute; unknown: Record<string, st
 
   if (!hash || hash === '#') {
     return {
-      known: { screen: 'overview', projectId: null, drawer: null },
+      known: { screen: 'overview', projectId: null, drawer: null, ticketNum: null },
       unknown,
     };
   }
@@ -28,6 +29,7 @@ function parseHash(hash: string): { known: HashRoute; unknown: Record<string, st
   let screen: Screen = 'overview';
   let projectId: string | null = null;
   let drawer: string | null = null;
+  let ticketNum: number | null = null;
 
   for (const [key, value] of params.entries()) {
     if (key === 'screen') {
@@ -40,24 +42,28 @@ function parseHash(hash: string): { known: HashRoute; unknown: Record<string, st
       }
     } else if (key === 'drawer') {
       drawer = value;
+    } else if (key === 'num') {
+      const parsed = parseInt(value, 10);
+      if (!isNaN(parsed) && parsed > 0) ticketNum = parsed;
     } else {
       unknown[key] = value;
     }
   }
 
-  return { known: { screen, projectId, drawer }, unknown };
+  return { known: { screen, projectId, drawer, ticketNum }, unknown };
 }
 
 function buildHash(
   screen: Screen,
   projectId: string | null,
   drawer: string | null,
+  ticketNum: number | null,
   unknown: Record<string, string>,
 ): string {
   const params = new URLSearchParams();
 
   // Write screen (omit if it's 'overview' AND everything else is empty — keep URLs clean)
-  const hasOtherKeys = projectId || drawer || Object.keys(unknown).length > 0;
+  const hasOtherKeys = projectId || drawer || ticketNum != null || Object.keys(unknown).length > 0;
   if (screen !== 'overview' || hasOtherKeys) {
     params.set('screen', screen);
   }
@@ -68,6 +74,10 @@ function buildHash(
 
   if (drawer) {
     params.set('drawer', drawer);
+  }
+
+  if (ticketNum != null) {
+    params.set('num', String(ticketNum));
   }
 
   for (const [key, value] of Object.entries(unknown)) {
@@ -93,17 +103,18 @@ export function useHashRoute() {
     (
       screen: Screen,
       projectId: string | null = null,
-      opts?: { drawer?: string | null; pushState?: boolean },
+      opts?: { drawer?: string | null; ticketNum?: number | null; pushState?: boolean },
     ) => {
       const drawer = opts?.drawer !== undefined ? opts.drawer : route.drawer;
-      const hash = buildHash(screen, projectId, drawer ?? null, unknown);
+      const ticketNum = opts?.ticketNum !== undefined ? opts.ticketNum : null;
+      const hash = buildHash(screen, projectId, drawer ?? null, ticketNum ?? null, unknown);
       if (opts?.pushState) {
         history.pushState(null, '', window.location.pathname + window.location.search + hash);
       } else {
         history.replaceState(null, '', window.location.pathname + window.location.search + hash);
       }
       setParsed(prev => ({
-        known: { screen, projectId, drawer: drawer ?? null },
+        known: { screen, projectId, drawer: drawer ?? null, ticketNum: ticketNum ?? null },
         unknown: prev.unknown,
       }));
     },
@@ -112,20 +123,21 @@ export function useHashRoute() {
 
   const setDrawer = useCallback(
     (drawer: string | null) => {
-      const hash = buildHash(route.screen, route.projectId, drawer, unknown);
+      const hash = buildHash(route.screen, route.projectId, drawer, route.ticketNum, unknown);
       history.replaceState(null, '', window.location.pathname + window.location.search + hash);
       setParsed(prev => ({
         known: { ...prev.known, drawer },
         unknown: prev.unknown,
       }));
     },
-    [route.screen, route.projectId, unknown],
+    [route.screen, route.projectId, route.ticketNum, unknown],
   );
 
   return {
     screen: route.screen,
     projectId: route.projectId,
     drawer: route.drawer,
+    ticketNum: route.ticketNum,
     navigateTo,
     setDrawer,
   };

--- a/web/src/screens/ProjectDetail.tsx
+++ b/web/src/screens/ProjectDetail.tsx
@@ -16,6 +16,7 @@ interface ProjectDetailProps {
   allProjectIds: string[];
   onBack: () => void;
   onProjectChange: (id: string) => void;
+  onTimelineOpen: (slug: string, num: number) => void;
 }
 
 const ROLE_COLORS: Record<string, string> = {
@@ -162,7 +163,7 @@ function CycleTimePanel({ cycleTimes, slo, runs }: CycleTimePanelProps) {
   );
 }
 
-export default function ProjectDetail({ projectId, allProjectIds, onBack, onProjectChange }: ProjectDetailProps) {
+export default function ProjectDetail({ projectId, allProjectIds, onBack, onProjectChange, onTimelineOpen }: ProjectDetailProps) {
   const [runs, setRuns] = useState<PipelineRun[]>([]);
   const [prs, setPrs] = useState<PRMonitorEntry[]>([]);
   const [feed, setFeed] = useState<FeedItem[]>([]);
@@ -336,11 +337,12 @@ export default function ProjectDetail({ projectId, allProjectIds, onBack, onProj
                   <th style={{ textAlign: 'right' }}>Runs</th>
                   <th>Last</th>
                   <th style={{ textAlign: 'right' }}>Pts</th>
+                  <th></th>
                 </tr>
               </thead>
               <tbody>
                 {issues.length === 0 && (
-                  <tr><td colSpan={5} className="muted" style={{ textAlign: 'center', padding: 'var(--pad-3)' }}>No runs yet</td></tr>
+                  <tr><td colSpan={6} className="muted" style={{ textAlign: 'center', padding: 'var(--pad-3)' }}>No runs yet</td></tr>
                 )}
                 {issues.map(i => (
                   <tr key={i.num}>
@@ -358,6 +360,16 @@ export default function ProjectDetail({ projectId, allProjectIds, onBack, onProj
                       {i.lastAt ? relTime(i.lastAt) : '—'}
                     </td>
                     <td className="num" style={{ textAlign: 'right' }}>{i.pts}</td>
+                    <td>
+                      <button
+                        className="btn"
+                        style={{ fontSize: 10, padding: '1px 6px' }}
+                        onClick={() => onTimelineOpen(projectId, i.num)}
+                        title={`View timeline for #${i.num}`}
+                      >
+                        timeline
+                      </button>
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/web/src/screens/Timeline.tsx
+++ b/web/src/screens/Timeline.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useState } from 'react';
+
+interface TimelineEvent {
+  id: number;
+  project: string;
+  role: string | null;
+  model: string | null;
+  event_type: string;
+  issue_number: number | null;
+  pr_number: number | null;
+  detail: string | null;
+  payload: Record<string, unknown> | null;
+  loop_id: string | null;
+  created_at: string;
+}
+
+interface TimelineResponse {
+  events: TimelineEvent[];
+}
+
+interface TimelineProps {
+  slug: string;
+  num: number;
+  onBack: () => void;
+}
+
+const BADGE_STYLES: Record<string, { color: string; bg: string }> = {
+  label_change:     { color: '#a78bfa', bg: 'rgba(167,139,250,0.12)' },
+  reconcile:        { color: '#34d399', bg: 'rgba(52,211,153,0.12)' },
+  reconcile_check:  { color: '#6ee7b7', bg: 'rgba(110,231,183,0.10)' },
+  handler:          { color: '#60a5fa', bg: 'rgba(96,165,250,0.12)' },
+  merge:            { color: '#f59e0b', bg: 'rgba(245,158,11,0.12)' },
+};
+
+const NEUTRAL_BADGE = { color: 'var(--fg-3)', bg: 'var(--bg-2)' };
+
+function badgeStyle(eventType: string): { color: string; bg: string } {
+  for (const prefix of Object.keys(BADGE_STYLES)) {
+    if (eventType === prefix || eventType.startsWith(prefix + '_') || eventType.startsWith(prefix + ':')) {
+      return BADGE_STYLES[prefix];
+    }
+  }
+  return NEUTRAL_BADGE;
+}
+
+function fmtTs(isoStr: string): string {
+  try {
+    const d = new Date(isoStr.includes('T') ? isoStr : isoStr + 'Z');
+    return d.toLocaleString(undefined, {
+      month: 'short', day: 'numeric',
+      hour: '2-digit', minute: '2-digit', second: '2-digit',
+    });
+  } catch {
+    return isoStr;
+  }
+}
+
+export default function Timeline({ slug, num, onBack }: TimelineProps) {
+  const [events, setEvents] = useState<TimelineEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [showSkipped, setShowSkipped] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(false);
+    const skipParam = showSkipped ? 'false' : 'true';
+    fetch(`/api/timeline?slug=${encodeURIComponent(slug)}&num=${num}&skip_reconcile_skip=${skipParam}`)
+      .then(r => r.ok ? r.json() : Promise.reject(r.status))
+      .then((data: TimelineResponse) => {
+        setEvents(data.events);
+        setLoading(false);
+      })
+      .catch(() => {
+        setError(true);
+        setLoading(false);
+      });
+  }, [slug, num, showSkipped]);
+
+  return (
+    <div data-testid="timeline">
+      {/* Header */}
+      <div className="screen-h" style={{ display: 'flex', alignItems: 'center', gap: 'var(--pad-3)', padding: 'var(--pad-2) var(--pad-4)' }}>
+        <button className="btn" onClick={onBack}>← Back</button>
+        <h1 style={{ flex: 1, margin: 0, fontFamily: 'var(--font-mono)', fontSize: 13, fontWeight: 500, letterSpacing: '0.04em' }}>
+          <span className="muted">timeline /</span> {slug} <span className="muted">·</span> #{num}
+        </h1>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: 'var(--fg-3)', cursor: 'pointer' }}>
+          <input
+            type="checkbox"
+            checked={showSkipped}
+            onChange={e => setShowSkipped(e.target.checked)}
+          />
+          Show reconcile skips
+        </label>
+      </div>
+
+      {/* Body */}
+      <div style={{ padding: 'var(--pad-4)' }}>
+        {loading && (
+          <div className="muted" style={{ textAlign: 'center', padding: 'var(--pad-4)', fontSize: 12 }}>
+            Loading…
+          </div>
+        )}
+        {error && (
+          <div style={{ color: 'var(--fail)', textAlign: 'center', padding: 'var(--pad-4)', fontSize: 12 }}>
+            Failed to load timeline
+          </div>
+        )}
+        {!loading && !error && events.length === 0 && (
+          <div className="muted" style={{ textAlign: 'center', padding: 'var(--pad-4)', fontSize: 13 }}>
+            No events recorded for this ticket
+          </div>
+        )}
+        {!loading && !error && events.length > 0 && (
+          <div style={{ position: 'relative', paddingLeft: 24 }}>
+            {/* Vertical line */}
+            <div style={{
+              position: 'absolute', left: 7, top: 8, bottom: 8,
+              width: 2, background: 'var(--border)',
+            }} />
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--pad-3)' }}>
+              {events.map(ev => {
+                const bs = badgeStyle(ev.event_type);
+                return (
+                  <div key={ev.id} style={{ position: 'relative', display: 'grid', gridTemplateColumns: '1fr', gap: 4 }}>
+                    {/* Dot on the line */}
+                    <div style={{
+                      position: 'absolute', left: -21, top: 6,
+                      width: 8, height: 8, borderRadius: '50%',
+                      background: bs.color, border: '2px solid var(--bg)',
+                      flexShrink: 0,
+                    }} />
+
+                    {/* Event card */}
+                    <div style={{
+                      background: 'var(--bg-2)',
+                      border: '1px solid var(--border)',
+                      padding: 'var(--pad-2) var(--pad-3)',
+                      display: 'flex', flexDirection: 'column', gap: 4,
+                    }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                        <span style={{
+                          fontFamily: 'var(--font-mono)', fontSize: 11,
+                          padding: '1px 6px',
+                          background: bs.bg, color: bs.color,
+                          border: `1px solid ${bs.color}`,
+                        }}>
+                          {ev.event_type}
+                        </span>
+                        {ev.role && (
+                          <span className="tag muted mono" style={{ fontSize: 10 }}>{ev.role}</span>
+                        )}
+                        {ev.model && (
+                          <span className="muted mono" style={{ fontSize: 10 }}>{ev.model}</span>
+                        )}
+                        <span className="muted mono" style={{ fontSize: 10, marginLeft: 'auto' }}>
+                          {fmtTs(ev.created_at)}
+                        </span>
+                      </div>
+                      {ev.detail && (
+                        <div className="muted" style={{ fontSize: 11 }}>{ev.detail}</div>
+                      )}
+                      {ev.payload && Object.keys(ev.payload).length > 0 && (
+                        <pre style={{
+                          margin: 0, fontSize: 10, color: 'var(--fg-3)',
+                          background: 'var(--bg)', padding: '4px 6px',
+                          overflow: 'auto', maxHeight: 120,
+                          whiteSpace: 'pre-wrap', wordBreak: 'break-all',
+                        }}>
+                          {JSON.stringify(ev.payload, null, 2)}
+                        </pre>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #110

## Changes
- Added `GET /api/timeline?slug=X&num=N` backend route reading from the events table (uses indexes from #109)
- `reconcile_check` events with `decision=skip` filtered by default; toggle via `skip_reconcile_skip=false`
- Added Timeline screen at hash route `#screen=timeline&project=X&num=N` with vertical timeline and type badges
- Extended hash router (`router.tsx`) with `ticketNum` param and `timeline` screen type
- Wired timeline into App.tsx with back-navigation to project detail
- Added "timeline" button per row in the ProjectDetail issues table
- Added 7 pytest tests covering happy path, empty result, skip-filter default, toggle, cross-project isolation, PR-number matching, and payload decoding

## Test Plan
- Navigate to a project in the dashboard, click a ticket's "timeline" button → lands on timeline page
- Verify events appear in chronological order with type-coloured badges
- Verify `reconcile_check/skip` events are hidden by default and revealed via toggle checkbox
- Verify empty state message for tickets with no events
- Run: `ruff check . && cd web && npm run typecheck && npm run build && cd .. && pytest tests/test_timeline.py -v`