### PR TITLE
[LM-257] Dedicated service checkout: redeploy script + sha lag banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,53 @@ cp config/projects.yaml.example config/projects.yaml   # then edit
 
 Open http://127.0.0.1:18792.
 
+## Running as a macOS service (LaunchAgent)
+
+The recommended setup runs the dashboard from a dedicated checkout that the pipeline never touches, so branch switches by automation can't cause the service to serve stale code.
+
+### One-time bootstrap
+
+```bash
+# 1. Clone into the dedicated service directory
+git clone https://github.com/svv2014/loop-monitor.git \
+  ~/.openclaw/workspace/services/loop-monitor
+
+# 2. Install Python deps and build the frontend
+cd ~/.openclaw/workspace/services/loop-monitor
+pip install -r requirements.txt
+cd web && npm ci && npm run build && cd ..
+
+# 3. Configure the dashboard (copy and edit)
+cp config/projects.yaml.example config/projects.yaml
+
+# 4. Install both LaunchAgents
+cp scripts/com.user.loop-monitor.plist ~/Library/LaunchAgents/
+cp scripts/com.user.loop-watch.plist   ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.user.loop-monitor.plist
+launchctl load ~/Library/LaunchAgents/com.user.loop-watch.plist
+launchctl start com.user.loop-monitor
+```
+
+> **Note:** The plist files hardcode `/Users/vadim/` — edit them to match your home directory before loading.
+
+### Redeploying to latest main
+
+```bash
+# From anywhere — updates the service checkout and restarts the server
+~/.openclaw/workspace/services/loop-monitor/scripts/redeploy.sh
+```
+
+The dashboard shows a warning banner when the running SHA is behind the latest `main`. Run `scripts/redeploy.sh` to clear it.
+
+### How it works
+
+| Component | Plist label | What it does |
+|-----------|-------------|--------------|
+| HTTP server | `com.user.loop-monitor` | Serves the dashboard at :18792, `KeepAlive=true` |
+| Loop watcher | `com.user.loop-watch` | Polls GitHub every 2h, POSTs events to the server |
+
+Both run from `~/.openclaw/workspace/services/loop-monitor` — a stable clone that `redeploy.sh` keeps on `origin/main`. The pipeline working tree (`projects/loop-monitor`) is never touched.
+
 ## Bring your own pipeline
 
 loop-monitor is wire-compatible with any system that can POST a small JSON payload per stage transition. Three configuration files cover the common reuse cases:

--- a/scripts/com.user.loop-monitor.plist
+++ b/scripts/com.user.loop-monitor.plist
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  loop-monitor HTTP server — serves the dashboard at http://127.0.0.1:18792.
+  Runs from the dedicated service checkout (NOT the pipeline working tree).
+
+  Bootstrap (one-time):
+    git clone https://github.com/svv2014/loop-monitor.git \
+      ~/.openclaw/workspace/services/loop-monitor
+    cd ~/.openclaw/workspace/services/loop-monitor
+    pip install -r requirements.txt
+    cd web && npm ci && npm run build && cd ..
+
+  Install:
+    cp scripts/com.user.loop-monitor.plist ~/Library/LaunchAgents/
+    launchctl load ~/Library/LaunchAgents/com.user.loop-monitor.plist
+    launchctl start com.user.loop-monitor
+
+  Redeploy to latest main:
+    scripts/redeploy.sh
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-monitor.plist
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-monitor</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/vadim/.openclaw/workspace/services/loop-monitor/run.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/vadim/.openclaw/workspace/services/loop-monitor</string>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/loop-monitor.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/loop-monitor.err.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>/Users/vadim</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/com.user.loop-watch.plist
+++ b/scripts/com.user.loop-watch.plist
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  loop-watch — temporary observability for the Loop pipeline.
+  loop-watch — periodic watcher for the Loop pipeline.
+  Runs from the dedicated service checkout (NOT the pipeline working tree).
+
   Install:  cp scripts/com.user.loop-watch.plist ~/Library/LaunchAgents/
             launchctl load ~/Library/LaunchAgents/com.user.loop-watch.plist
   Disable:  launchctl unload ~/Library/LaunchAgents/com.user.loop-watch.plist
@@ -13,8 +15,11 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/vadim/.openclaw/workspace/projects/loop-monitor/scripts/loop-watch.sh</string>
+        <string>/Users/vadim/.openclaw/workspace/services/loop-monitor/scripts/loop-watch.sh</string>
     </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/vadim/.openclaw/workspace/services/loop-monitor</string>
 
     <key>StartInterval</key>
     <integer>7200</integer>

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Redeploy loop-monitor from the dedicated service checkout.
+# Idempotent — safe to run multiple times.
+# Usage: scripts/redeploy.sh
+set -euo pipefail
+
+SERVICE_DIR="${LOOP_MONITOR_SERVICE_DIR:-$HOME/.openclaw/workspace/services/loop-monitor}"
+PLIST_LABEL="com.user.loop-monitor"
+
+if [[ ! -d "$SERVICE_DIR/.git" ]]; then
+  echo "ERROR: $SERVICE_DIR is not a git repository." >&2
+  echo "Bootstrap: git clone https://github.com/svv2014/loop-monitor.git $SERVICE_DIR" >&2
+  exit 1
+fi
+
+cd "$SERVICE_DIR"
+
+echo "==> Fetching origin/main ..."
+git fetch origin
+git reset --hard origin/main
+
+if [[ -f requirements.txt ]]; then
+  echo "==> Installing Python dependencies ..."
+  pip install -r requirements.txt --quiet
+fi
+
+echo "==> Building web frontend ..."
+cd web
+npm ci --silent
+npm run build
+cd ..
+
+echo "==> Restarting $PLIST_LABEL ..."
+launchctl kickstart -k "gui/$(id -u)/$PLIST_LABEL"
+
+echo "==> Done. Running $(git rev-parse --short HEAD)."

--- a/server/routes/health.py
+++ b/server/routes/health.py
@@ -1,5 +1,7 @@
 import sqlite3
 import subprocess
+import threading
+import time
 from pathlib import Path
 
 from fastapi import APIRouter, Depends
@@ -10,6 +12,13 @@ from server.db import db_dep
 router = APIRouter()
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+_REMOTE_URL = "https://github.com/svv2014/loop-monitor.git"
+_CACHE_TTL = 60.0
+
+_cache_lock = threading.Lock()
+_cache_sha: str | None = None
+_cache_commits_behind: int | None = None
+_cache_fetched_at: float = 0.0
 
 
 def _git_sha() -> str:
@@ -29,6 +38,75 @@ def _git_sha() -> str:
     return sha or "unknown"
 
 
+def _refresh_latest_main() -> tuple[str, int | None]:
+    try:
+        ls = subprocess.run(
+            ["git", "ls-remote", _REMOTE_URL, "refs/heads/main"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if ls.returncode != 0 or not ls.stdout.strip():
+            return "unknown", None
+        full_sha = ls.stdout.strip().split()[0]
+        latest_sha = full_sha[:7]
+    except Exception:
+        return "unknown", None
+
+    commits_behind: int | None = None
+    try:
+        running = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            cwd=_REPO_ROOT,
+        )
+        if running.returncode == 0:
+            running_full = running.stdout.strip()
+            if running_full != full_sha:
+                # Fetch remote objects so rev-list can traverse them
+                subprocess.run(
+                    ["git", "fetch", "origin", "main", "--quiet"],
+                    capture_output=True,
+                    timeout=15,
+                    cwd=_REPO_ROOT,
+                )
+                rev = subprocess.run(
+                    ["git", "rev-list", f"{running_full}..origin/main", "--count"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                    cwd=_REPO_ROOT,
+                )
+                if rev.returncode == 0:
+                    commits_behind = int(rev.stdout.strip())
+            else:
+                commits_behind = 0
+    except Exception:
+        pass
+
+    return latest_sha, commits_behind
+
+
+def _get_latest_main() -> tuple[str, int | None]:
+    global _cache_sha, _cache_commits_behind, _cache_fetched_at
+
+    now = time.monotonic()
+    with _cache_lock:
+        if _cache_sha is not None and now - _cache_fetched_at < _CACHE_TTL:
+            return _cache_sha, _cache_commits_behind
+
+    sha, behind = _refresh_latest_main()
+
+    with _cache_lock:
+        _cache_sha = sha
+        _cache_commits_behind = behind
+        _cache_fetched_at = time.monotonic()
+
+    return sha, behind
+
+
 @router.get("/api/health")
 def health(conn: sqlite3.Connection = Depends(db_dep)):
     rows = conn.execute(
@@ -39,10 +117,13 @@ def health(conn: sqlite3.Connection = Depends(db_dep)):
         "SELECT DISTINCT COALESCE(loop_id, '(unknown)') AS loop_id FROM events ORDER BY loop_id"
     ).fetchall()
     loop_ids = [r["loop_id"] for r in loop_rows]
+    latest_main_sha, commits_behind = _get_latest_main()
     return {
         "status": "ok",
         "monitor_version": MONITOR_VERSION,
         "git_sha": _git_sha(),
+        "latest_main_sha": latest_main_sha,
+        "commits_behind": commits_behind,
         "supported_bounty_api": f"{SUPPORTED_API_MAJOR}.x",
         "core_version_counts": core_version_counts,
         "loop_ids": loop_ids,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -104,10 +104,59 @@ export default function App() {
   const online = !activeQuery.isError;
   const version = healthQuery.data?.monitor_version ?? '…';
 
+  const runningSha = healthQuery.data?.git_sha;
+  const latestSha = healthQuery.data?.latest_main_sha;
+  const commitsBehind = healthQuery.data?.commits_behind ?? null;
+  const shaMismatch =
+    runningSha != null &&
+    latestSha != null &&
+    latestSha !== 'unknown' &&
+    runningSha !== latestSha;
+
+  const [bannerDismissedFor, setBannerDismissedFor] = useState<string | null>(null);
+  const bannerVisible = shaMismatch && bannerDismissedFor !== latestSha;
+
   return (
     <div className="app">
       <Logo />
       <TopBar events={events} online={online} version={version} />
+      {bannerVisible && (
+        <div
+          style={{
+            gridColumn: '1 / -1',
+            background: 'var(--amber, #b45309)',
+            color: '#fff',
+            padding: '6px 16px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
+            fontSize: 12,
+            fontFamily: 'var(--font-mono, monospace)',
+          }}
+        >
+          <span>
+            Service is behind main —{' '}
+            running <strong>{runningSha}</strong>, latest <strong>{latestSha}</strong>
+            {commitsBehind != null && commitsBehind > 0 ? ` (${commitsBehind} commit${commitsBehind === 1 ? '' : 's'} behind)` : ''}
+            . Run <code style={{ background: 'rgba(0,0,0,0.2)', padding: '1px 4px', borderRadius: 3 }}>scripts/redeploy.sh</code> to update.
+          </span>
+          <button
+            onClick={() => setBannerDismissedFor(latestSha ?? null)}
+            style={{
+              marginLeft: 'auto',
+              background: 'none',
+              border: 'none',
+              color: '#fff',
+              cursor: 'pointer',
+              fontSize: 14,
+              padding: '0 4px',
+            }}
+            aria-label="Dismiss"
+          >
+            ×
+          </button>
+        </div>
+      )}
       <NavRail screen={isProjectDetail ? 'projects' : navScreen} setScreen={handleNavChange} />
       <main className="main">
         {showCost ? (

--- a/web/src/lib/fixtures.ts
+++ b/web/src/lib/fixtures.ts
@@ -287,6 +287,8 @@ export function getFixtureHealth(): Health {
     status: 'ok',
     monitor_version: '0.0.0-fixture',
     git_sha: 'c0ffee0',
+    latest_main_sha: 'c0ffee0',
+    commits_behind: 0,
     supported_bounty_api: '1.x',
     core_version_counts: { '1.0': 300, '1.1': 45 },
     loop_ids: ['loop-001', 'loop-002'],

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -135,6 +135,8 @@ export interface Health {
   status: string;
   monitor_version: string;
   git_sha: string;
+  latest_main_sha: string;
+  commits_behind: number | null;
   supported_bounty_api: string;
   core_version_counts: Record<string, number>;
   loop_ids: string[];


### PR DESCRIPTION
Closes #257

## Changes

### New: `scripts/redeploy.sh`
Idempotent operator script that:
1. `git fetch origin && git reset --hard origin/main` in the service checkout
2. `pip install -r requirements.txt --quiet` (skipped if no file)
3. `cd web && npm ci --silent && npm run build`
4. `launchctl kickstart -k gui/$(id -u)/com.user.loop-monitor`

Exits non-zero on any failed step. `LOOP_MONITOR_SERVICE_DIR` env var overrides the default path.

### New: `scripts/com.user.loop-monitor.plist`
LaunchAgent for the HTTP server (`run.sh`), pointing to `~/.openclaw/workspace/services/loop-monitor` with `KeepAlive=true`. Decouples the running service from the pipeline working tree.

### Updated: `scripts/com.user.loop-watch.plist`
`ProgramArguments` and new `WorkingDirectory` now point to the service checkout instead of the pipeline working tree.

### Backend: `server/routes/health.py`
`/api/health` now returns `latest_main_sha` and `commits_behind`:
- `latest_main_sha`: resolved via `git ls-remote https://github.com/svv2014/loop-monitor.git refs/heads/main` — no auth, no GitHub API rate limits
- `commits_behind`: computed with `git fetch origin main` + `git rev-list HEAD..origin/main --count` on cache miss
- Cached in-process for 60 s (thread-safe); warm-cache response stays well under 200 ms

### Frontend: SHA lag banner in `web/src/App.tsx`
Amber banner renders below the TopBar when `git_sha != latest_main_sha`. Shows running SHA, latest SHA, and commit-count delta. Dismissible per-session (reappears when `latest_main_sha` changes again, i.e. a new commit lands on main).

### Docs: `README.md`
Added "Running as a macOS service" section with bootstrap steps, redeploy instructions, and a component table.

## Test Plan

- [ ] `ruff check .` passes (✓ verified locally)
- [ ] `pyright server/` passes (✓ verified locally)
- [ ] `cd web && npm run typecheck && npm run build` passes (✓ verified locally)
- [ ] Bootstrap service checkout, install plist, start service — dashboard loads at :18792
- [ ] Run `scripts/redeploy.sh` from old checkout — service restarts on latest main
- [ ] Simulate SHA mismatch: banner appears in the UI with correct SHAs and commit delta
- [ ] Dismiss banner → gone for session; reload page with same mismatch → banner reappears
- [ ] `/api/health` responds in < 200 ms when cache is warm (second call within 60 s)
- [ ] `/api/health` includes `latest_main_sha` and `commits_behind` fields