### PR TITLE
[LM-268] fix NaNd ago in Completed Jobs panel

### DIFF
--- a/web/src/lib/transforms.test.ts
+++ b/web/src/lib/transforms.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { buildLeaderboard, buildProjectStatus, build24hBuckets } from './transforms';
-import { relTime, durationFmt, absoluteUtc, matchesProjectFilter } from './utils';
+import { relTime, durationFmt, absoluteUtc, matchesProjectFilter, parseServerTs } from './utils';
 import type { LoopEvent, Worker } from './types';
 
 type ExtLoopEvent = LoopEvent & { points?: number; agent?: string; ts?: number };
@@ -58,6 +58,41 @@ describe('relTime', () => {
   it('returns days with ago suffix', () => {
     vi.spyOn(Date, 'now').mockReturnValue(2 * 86400 * 1000);
     expect(relTime(0)).toBe('2d ago');
+  });
+
+  it('returns fallback for NaN timestamp', () => {
+    expect(relTime(NaN)).toBe('—');
+  });
+
+  it('returns fallback for Infinity timestamp', () => {
+    expect(relTime(Infinity)).toBe('—');
+  });
+});
+
+// ── parseServerTs ─────────────────────────────────────────────────────────────
+
+describe('parseServerTs', () => {
+  it('parses a UTC-naive ISO string as UTC', () => {
+    const ts = parseServerTs('2024-05-01T12:00:00');
+    expect(ts).toBe(new Date('2024-05-01T12:00:00Z').getTime());
+  });
+
+  it('parses a Z-suffixed ISO string correctly', () => {
+    const ts = parseServerTs('2024-05-01T12:00:00Z');
+    expect(ts).toBe(new Date('2024-05-01T12:00:00Z').getTime());
+  });
+
+  it('parses a string with explicit +00:00 offset correctly', () => {
+    const ts = parseServerTs('2024-05-01T12:00:00+00:00');
+    expect(ts).toBe(new Date('2024-05-01T12:00:00Z').getTime());
+  });
+
+  it('returns NaN for a genuinely unparseable string', () => {
+    expect(parseServerTs('not-a-date')).toBeNaN();
+  });
+
+  it('returns NaN for an empty string', () => {
+    expect(parseServerTs('')).toBeNaN();
   });
 });
 

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -1,6 +1,15 @@
 import { useState, useEffect } from 'react';
 
+/** Parses a UTC ISO string that may lack a Z/offset suffix (e.g. from SQLite). */
+export function parseServerTs(s: string): number {
+  if (!s) return NaN;
+  // If the string already has a timezone indicator, parse as-is; otherwise treat as UTC.
+  const normalized = /[Zz]$|[+-]\d{2}:\d{2}$/.test(s) ? s : s + 'Z';
+  return new Date(normalized).getTime();
+}
+
 export function relTime(ts: number): string {
+  if (!isFinite(ts)) return '—';
   const s = Math.max(0, Math.floor((Date.now() - ts) / 1000));
   if (s < 60) return s + 's ago';
   if (s < 3600) return Math.floor(s / 60) + 'm ago';

--- a/web/src/screens/Overview.tsx
+++ b/web/src/screens/Overview.tsx
@@ -11,7 +11,7 @@ import Leaderboard from '../panels/Leaderboard';
 import ActivityFeed from '../panels/ActivityFeed';
 import EventGlyph from '../components/EventGlyph';
 import RoleTag from '../components/RoleTag';
-import { relTime, durationFmt, matchesProjectFilter } from '../lib/utils';
+import { relTime, durationFmt, matchesProjectFilter, parseServerTs } from '../lib/utils';
 import Charts from '../panels/Charts';
 import ClaudeUsage from '../panels/ClaudeUsage';
 import { useRoleIds } from '../lib/useRoles';
@@ -141,7 +141,7 @@ export default function Overview({ globalProjectFilter }: OverviewProps) {
             <div className="panel-h"><span>Completed jobs · last 30</span></div>
             <div style={{ overflow: 'auto', maxHeight: 480 }}>
               {completed.map(e => {
-                const ts = new Date(e.created_at).getTime();
+                const ts = parseServerTs(e.created_at);
                 const durMs = (e.duration_seconds ?? 0) * 1000;
                 return (
                   <div key={e.id} className="feed-row">


### PR DESCRIPTION
Closes #268

## Changes

- **`web/src/lib/utils.ts`** — Added `parseServerTs(s: string): number` helper that normalizes UTC-naive ISO strings (no `Z`/offset suffix) by appending `Z` before parsing, mirroring the fix applied to `build24hBuckets` in #174. Also updated `relTime` to return `—` for non-finite (NaN/Infinity) timestamps instead of propagating `NaN* ago`.

- **`web/src/screens/Overview.tsx`** — Completed Jobs panel now calls `parseServerTs(e.created_at)` instead of `new Date(e.created_at).getTime()`, fixing the root cause.

- **`web/src/lib/transforms.test.ts`** — Extended with `parseServerTs` tests (UTC-naive string, Z-suffix, explicit offset, unparseable, empty) and NaN/Infinity fallback tests for `relTime`.

## Test Plan
- `cd web && npm run typecheck` — passes
- `cd web && npm test` — 51/51 tests pass
- `cd web && npm run build` — clean build
- Manually verify: Completed Jobs rows show `5m ago`, `1h ago`, `3d ago` instead of `NaNd ago`