### PR TITLE
[LM-270] refresh dashboard.py — box-drawn cards, two-column feed/leaderboard, ANSI color

### DIFF
--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 import time
 import urllib.error
@@ -15,6 +16,33 @@ DEFAULT_URL = "http://127.0.0.1:18792"
 DEFAULT_INTERVAL = 10
 HTTP_TIMEOUT = 5
 CLEAR = "\x1b[2J\x1b[H"
+MIN_WIDE = 80  # below this width → narrow stacked layout
+
+# ANSI basic 8 colors + bold — no 256/truecolor for portability
+_A: dict[str, str] = {
+    "R": "\x1b[0m", "B": "\x1b[1m",
+    "red": "\x1b[31m", "green": "\x1b[32m", "yellow": "\x1b[33m",
+    "blue": "\x1b[34m", "magenta": "\x1b[35m", "cyan": "\x1b[36m",
+    "white": "\x1b[37m",
+}
+
+_ROLE_COLOR: dict[str, str] = {
+    "builder": "cyan", "dev": "cyan",
+    "tester": "green",
+    "reviewer": "yellow",
+    "judge": "magenta",
+    "planner": "blue",
+}
+
+_ROLE_GLYPH: dict[str, str] = {
+    "builder": "◉", "dev": "◉",
+    "tester": "✓",
+    "reviewer": "★",
+    "judge": "⚖",
+    "planner": "◈",
+}
+
+CARD_INNER = 12  # inner content width of each project card box
 
 
 def fetch_json(base_url: str, path: str) -> Any:
@@ -53,86 +81,285 @@ def _since(row: dict) -> str:
     return f"{age // 86400}d"
 
 
-def format_active(rows: list[dict]) -> str:
-    header = "ACTIVE WORKERS"
-    if not rows:
-        return f"{header}\n  No active workers."
-    lines = [header]
-    lines.append(f"  {'PROJECT':<18} {'ROLE':<10} {'MODEL':<14} {'EVENT':<18} {'TASK':<10} SINCE")
-    for r in rows:
-        task = ""
-        if r.get("issue_number"):
-            task = f"#{r['issue_number']}"
-        elif r.get("pr_number"):
-            task = f"PR{r['pr_number']}"
-        lines.append(
-            f"  {_truncate(r.get('project',''), 18):<18} "
-            f"{_truncate(r.get('role',''), 10):<10} "
-            f"{_truncate(r.get('model','') or '', 14):<14} "
-            f"{_truncate(r.get('event_type',''), 18):<18} "
-            f"{_truncate(task, 10):<10} "
-            f"{_since(r)}"
-        )
-    return "\n".join(lines)
+def _role_glyph(role: str) -> str:
+    return _ROLE_GLYPH.get(role.lower(), "•")
 
 
-def format_board(rows: list[dict]) -> str:
-    header = "PROJECT STATUS"
-    if not rows:
-        return f"{header}\n  No project scores yet."
-    lines = [header]
-    lines.append(f"  {'PROJECT':<18} {'ROLE':<10} {'MODEL':<14} {'PTS':>6} {'VERDICTS':>9}")
-    for r in rows:
-        lines.append(
-            f"  {_truncate(r.get('project',''), 18):<18} "
-            f"{_truncate(r.get('role',''), 10):<10} "
-            f"{_truncate(r.get('model','') or '', 14):<14} "
-            f"{int(r.get('total_points') or 0):>6} "
-            f"{int(r.get('verdict_count') or 0):>9}"
-        )
-    return "\n".join(lines)
+def colorize(role: str, text: str, use_color: bool = True) -> str:
+    """Wrap pre-padded plain text in ANSI color for the given role.
+
+    Caller must measure/pad text BEFORE calling — ANSI codes are invisible to
+    the terminal but inflate Python's len(), so all width math must use the
+    plain string.
+    """
+    if not use_color:
+        return text
+    color = _ROLE_COLOR.get(role.lower(), "white")
+    return _A.get(color, "") + text + _A["R"]
 
 
-def format_feed(rows: list[dict], limit: int = 5) -> str:
-    header = "RECENT FEED"
-    if not rows:
-        return f"{header}\n  No recent events."
-    lines = [header]
-    for r in rows[:limit]:
+def _bold(text: str, use_color: bool) -> str:
+    """Wrap pre-padded plain text in bold. Same caveat as colorize."""
+    if not use_color:
+        return text
+    return _A["B"] + text + _A["R"]
+
+
+def render_banner(base_url: str, term_cols: int, use_color: bool) -> list[str]:
+    """Bordered header: LOOP MONITOR title, base URL, UTC + local time."""
+    inner = term_cols - 2
+    now_utc = datetime.now(timezone.utc).strftime("%H:%M UTC")
+    now_local = datetime.now().strftime("%H:%M local")
+    time_str = f"{now_utc} · {now_local}"
+    title_padded = "LOOP MONITOR".center(inner)
+    return [
+        "┌" + "─" * inner + "┐",
+        "│" + _bold(title_padded, use_color) + "│",
+        "│" + _truncate(base_url, inner).center(inner) + "│",
+        "├" + "─" * inner + "┤",
+        "│" + time_str.center(inner) + "│",
+    ]
+
+
+def _project_state(project: str, active: list[dict]) -> str:
+    for w in active:
+        if w.get("project") == project:
+            event_type = w.get("event_type", "")
+            return "wait" if "wait" in event_type else "busy"
+    return "idle"
+
+
+def _project_points(project: str, board: list[dict]) -> int:
+    return sum(int(r.get("total_points") or 0) for r in board if r.get("project") == project)
+
+
+def _project_last_event(project: str, feed: list[dict]) -> str:
+    for ev in feed:
+        if ev.get("project") == project:
+            return _since(ev)
+    return "?"
+
+
+def render_cards(
+    projects: list[str],
+    active: list[dict],
+    board: list[dict],
+    feed: list[dict],
+    term_cols: int,
+    use_color: bool,
+) -> list[str]:
+    """One box per project, wrapping to the next row when they exceed terminal width."""
+    inner = term_cols - 2
+    box_w = CARD_INNER + 2  # │content│
+    gap = 2
+    cards_per_row = max(1, (inner - 2) // (box_w + gap))
+
+    def make_card(proj: str) -> list[str]:
+        state = _project_state(proj, active)
+        pts = _project_points(proj, board)
+        age = _project_last_event(proj, feed)
+        return [
+            "┌" + "─" * CARD_INNER + "┐",
+            "│" + _truncate(proj, CARD_INNER).center(CARD_INNER) + "│",
+            "│" + f"◉  {state}".center(CARD_INNER) + "│",
+            "│" + f"{pts} pts".center(CARD_INNER) + "│",
+            "│" + age.center(CARD_INNER) + "│",
+            "└" + "─" * CARD_INNER + "┘",
+        ]
+
+    all_lines: list[str] = []
+    for chunk_start in range(0, len(projects), cards_per_row):
+        chunk = projects[chunk_start: chunk_start + cards_per_row]
+        cards = [make_card(p) for p in chunk]
+        for row_idx in range(len(cards[0])):
+            row_content = "  ".join(c[row_idx] for c in cards)
+            padded = (" " + row_content).ljust(inner)
+            all_lines.append("│" + padded + "│")
+    return all_lines
+
+
+def render_feed(events: list[dict], col_w: int, use_color: bool, limit: int = 8) -> list[str]:
+    """LIVE FEED column — each line padded to exactly col_w plain chars, then colorized."""
+    header = "LIVE FEED".ljust(col_w)
+    lines = [_bold(header, use_color)]
+    if not events:
+        lines.append("  No recent events.".ljust(col_w))
+        return lines
+    for ev in events[:limit]:
+        role = ev.get("role") or ""
+        glyph = _role_glyph(role)
+        project = _truncate(ev.get("project") or "", 10)
+        event_type = _truncate(ev.get("event_type") or "", 14)
         target = ""
-        if r.get("issue_number"):
-            target = f" #{r['issue_number']}"
-        elif r.get("pr_number"):
-            target = f" PR{r['pr_number']}"
-        detail = r.get("detail") or ""
-        status = r.get("status") or ""
-        lines.append(
-            f"  [{_since(r):>4}] "
-            f"{_truncate(r.get('project',''), 14):<14} "
-            f"{_truncate(r.get('role',''), 8):<8} "
-            f"{_truncate(r.get('event_type',''), 18):<18}"
-            f"{target}"
-            f"{(' — ' + _truncate(detail, 50)) if detail else ''}"
-            f"{(' [' + status + ']') if status else ''}"
-        )
+        if ev.get("issue_number"):
+            target = f" #{ev['issue_number']}"
+        elif ev.get("pr_number"):
+            target = f" PR{ev['pr_number']}"
+        age = _since(ev)
+        plain = f"  {glyph} {project} {event_type}{target} [{age}]"
+        padded = _truncate(plain, col_w).ljust(col_w)
+        lines.append(colorize(role, padded, use_color))
+    return lines
+
+
+def render_leaderboard(board: list[dict], col_w: int, use_color: bool, limit: int = 5) -> list[str]:
+    """LEADERBOARD column — each line padded to exactly col_w plain chars."""
+    header = "LEADERBOARD".ljust(col_w)
+    lines = [_bold(header, use_color)]
+    if not board:
+        lines.append("  No scores yet.".ljust(col_w))
+        return lines
+    sorted_board = sorted(board, key=lambda r: int(r.get("total_points") or 0), reverse=True)
+    for i, r in enumerate(sorted_board[:limit], 1):
+        role = _truncate(r.get("role") or r.get("project") or "", 10)
+        pts = int(r.get("total_points") or 0)
+        plain = f"  {i}. {role:<10} {pts:>5} pts"
+        lines.append(_truncate(plain, col_w).ljust(col_w))
+    return lines
+
+
+def render_verdict(events: list[dict], term_cols: int) -> str | None:
+    """Latest judge verdict as a single bordered line, or None if not found."""
+    inner = term_cols - 2
+    for ev in events:
+        role = (ev.get("role") or "").lower()
+        if role != "judge" and ev.get("event_type") != "judge":
+            continue
+        detail = ev.get("detail") or ""
+        if not detail:
+            continue
+        if ev.get("pr_number"):
+            prefix = f"JUDGE VERDICT (PR #{ev['pr_number']}): "
+        elif ev.get("issue_number"):
+            prefix = f"JUDGE VERDICT (#{ev['issue_number']}): "
+        else:
+            prefix = "JUDGE VERDICT: "
+        max_detail = inner - len(prefix) - 2
+        content = f" {prefix}{_truncate(detail, max_detail)} "
+        return "│" + content.ljust(inner) + "│"
+    return None
+
+
+def render_wide(
+    active: list[dict],
+    board: list[dict],
+    feed: list[dict],
+    base_url: str,
+    term_cols: int,
+    use_color: bool,
+) -> str:
+    """Full box-drawn layout for wide terminals (>= MIN_WIDE cols)."""
+    inner = term_cols - 2
+    blank = "│" + " " * inner + "│"
+    lines: list[str] = []
+
+    lines.extend(render_banner(base_url, term_cols, use_color))
+    lines.append(blank)
+
+    projects = sorted({r.get("project") for r in board if r.get("project")})
+    for w in active:
+        p = w.get("project")
+        if p and p not in projects:
+            projects.append(p)
+
+    if projects:
+        lines.extend(render_cards(projects, active, board, feed, term_cols, use_color))
+        lines.append(blank)
+
+    col_w = inner // 2
+    right_w = inner - col_w
+    feed_lines = render_feed(feed, col_w, use_color)
+    lb_lines = render_leaderboard(board, right_w, use_color)
+    height = max(len(feed_lines), len(lb_lines))
+    for i in range(height):
+        fl = feed_lines[i] if i < len(feed_lines) else " " * col_w
+        ll = lb_lines[i] if i < len(lb_lines) else " " * right_w
+        lines.append("│" + fl + ll + "│")
+
+    lines.append(blank)
+
+    verdict = render_verdict(feed, term_cols)
+    if verdict:
+        lines.append(verdict)
+        lines.append(blank)
+
+    lines.append("└" + "─" * inner + "┘")
     return "\n".join(lines)
 
 
-def render_snapshot(base_url: str) -> str:
+def render_narrow(
+    active: list[dict],
+    board: list[dict],
+    feed: list[dict],
+    base_url: str,
+    use_color: bool,
+) -> str:
+    """Simple stacked layout for narrow terminals (< MIN_WIDE cols)."""
+    now_utc = datetime.now(timezone.utc).strftime("%H:%M UTC")
+    parts: list[str] = [
+        _bold(f"LOOP MONITOR — {base_url}", use_color),
+        f"  {now_utc}",
+        "",
+    ]
+
+    projects = sorted({r.get("project") for r in board if r.get("project")})
+    for w in active:
+        p = w.get("project")
+        if p and p not in projects:
+            projects.append(p)
+
+    if projects:
+        parts.append(_bold("PROJECTS", use_color))
+        for p in projects:
+            state = _project_state(p, active)
+            pts = _project_points(p, board)
+            parts.append(f"  {p}  ◉ {state}  {pts} pts")
+        parts.append("")
+
+    parts.append(_bold("LIVE FEED", use_color))
+    if feed:
+        for ev in feed[:6]:
+            role = ev.get("role") or ""
+            glyph = _role_glyph(role)
+            event_type = _truncate(ev.get("event_type") or "", 18)
+            target = ""
+            if ev.get("issue_number"):
+                target = f" #{ev['issue_number']}"
+            elif ev.get("pr_number"):
+                target = f" PR{ev['pr_number']}"
+            age = _since(ev)
+            plain = f"  {glyph} {event_type}{target} [{age}]"
+            parts.append(colorize(role, plain, use_color))
+    else:
+        parts.append("  No recent events.")
+    parts.append("")
+
+    parts.append(_bold("LEADERBOARD", use_color))
+    sorted_board = sorted(board, key=lambda r: int(r.get("total_points") or 0), reverse=True)
+    for i, r in enumerate(sorted_board[:5], 1):
+        role = _truncate(r.get("role") or r.get("project") or "", 10)
+        pts = int(r.get("total_points") or 0)
+        parts.append(f"  {i}. {role:<10} {pts} pts")
+
+    return "\n".join(parts)
+
+
+def render_snapshot(base_url: str, use_color: bool | None = None) -> str:
     active = fetch_json(base_url, "/api/active")
     board = fetch_json(base_url, "/api/board")
     feed = fetch_json(base_url, "/api/feed")
-    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    parts = [
-        f"LOOP MONITOR — {base_url}   {now}",
-        "",
-        format_active(active or []),
-        "",
-        format_board(board or []),
-        "",
-        format_feed(feed or [], limit=5),
-    ]
-    return "\n".join(parts)
+
+    if use_color is None:
+        use_color = sys.stdout.isatty()
+
+    try:
+        term_cols = os.get_terminal_size().columns
+    except OSError:
+        term_cols = 80
+
+    if term_cols < MIN_WIDE:
+        return render_narrow(active or [], board or [], feed or [], base_url, use_color)
+    return render_wide(active or [], board or [], feed or [], base_url, term_cols, use_color)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -140,13 +367,14 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--url", default=DEFAULT_URL, help=f"API base URL (default: {DEFAULT_URL})")
     parser.add_argument("--interval", type=float, default=DEFAULT_INTERVAL,
                         help=f"refresh interval in seconds (default: {DEFAULT_INTERVAL})")
-    parser.add_argument("--once", action="store_true",
-                        help="print one snapshot and exit")
+    parser.add_argument("--once", action="store_true", help="print one snapshot and exit")
     args = parser.parse_args(argv)
+
+    use_color = sys.stdout.isatty()
 
     if args.once:
         try:
-            print(render_snapshot(args.url))
+            print(render_snapshot(args.url, use_color=use_color))
             return 0
         except (urllib.error.URLError, urllib.error.HTTPError, ConnectionError, OSError) as e:
             print(f"loop-monitor unreachable at {args.url}: {e}", file=sys.stderr)
@@ -155,8 +383,11 @@ def main(argv: list[str] | None = None) -> int:
     try:
         while True:
             try:
-                snapshot = render_snapshot(args.url)
-                sys.stdout.write(CLEAR + snapshot + "\n")
+                snapshot = render_snapshot(args.url, use_color=use_color)
+                if use_color:
+                    sys.stdout.write(CLEAR + snapshot + "\n")
+                else:
+                    print(snapshot)
                 sys.stdout.flush()
             except (urllib.error.URLError, urllib.error.HTTPError, ConnectionError, OSError) as e:
                 print(f"loop-monitor unreachable at {args.url}: {e}", file=sys.stderr)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,81 +1,17 @@
-from scripts.dashboard import _since, format_active, format_board, format_feed
-
-
-def test_format_active_empty():
-    out = format_active([])
-    assert "ACTIVE WORKERS" in out
-    assert "No active workers." in out
-
-
-def test_format_active_rows():
-    rows = [
-        {"project": "loop-monitor", "role": "builder", "model": "sonnet",
-         "event_type": "dev_start", "issue_number": 42, "pr_number": None,
-         "detail": "working", "created_at": "2026-04-30T12:00:00+00:00"},
-    ]
-    out = format_active(rows)
-    assert "loop-monitor" in out
-    assert "builder" in out
-    assert "dev_start" in out
-    assert "#42" in out
-
-
-def test_format_active_handles_missing_fields():
-    rows = [{"project": "p", "role": "r"}]  # no event_type, model, ids, etc.
-    out = format_active(rows)
-    assert "p" in out
-    assert "r" in out
-
-
-def test_format_board_empty():
-    out = format_board([])
-    assert "PROJECT STATUS" in out
-    assert "No project scores yet." in out
-
-
-def test_format_board_rows():
-    rows = [
-        {"project": "loop-monitor", "role": "builder", "model": "sonnet",
-         "total_points": 185, "verdict_count": 7},
-    ]
-    out = format_board(rows)
-    assert "185" in out
-    assert "7" in out
-
-
-def test_format_board_handles_none_points():
-    rows = [{"project": "p", "role": "r", "model": None,
-             "total_points": None, "verdict_count": None}]
-    out = format_board(rows)
-    assert "p" in out
-    assert "0" in out
-
-
-def test_format_feed_empty():
-    out = format_feed([])
-    assert "RECENT FEED" in out
-    assert "No recent events." in out
-
-
-def test_format_feed_rows_truncates_to_limit():
-    rows = [
-        {"project": f"p{i}", "role": "builder", "event_type": "dev_done",
-         "issue_number": i, "detail": "ok", "age_seconds": i, "status": "done"}
-        for i in range(10)
-    ]
-    out = format_feed(rows, limit=5)
-    # 1 header + 5 rows
-    assert len(out.splitlines()) == 6
-    assert "p0" in out
-    assert "p4" in out
-    assert "p5" not in out
-
-
-def test_format_feed_uses_age_seconds():
-    rows = [{"project": "p", "role": "r", "event_type": "x_done",
-             "age_seconds": 90, "status": "done"}]
-    out = format_feed(rows)
-    assert "1m" in out
+from scripts.dashboard import (
+    _project_points,
+    _project_state,
+    _role_glyph,
+    _since,
+    colorize,
+    render_banner,
+    render_cards,
+    render_feed,
+    render_leaderboard,
+    render_narrow,
+    render_verdict,
+    render_wide,
+)
 
 
 def test_since_seconds_minutes_hours_days():
@@ -90,6 +26,250 @@ def test_since_unknown():
 
 
 def test_since_falls_back_to_created_at():
-    # any valid ISO timestamp parses without crashing
     out = _since({"created_at": "2026-04-30T12:00:00+00:00"})
     assert out and out != "?"
+
+
+def test_role_glyph_known():
+    assert _role_glyph("builder") == "◉"
+    assert _role_glyph("tester") == "✓"
+    assert _role_glyph("judge") == "⚖"
+
+
+def test_role_glyph_unknown():
+    assert _role_glyph("unknown_role") == "•"
+
+
+def test_colorize_no_color():
+    assert colorize("builder", "hello", use_color=False) == "hello"
+
+
+def test_colorize_with_color():
+    result = colorize("builder", "hello", use_color=True)
+    assert "hello" in result
+    assert "\x1b[" in result
+
+
+def test_render_banner_structure():
+    lines = render_banner("http://localhost:18792", 80, use_color=False)
+    assert lines[0].startswith("┌")
+    assert lines[0].endswith("┐")
+    assert "LOOP MONITOR" in lines[1]
+    assert "localhost:18792" in lines[2]
+    assert lines[3].startswith("├")
+
+
+def test_render_banner_width():
+    cols = 80
+    lines = render_banner("http://localhost:18792", cols, use_color=False)
+    for line in lines:
+        assert len(line) == cols, f"expected {cols}, got {len(line)}: {line!r}"
+
+
+def test_project_state_idle():
+    assert _project_state("foo", []) == "idle"
+
+
+def test_project_state_busy():
+    active = [{"project": "foo", "event_type": "dev_start"}]
+    assert _project_state("foo", active) == "busy"
+
+
+def test_project_state_wait():
+    active = [{"project": "foo", "event_type": "dev_wait"}]
+    assert _project_state("foo", active) == "wait"
+
+
+def test_project_points_aggregates_roles():
+    board = [
+        {"project": "foo", "role": "builder", "total_points": 100},
+        {"project": "foo", "role": "tester", "total_points": 50},
+        {"project": "bar", "role": "builder", "total_points": 200},
+    ]
+    assert _project_points("foo", board) == 150
+    assert _project_points("bar", board) == 200
+    assert _project_points("baz", board) == 0
+
+
+def test_project_points_handles_none():
+    board = [{"project": "foo", "role": "builder", "total_points": None}]
+    assert _project_points("foo", board) == 0
+
+
+def test_render_cards_empty():
+    assert render_cards([], [], [], [], 80, use_color=False) == []
+
+
+def test_render_cards_single_project_shows_name_and_pts():
+    board = [{"project": "loop", "role": "builder", "total_points": 42}]
+    lines = render_cards(["loop"], [], board, [], 80, use_color=False)
+    content = "\n".join(lines)
+    assert "loop" in content
+    assert "42 pts" in content
+    assert "idle" in content
+
+
+def test_render_cards_busy_state():
+    active = [{"project": "loop", "event_type": "dev_start"}]
+    lines = render_cards(["loop"], active, [], [], 80, use_color=False)
+    assert any("busy" in line for line in lines)
+
+
+def test_render_cards_line_width():
+    board = [{"project": "p", "role": "r", "total_points": 10}]
+    lines = render_cards(["p"], [], board, [], 80, use_color=False)
+    for line in lines:
+        assert len(line) == 80, f"expected 80, got {len(line)}: {line!r}"
+
+
+def test_render_feed_empty():
+    lines = render_feed([], 40, use_color=False)
+    assert any("LIVE FEED" in line for line in lines)
+    assert any("No recent events" in line for line in lines)
+
+
+def test_render_feed_shows_event():
+    events = [
+        {"project": "loop", "role": "builder", "event_type": "dev_start",
+         "issue_number": 42, "pr_number": None, "age_seconds": 10},
+    ]
+    lines = render_feed(events, 40, use_color=False)
+    content = "\n".join(lines)
+    assert "dev_start" in content
+    assert "#42" in content
+
+
+def test_render_feed_respects_limit():
+    events = [
+        {"project": f"p{i}", "role": "builder", "event_type": "dev_done",
+         "issue_number": i, "pr_number": None, "age_seconds": i}
+        for i in range(10)
+    ]
+    lines = render_feed(events, 40, use_color=False, limit=3)
+    assert len(lines) == 4  # header + 3 events
+
+
+def test_render_feed_header_padded_to_col_w():
+    col_w = 40
+    lines = render_feed([], col_w, use_color=False)
+    assert len(lines[0]) == col_w
+
+
+def test_render_feed_empty_line_padded_to_col_w():
+    col_w = 40
+    lines = render_feed([], col_w, use_color=False)
+    for line in lines:
+        assert len(line) == col_w
+
+
+def test_render_leaderboard_empty():
+    lines = render_leaderboard([], 40, use_color=False)
+    assert any("LEADERBOARD" in line for line in lines)
+    assert any("No scores yet" in line for line in lines)
+
+
+def test_render_leaderboard_sorted_by_points():
+    board = [
+        {"role": "tester", "project": "p", "total_points": 50},
+        {"role": "builder", "project": "p", "total_points": 185},
+        {"role": "reviewer", "project": "p", "total_points": 120},
+    ]
+    lines = render_leaderboard(board, 40, use_color=False)
+    content = "\n".join(lines)
+    assert content.index("185") < content.index("120") < content.index("50")
+
+
+def test_render_leaderboard_respects_limit():
+    board = [{"role": f"r{i}", "project": "p", "total_points": i * 10} for i in range(10)]
+    lines = render_leaderboard(board, 40, use_color=False, limit=3)
+    assert len(lines) == 4  # header + 3 entries
+
+
+def test_render_leaderboard_padded_to_col_w():
+    board = [{"role": "builder", "project": "p", "total_points": 100}]
+    col_w = 40
+    lines = render_leaderboard(board, col_w, use_color=False)
+    for line in lines:
+        assert len(line) == col_w
+
+
+def test_render_verdict_none_when_no_judge():
+    events = [{"role": "builder", "event_type": "dev_done", "detail": "done",
+               "pr_number": None, "issue_number": None}]
+    assert render_verdict(events, 80) is None
+
+
+def test_render_verdict_found_with_pr():
+    events = [{"role": "judge", "event_type": "judge_done",
+               "detail": "Clean merge, full score",
+               "pr_number": 42, "issue_number": None}]
+    verdict = render_verdict(events, 80)
+    assert verdict is not None
+    assert "PR #42" in verdict
+    assert "Clean merge" in verdict
+    assert verdict.startswith("│")
+    assert verdict.endswith("│")
+
+
+def test_render_verdict_width():
+    events = [{"role": "judge", "event_type": "judge",
+               "detail": "All good", "pr_number": 1, "issue_number": None}]
+    cols = 80
+    verdict = render_verdict(events, cols)
+    assert verdict is not None
+    assert len(verdict) == cols
+
+
+def test_render_verdict_skips_empty_detail():
+    events = [
+        {"role": "judge", "event_type": "judge", "detail": "", "pr_number": 1, "issue_number": None},
+        {"role": "judge", "event_type": "judge", "detail": "real verdict", "pr_number": 2, "issue_number": None},
+    ]
+    verdict = render_verdict(events, 80)
+    assert verdict is not None
+    assert "real verdict" in verdict
+
+
+def test_render_wide_structure():
+    board = [{"project": "loop", "role": "builder", "total_points": 100, "verdict_count": 3}]
+    feed = [{"project": "loop", "role": "builder", "event_type": "dev_done",
+             "age_seconds": 60, "issue_number": 1, "pr_number": None, "detail": "done", "status": "done"}]
+    result = render_wide([], board, feed, "http://localhost:18792", 80, use_color=False)
+    assert "LOOP MONITOR" in result
+    assert "LIVE FEED" in result
+    assert "LEADERBOARD" in result
+    assert result.endswith("┘")
+
+
+def test_render_wide_line_widths():
+    board = [{"project": "loop", "role": "builder", "total_points": 50}]
+    cols = 80
+    result = render_wide([], board, [], "http://localhost", cols, use_color=False)
+    for line in result.splitlines():
+        assert len(line) == cols, f"expected {cols}, got {len(line)}: {line!r}"
+
+
+def test_render_narrow_structure():
+    board = [{"project": "loop", "role": "builder", "total_points": 100, "verdict_count": 3}]
+    feed = [{"project": "loop", "role": "builder", "event_type": "dev_done",
+             "age_seconds": 60, "issue_number": 1, "pr_number": None, "detail": "done", "status": "done"}]
+    result = render_narrow([], board, feed, "http://localhost:18792", use_color=False)
+    assert "LOOP MONITOR" in result
+    assert "LIVE FEED" in result
+    assert "LEADERBOARD" in result
+
+
+def test_render_narrow_no_color():
+    result = render_narrow([], [], [], "http://localhost", use_color=False)
+    assert "\x1b[" not in result
+
+
+def test_render_wide_with_judge_verdict():
+    feed = [
+        {"project": "loop", "role": "judge", "event_type": "judge",
+         "age_seconds": 5, "issue_number": None, "pr_number": 7,
+         "detail": "Solid spec, clean merge.", "status": "done"},
+    ]
+    result = render_wide([], [], feed, "http://localhost", 80, use_color=False)
+    assert "JUDGE VERDICT" in result
+    assert "PR #7" in result


### PR DESCRIPTION
Closes #270

## Changes

Rewrote `scripts/dashboard.py` (~280 lines, up from 170) to match the ASCII mockup from the pre-v0.3.0 README:

- **Top banner** — Unicode box-drawing header (`┌─┐│└┘├┤`) with `LOOP MONITOR`, base URL, and current time (UTC + local).
- **Project cards row** — one `┌──────────┐` box per project showing name, `◉ idle|busy|wait` state (derived from active workers), aggregated pts across roles, and last event age. Cards wrap to next row when total width exceeds terminal columns.
- **Two-column body** — `LIVE FEED` (left, last 8 events with role glyph) + `LEADERBOARD` (right, top 5 by points). Columns are each padded to exact character widths so the border math is clean.
- **Judge verdict callout** — optional bottom line inside the border showing the latest judge verdict truncated to terminal width.
- **ANSI color** — `colorize(role, text, use_color)` wraps pre-padded plain text after width math, using only 8 basic colors + bold. Enabled only when `sys.stdout.isatty()`.
- **Narrow fallback** — `render_narrow()` for terminals < 80 cols: stacked sections, no card boxes.
- **Piped output stays plain** — when stdout is not a TTY, no ANSI codes are emitted.
- `--once` and `--interval` behaviours preserved. No new dependencies.

Updated `tests/test_dashboard.py`: replaced old flat-format tests with 36 tests covering all new helpers (`render_banner`, `render_cards`, `render_feed`, `render_leaderboard`, `render_verdict`, `render_wide`, `render_narrow`, plus utilities). Width-invariant tests verify box lines are exactly `term_cols` wide.

## Test Plan
- `ruff check .` — passes clean
- `python3 -m pytest tests/test_dashboard.py -v` — 36/36 pass
- Pre-existing failures in `test_action_queue` and `test_runs` are unrelated to this change (confirmed they fail on main too)
- Piped output (`python3 scripts/dashboard.py --once 2>/dev/null | cat`) contains no ANSI escape codes
- Wide terminal (≥80 cols): bordered layout with cards, two-column body, verdict callout
- Narrow terminal (<80 cols): stacked plain layout