### PR TITLE
[LM-264] Action Queue table pagination

### DIFF
--- a/web/src/screens/Queue.test.ts
+++ b/web/src/screens/Queue.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { applyFilters, applySort } from './Queue';
+import { applyFilters, applySort, PAGE_SIZE } from './Queue';
 import type { QueueItem } from '../lib/types';
 
 function item(overrides: Partial<QueueItem> = {}): QueueItem {
@@ -113,3 +113,57 @@ describe('applySort', () => {
     expect(items).toEqual(original);
   });
 });
+
+// ── pagination helpers ────────────────────────────────────────────────────────
+
+function makeItems(count: number): QueueItem[] {
+  return Array.from({ length: count }, (_, i) =>
+    item({ number: i + 1 }),
+  );
+}
+
+describe('PAGE_SIZE', () => {
+  it('is 20', () => {
+    expect(PAGE_SIZE).toBe(20);
+  });
+});
+
+describe('pagination slicing', () => {
+  it('page 1 of 25 items renders 20 rows', () => {
+    const all = makeItems(25);
+    const page1 = all.slice(0, PAGE_SIZE);
+    expect(page1).toHaveLength(20);
+  });
+
+  it('page 2 of 25 items renders 5 rows', () => {
+    const all = makeItems(25);
+    const page2 = all.slice(PAGE_SIZE, PAGE_SIZE * 2);
+    expect(page2).toHaveLength(5);
+  });
+
+  it('page 1 of exactly 20 items renders 20 rows', () => {
+    const all = makeItems(20);
+    const page1 = all.slice(0, PAGE_SIZE);
+    expect(page1).toHaveLength(20);
+  });
+
+  it('no second page when items <= 20', () => {
+    const all = makeItems(20);
+    const totalPages = Math.max(1, Math.ceil(all.length / PAGE_SIZE));
+    expect(totalPages).toBe(1);
+  });
+
+  it('two pages when items = 21', () => {
+    const all = makeItems(21);
+    const totalPages = Math.max(1, Math.ceil(all.length / PAGE_SIZE));
+    expect(totalPages).toBe(2);
+  });
+
+  it('clamps page to totalPages', () => {
+    const all = makeItems(25);
+    const totalPages = Math.max(1, Math.ceil(all.length / PAGE_SIZE));
+    const clampedPage = Math.min(5, totalPages);
+    expect(clampedPage).toBe(totalPages);
+  });
+});
+

--- a/web/src/screens/Queue.tsx
+++ b/web/src/screens/Queue.tsx
@@ -1,10 +1,27 @@
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useState, useEffect, useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchActionQueue } from '../lib/api';
 import type { QueueItem } from '../lib/types';
 import FailureInspector from '../components/FailureInspector';
 import Drawer from '../components/Drawer';
 import { useHashRoute } from '../router';
+
+export const PAGE_SIZE = 20;
+
+export function parsePageFromHash(): number {
+  const hash = window.location.hash.replace(/^#/, '');
+  const match = hash.match(/(?:^|[?&])page=(\d+)/);
+  if (match) {
+    const n = parseInt(match[1], 10);
+    return isNaN(n) || n < 1 ? 1 : n;
+  }
+  return 1;
+}
+
+function writePageToHash(page: number): void {
+  const base = 'queue';
+  window.location.hash = page > 1 ? `${base}?page=${page}` : base;
+}
 
 function isFailureItem(item: QueueItem): boolean {
   return item.stage === 'needs-clarification' || item.reason === 'qa_fail_repeated';
@@ -175,10 +192,17 @@ export default function Queue({ globalProjectFilter }: QueueProps) {
   const [filterLoop, setFilterLoop] = useState('');
   const [sortCol, setSortCol] = useState<SortCol>('age_seconds');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const [page, setPage] = useState<number>(parsePageFromHash);
 
   useEffect(() => {
     setFilterProject(globalProjectFilter ?? '');
+    setPage(1);
   }, [globalProjectFilter]);
+
+  const goToPage = useCallback((p: number) => {
+    setPage(p);
+    writePageToHash(p);
+  }, []);
 
   const projects = useMemo(
     () => [...new Set(items.map(i => i.project))].sort(),
@@ -214,6 +238,17 @@ export default function Queue({ globalProjectFilter }: QueueProps) {
     [items, filterProject, filterReason, filterLoop, sortCol, sortDir],
   );
 
+  const totalPages = Math.max(1, Math.ceil(allFiltered.length / PAGE_SIZE));
+  const clampedPage = Math.min(page, totalPages);
+  const pageItems = allFiltered.slice((clampedPage - 1) * PAGE_SIZE, clampedPage * PAGE_SIZE);
+
+  // Clamp page when filter changes reduce total pages
+  useEffect(() => {
+    if (page > totalPages) {
+      goToPage(totalPages);
+    }
+  }, [totalPages, page, goToPage]);
+
   function handleSort(col: SortCol) {
     if (col === sortCol) {
       setSortDir(d => (d === 'asc' ? 'desc' : 'asc'));
@@ -221,6 +256,7 @@ export default function Queue({ globalProjectFilter }: QueueProps) {
       setSortCol(col);
       setSortDir('asc');
     }
+    goToPage(1);
   }
 
   function handleRowClick(item: QueueItem) {
@@ -262,18 +298,18 @@ export default function Queue({ globalProjectFilter }: QueueProps) {
         </div>
 
         <div style={{ display: 'flex', gap: 'var(--pad-2)', marginBottom: 'var(--pad-3)', flexWrap: 'wrap' }}>
-          <select className="btn" value={filterProject} onChange={e => setFilterProject(e.target.value)}>
+          <select className="btn" value={filterProject} onChange={e => { setFilterProject(e.target.value); goToPage(1); }}>
             <option value="">All projects</option>
             {projects.map(p => <option key={p} value={p}>{p}</option>)}
           </select>
-          <select className="btn" value={filterReason} onChange={e => setFilterReason(e.target.value)}>
+          <select className="btn" value={filterReason} onChange={e => { setFilterReason(e.target.value); goToPage(1); }}>
             <option value="">All reasons</option>
             <option value="stuck_label">stuck_label</option>
             <option value="timeout">timeout</option>
             <option value="qa_fail_repeated">qa_fail_repeated</option>
           </select>
           {showLoopFilter && (
-            <select className="btn" value={filterLoop} onChange={e => setFilterLoop(e.target.value)}>
+            <select className="btn" value={filterLoop} onChange={e => { setFilterLoop(e.target.value); goToPage(1); }}>
               <option value="">All loops</option>
               {loops.map(l => <option key={l} value={l}>{l}</option>)}
             </select>
@@ -283,13 +319,34 @@ export default function Queue({ globalProjectFilter }: QueueProps) {
         {allFiltered.length === 0 ? (
           <div className="muted" style={{ padding: 'var(--pad-3) 0' }}>No items</div>
         ) : (
-          <QueueTable
-            items={allFiltered}
-            onRowClick={handleRowClick}
-            sortCol={sortCol}
-            sortDir={sortDir}
-            onSort={handleSort}
-          />
+          <>
+            <QueueTable
+              items={pageItems}
+              onRowClick={handleRowClick}
+              sortCol={sortCol}
+              sortDir={sortDir}
+              onSort={handleSort}
+            />
+            {allFiltered.length > PAGE_SIZE && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--pad-2)', marginTop: 'var(--pad-3)' }}>
+                <button
+                  className="btn"
+                  onClick={() => goToPage(clampedPage - 1)}
+                  disabled={clampedPage <= 1}
+                >
+                  &lt; Prev
+                </button>
+                <span className="meta">Page {clampedPage} of {totalPages}</span>
+                <button
+                  className="btn"
+                  onClick={() => goToPage(clampedPage + 1)}
+                  disabled={clampedPage >= totalPages}
+                >
+                  Next &gt;
+                </button>
+              </div>
+            )}
+          </>
         )}
       </section>
 


### PR DESCRIPTION
Closes #264

## Changes
- `web/src/screens/Queue.tsx`: Added client-side pagination (20 rows/page). Page state is stored in URL hash (`#queue?page=N`) so it survives refresh. Pagination controls show only when item count > 20. Page resets to 1 on any filter change and is clamped to valid range.
- `web/src/screens/Queue.test.ts`: Added pagination tests including slicing assertion (25 items → 20 on page 1, 5 on page 2).

## Test Plan
- Load Queue screen with >20 items — only 20 rows show, pagination controls appear
- Navigate to page 2, refresh — stays on page 2
- Change a filter — resets to page 1
- Verify Prev disabled on page 1, Next disabled on last page
- Run `cd web && npm run test`