### PR TITLE
[LM-270] Refresh dashboard.py with box-drawn layout, ANSI color, two-column view

### DIFF
--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -195,6 +195,7 @@ def render_cards(
     board: list[dict],
     active_projects: set[str],
     last_age: dict[str, str],
+    queue_projects: set[str],
     cols: int,
     use_color: bool,
 ) -> list[str]:
@@ -221,7 +222,7 @@ def render_cards(
         rendered_cards = [
             _render_single_card(
                 p,
-                "busy" if p in active_projects else "idle",
+                "wait" if p in queue_projects else "busy" if p in active_projects else "idle",
                 project_pts[p],
                 last_age.get(p, "?"),
                 use_color,
@@ -337,6 +338,7 @@ def render_narrow(
     feed: list[dict],
     board: list[dict],
     active_projects: set[str],
+    queue_projects: set[str],
     verdict: dict | None,
     cols: int,
     use_color: bool,
@@ -356,7 +358,7 @@ def render_narrow(
         parts.append("  No project data.")
     else:
         for proj in sorted(project_pts):
-            status = "busy" if proj in active_projects else "idle"
+            status = "wait" if proj in queue_projects else "busy" if proj in active_projects else "idle"
             parts.append(f"  {proj}: ◉ {status}  {project_pts[proj]} pts")
 
     parts += ["", "LIVE FEED"]
@@ -401,6 +403,13 @@ def render_snapshot(base_url: str, use_color: bool) -> str:
     board_data: list[dict] = fetch_json(base_url, "/api/board") or []
     feed_data: list[dict] = fetch_json(base_url, "/api/feed") or []
 
+    queue_projects: set[str] = set()
+    try:
+        queue_data: list[dict] = fetch_json(base_url, "/api/action_queue") or []
+        queue_projects = {r.get("project", "") for r in queue_data if r.get("project")}
+    except Exception:
+        pass
+
     latest_verdict: dict | None = None
     try:
         verdicts: list[dict] = fetch_json(base_url, "/api/verdicts") or []
@@ -420,12 +429,12 @@ def render_snapshot(base_url: str, use_color: bool) -> str:
 
     if cols < NARROW_COLS:
         return render_narrow(
-            base_url, feed_data, board_data, active_projects, latest_verdict, cols, use_color
+            base_url, feed_data, board_data, active_projects, queue_projects, latest_verdict, cols, use_color
         )
 
     lines: list[str] = []
     lines += render_banner(base_url, cols, use_color)
-    lines += render_cards(board_data, active_projects, last_age, cols, use_color)
+    lines += render_cards(board_data, active_projects, last_age, queue_projects, cols, use_color)
     lines += render_two_columns(feed_data, board_data, cols, use_color)
     lines += render_verdict(latest_verdict, cols, use_color)
     lines.append(_hbar(cols, _BL, _BR))

--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 import time
 import urllib.error
@@ -15,6 +16,50 @@ DEFAULT_URL = "http://127.0.0.1:18792"
 DEFAULT_INTERVAL = 10
 HTTP_TIMEOUT = 5
 CLEAR = "\x1b[2J\x1b[H"
+
+# Box-drawing
+_H = "─"
+_V = "│"
+_TL = "┌"
+_TR = "┐"
+_BL = "└"
+_BR = "┘"
+_LT = "├"
+_RT = "┤"
+
+# ANSI
+_RST = "\x1b[0m"
+_BOLD = "\x1b[1m"
+_ROLE_COLORS: dict[str, str] = {
+    "dev": "\x1b[34m",
+    "po": "\x1b[33m",
+    "judge": "\x1b[35m",
+    "qa": "\x1b[36m",
+    "builder": "\x1b[32m",
+    "reviewer": "\x1b[34m",
+    "admin": "\x1b[31m",
+}
+_STATUS_COLORS: dict[str, str] = {
+    "busy": "\x1b[32m",
+    "idle": "\x1b[37m",
+    "wait": "\x1b[33m",
+}
+_EVENT_GLYPHS: dict[str, str] = {
+    "start": "◉",
+    "done": "✓",
+    "fail": "✗",
+    "pass": "✓",
+    "skip": "→",
+    "judge": "★",
+}
+
+CARD_INNER = 12
+CARD_TOTAL = CARD_INNER + 2
+CARD_GAP = 2
+NARROW_COLS = 80
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
 
 
 def fetch_json(base_url: str, path: str) -> Any:
@@ -53,100 +98,363 @@ def _since(row: dict) -> str:
     return f"{age // 86400}d"
 
 
-def format_active(rows: list[dict]) -> str:
-    header = "ACTIVE WORKERS"
-    if not rows:
-        return f"{header}\n  No active workers."
-    lines = [header]
-    lines.append(f"  {'PROJECT':<18} {'ROLE':<10} {'MODEL':<14} {'EVENT':<18} {'TASK':<10} SINCE")
-    for r in rows:
-        task = ""
-        if r.get("issue_number"):
-            task = f"#{r['issue_number']}"
-        elif r.get("pr_number"):
-            task = f"PR{r['pr_number']}"
-        lines.append(
-            f"  {_truncate(r.get('project',''), 18):<18} "
-            f"{_truncate(r.get('role',''), 10):<10} "
-            f"{_truncate(r.get('model','') or '', 14):<14} "
-            f"{_truncate(r.get('event_type',''), 18):<18} "
-            f"{_truncate(task, 10):<10} "
-            f"{_since(r)}"
-        )
-    return "\n".join(lines)
+def _get_term_cols() -> int:
+    try:
+        return os.get_terminal_size().columns
+    except OSError:
+        return 80
 
 
-def format_board(rows: list[dict]) -> str:
-    header = "PROJECT STATUS"
-    if not rows:
-        return f"{header}\n  No project scores yet."
-    lines = [header]
-    lines.append(f"  {'PROJECT':<18} {'ROLE':<10} {'MODEL':<14} {'PTS':>6} {'VERDICTS':>9}")
-    for r in rows:
-        lines.append(
-            f"  {_truncate(r.get('project',''), 18):<18} "
-            f"{_truncate(r.get('role',''), 10):<10} "
-            f"{_truncate(r.get('model','') or '', 14):<14} "
-            f"{int(r.get('total_points') or 0):>6} "
-            f"{int(r.get('verdict_count') or 0):>9}"
-        )
-    return "\n".join(lines)
+def _colorize(code: str, text: str, use_color: bool) -> str:
+    if not use_color:
+        return text
+    return f"{code}{text}{_RST}"
 
 
-def format_feed(rows: list[dict], limit: int = 5) -> str:
-    header = "RECENT FEED"
-    if not rows:
-        return f"{header}\n  No recent events."
-    lines = [header]
-    for r in rows[:limit]:
+def _role_color(role: str) -> str:
+    return _ROLE_COLORS.get((role or "").lower(), "\x1b[37m")
+
+
+def _event_glyph(event_type: str) -> str:
+    if not event_type:
+        return "•"
+    if event_type == "judge":
+        return _EVENT_GLYPHS["judge"]
+    suffix = event_type.rsplit("_", 1)[-1].lower()
+    return _EVENT_GLYPHS.get(suffix, "•")
+
+
+def _hbar(width: int, left: str = _TL, right: str = _TR) -> str:
+    return left + _H * (width - 2) + right
+
+
+def _box_row(text: str, total_w: int) -> str:
+    """One │-bordered row: pad text to fill total_w (includes borders)."""
+    inner_w = total_w - 2
+    # text may contain ANSI codes; truncate on display length only for plain text
+    padded = text[:inner_w].ljust(inner_w)
+    return f"{_V}{padded}{_V}"
+
+
+# ── renderers ────────────────────────────────────────────────────────────────
+
+
+def render_banner(base_url: str, cols: int, use_color: bool) -> list[str]:
+    now_utc = datetime.now(timezone.utc)
+    now_local = datetime.now()
+    utc_str = now_utc.strftime("UTC %H:%M:%S")
+    local_str = now_local.strftime("Local %H:%M:%S")
+    time_str = f"{utc_str}   {local_str}"
+
+    inner_w = cols - 2
+    title = "LOOP MONITOR"
+    title_plain = title.center(inner_w)
+    url_plain = _truncate(base_url, inner_w).center(inner_w)
+    time_plain = time_str.center(inner_w)
+
+    if use_color:
+        title_line = f"{_V}{_BOLD}{title_plain}{_RST}{_V}"
+    else:
+        title_line = f"{_V}{title_plain}{_V}"
+
+    return [
+        _hbar(cols),
+        title_line,
+        f"{_V}{url_plain}{_V}",
+        f"{_V}{time_plain}{_V}",
+        _hbar(cols, _LT, _RT),
+    ]
+
+
+def _render_single_card(
+    name: str, status: str, pts: int, age: str, use_color: bool
+) -> list[str]:
+    """Six-line card box (CARD_TOTAL wide)."""
+    name_s = _truncate(name, CARD_INNER).center(CARD_INNER)
+    status_content = f"◉ {status}".center(CARD_INNER)
+    pts_s = f"{pts} pts".center(CARD_INNER)
+    age_s = (f"{age} ago" if age != "?" else "?").center(CARD_INNER)
+
+    if use_color:
+        sc = _STATUS_COLORS.get(status, "")
+        status_line = f"{_V}{_colorize(sc, status_content, True)}{_V}"
+    else:
+        status_line = f"{_V}{status_content}{_V}"
+
+    return [
+        _TL + _H * CARD_INNER + _TR,
+        f"{_V}{name_s}{_V}",
+        status_line,
+        f"{_V}{pts_s}{_V}",
+        f"{_V}{age_s}{_V}",
+        _BL + _H * CARD_INNER + _BR,
+    ]
+
+
+def render_cards(
+    board: list[dict],
+    active_projects: set[str],
+    last_age: dict[str, str],
+    cols: int,
+    use_color: bool,
+) -> list[str]:
+    # Aggregate pts by project
+    project_pts: dict[str, int] = {}
+    for row in board:
+        proj = row.get("project") or "?"
+        project_pts[proj] = project_pts.get(proj, 0) + int(row.get("total_points") or 0)
+
+    inner_w = cols - 2
+    if not project_pts:
+        return [_box_row("  No project data.", cols)]
+
+    avail = inner_w - 2  # 1-space margin on each side
+    card_slot = CARD_TOTAL + CARD_GAP
+    per_row = max(1, avail // card_slot)
+
+    projects = sorted(project_pts.keys())
+    card_h = 6
+    output: list[str] = []
+
+    for chunk_start in range(0, len(projects), per_row):
+        chunk = projects[chunk_start : chunk_start + per_row]
+        rendered_cards = [
+            _render_single_card(
+                p,
+                "busy" if p in active_projects else "idle",
+                project_pts[p],
+                last_age.get(p, "?"),
+                use_color,
+            )
+            for p in chunk
+        ]
+
+        for line_idx in range(card_h):
+            gap = " " * CARD_GAP
+            row_content = " " + gap.join(c[line_idx] for c in rendered_cards)
+            # Pad to inner_w
+            # ANSI codes in status line (line_idx==2) inflate len(); use plain width estimate
+            plain_len = 1 + (CARD_TOTAL + CARD_GAP) * len(chunk) - CARD_GAP
+            padding = " " * max(0, inner_w - plain_len)
+            output.append(f"{_V}{row_content}{padding}{_V}")
+
+        output.append(_box_row("", cols))  # blank spacer between card rows
+
+    return output
+
+
+def render_feed_items(feed: list[dict]) -> list[tuple[str, str]]:
+    """Return (plain_line, role) for up to 8 feed entries."""
+    items: list[tuple[str, str]] = []
+    for row in feed[:8]:
+        role = (row.get("role") or "").lower()
+        glyph = _event_glyph(row.get("event_type") or "")
         target = ""
-        if r.get("issue_number"):
-            target = f" #{r['issue_number']}"
-        elif r.get("pr_number"):
-            target = f" PR{r['pr_number']}"
-        detail = r.get("detail") or ""
-        status = r.get("status") or ""
-        lines.append(
-            f"  [{_since(r):>4}] "
-            f"{_truncate(r.get('project',''), 14):<14} "
-            f"{_truncate(r.get('role',''), 8):<8} "
-            f"{_truncate(r.get('event_type',''), 18):<18}"
-            f"{target}"
-            f"{(' — ' + _truncate(detail, 50)) if detail else ''}"
-            f"{(' [' + status + ']') if status else ''}"
-        )
-    return "\n".join(lines)
+        if row.get("issue_number"):
+            target = f" #{row['issue_number']}"
+        elif row.get("pr_number"):
+            target = f" PR{row['pr_number']}"
+        evtype = _truncate(row.get("event_type") or "", 16)
+        role_s = _truncate(role, 8)
+        line = f"  {glyph} {role_s:<8} {evtype}{target}"
+        items.append((line, role))
+    return items
 
 
-def render_snapshot(base_url: str) -> str:
-    active = fetch_json(base_url, "/api/active")
-    board = fetch_json(base_url, "/api/board")
-    feed = fetch_json(base_url, "/api/feed")
+def render_leaderboard_items(board: list[dict]) -> list[str]:
+    """Return plain lines for top-5 leaderboard."""
+    lines: list[str] = []
+    for i, row in enumerate(board[:5], 1):
+        role = _truncate(row.get("role") or "?", 10)
+        pts = int(row.get("total_points") or 0)
+        lines.append(f"  {i}. {role:<10} {pts:>5} pts")
+    return lines or ["  No scores yet."]
+
+
+def render_two_columns(
+    feed: list[dict], board: list[dict], cols: int, use_color: bool
+) -> list[str]:
+    inner_w = cols - 2
+    left_w = inner_w * 3 // 5
+    right_w = inner_w - left_w
+
+    hdr_left = "  LIVE FEED"
+    hdr_right = "  LEADERBOARD"
+
+    feed_items = render_feed_items(feed)
+    board_lines = render_leaderboard_items(board)
+
+    # Pad to equal height
+    max_h = max(len(feed_items), len(board_lines), 1)
+    feed_items += [("", "")] * (max_h - len(feed_items))
+    board_lines += [""] * (max_h - len(board_lines))
+
+    output: list[str] = []
+
+    # Header
+    hdr_l_plain = hdr_left[:left_w].ljust(left_w)
+    hdr_r_plain = hdr_right[:right_w].ljust(right_w)
+    if use_color:
+        hdr_l = _colorize(_BOLD, hdr_l_plain, True)
+        hdr_r = _colorize(_BOLD, hdr_r_plain, True)
+    else:
+        hdr_l, hdr_r = hdr_l_plain, hdr_r_plain
+    output.append(f"{_V}{hdr_l}{hdr_r}{_V}")
+
+    for (plain_l, role), plain_r in zip(feed_items, board_lines):
+        left_plain = plain_l[:left_w].ljust(left_w)
+        right_plain = plain_r[:right_w].ljust(right_w)
+        if use_color and plain_l:
+            left_cell = _colorize(_role_color(role), left_plain, True)
+        else:
+            left_cell = left_plain
+        output.append(f"{_V}{left_cell}{right_plain}{_V}")
+
+    return output
+
+
+def render_verdict(verdict: dict | None, cols: int, use_color: bool) -> list[str]:
+    if not verdict:
+        return []
+    project = verdict.get("project") or ""
+    reason = verdict.get("reason") or ""
+    inner_w = cols - 2
+    label = f"  JUDGE VERDICT ({project}):"
+    reason_line = f'  "{_truncate(reason, inner_w - 3)}"'
+    output = [
+        _hbar(cols, _LT, _RT),
+        _box_row(label, cols),
+        _box_row(reason_line, cols),
+    ]
+    return output
+
+
+# ── narrow (< 80 col) fallback ───────────────────────────────────────────────
+
+
+def render_narrow(
+    base_url: str,
+    feed: list[dict],
+    board: list[dict],
+    active_projects: set[str],
+    verdict: dict | None,
+    cols: int,
+    use_color: bool,
+) -> str:
     now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    parts = [
+    parts: list[str] = [
         f"LOOP MONITOR — {base_url}   {now}",
         "",
-        format_active(active or []),
-        "",
-        format_board(board or []),
-        "",
-        format_feed(feed or [], limit=5),
+        "PROJECT STATUS",
     ]
+    # Aggregate pts by project
+    project_pts: dict[str, int] = {}
+    for row in board:
+        proj = row.get("project") or "?"
+        project_pts[proj] = project_pts.get(proj, 0) + int(row.get("total_points") or 0)
+    if not project_pts:
+        parts.append("  No project data.")
+    else:
+        for proj in sorted(project_pts):
+            status = "busy" if proj in active_projects else "idle"
+            parts.append(f"  {proj}: ◉ {status}  {project_pts[proj]} pts")
+
+    parts += ["", "LIVE FEED"]
+    if not feed:
+        parts.append("  No recent events.")
+    else:
+        for row in feed[:8]:
+            role = (row.get("role") or "").lower()
+            glyph = _event_glyph(row.get("event_type") or "")
+            target = ""
+            if row.get("issue_number"):
+                target = f" #{row['issue_number']}"
+            elif row.get("pr_number"):
+                target = f" PR{row['pr_number']}"
+            evtype = _truncate(row.get("event_type") or "", 16)
+            line = f"  {glyph} {role:<8} {evtype}{target}"
+            if use_color:
+                line = _colorize(_role_color(role), line, True)
+            parts.append(line)
+
+    parts += ["", "LEADERBOARD"]
+    for i, row in enumerate(board[:5], 1):
+        role = _truncate(row.get("role") or "?", 10)
+        pts = int(row.get("total_points") or 0)
+        parts.append(f"  {i}. {role:<10} {pts:>5} pts")
+
+    if verdict:
+        parts += [
+            "",
+            f"JUDGE VERDICT ({verdict.get('project','')}):",
+            f"  \"{_truncate(verdict.get('reason',''), cols - 5)}\"",
+        ]
+
     return "\n".join(parts)
+
+
+# ── snapshot ─────────────────────────────────────────────────────────────────
+
+
+def render_snapshot(base_url: str, use_color: bool) -> str:
+    active_data: list[dict] = fetch_json(base_url, "/api/active") or []
+    board_data: list[dict] = fetch_json(base_url, "/api/board") or []
+    feed_data: list[dict] = fetch_json(base_url, "/api/feed") or []
+
+    latest_verdict: dict | None = None
+    try:
+        verdicts: list[dict] = fetch_json(base_url, "/api/verdicts") or []
+        latest_verdict = verdicts[0] if verdicts else None
+    except Exception:
+        pass
+
+    cols = _get_term_cols()
+    active_projects = {r.get("project", "") for r in active_data}
+
+    # Last event age per project from feed (feed is DESC by id)
+    last_age: dict[str, str] = {}
+    for row in feed_data:
+        proj = row.get("project") or ""
+        if proj and proj not in last_age:
+            last_age[proj] = _since(row)
+
+    if cols < NARROW_COLS:
+        return render_narrow(
+            base_url, feed_data, board_data, active_projects, latest_verdict, cols, use_color
+        )
+
+    lines: list[str] = []
+    lines += render_banner(base_url, cols, use_color)
+    lines += render_cards(board_data, active_projects, last_age, cols, use_color)
+    lines += render_two_columns(feed_data, board_data, cols, use_color)
+    lines += render_verdict(latest_verdict, cols, use_color)
+    lines.append(_hbar(cols, _BL, _BR))
+
+    return "\n".join(lines)
+
+
+# ── main ─────────────────────────────────────────────────────────────────────
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Terminal dashboard for Loop Monitor.")
-    parser.add_argument("--url", default=DEFAULT_URL, help=f"API base URL (default: {DEFAULT_URL})")
-    parser.add_argument("--interval", type=float, default=DEFAULT_INTERVAL,
-                        help=f"refresh interval in seconds (default: {DEFAULT_INTERVAL})")
-    parser.add_argument("--once", action="store_true",
-                        help="print one snapshot and exit")
+    parser.add_argument(
+        "--url", default=DEFAULT_URL, help=f"API base URL (default: {DEFAULT_URL})"
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=DEFAULT_INTERVAL,
+        help=f"refresh interval in seconds (default: {DEFAULT_INTERVAL})",
+    )
+    parser.add_argument("--once", action="store_true", help="print one snapshot and exit")
     args = parser.parse_args(argv)
+
+    use_color = sys.stdout.isatty()
 
     if args.once:
         try:
-            print(render_snapshot(args.url))
+            print(render_snapshot(args.url, use_color))
             return 0
         except (urllib.error.URLError, urllib.error.HTTPError, ConnectionError, OSError) as e:
             print(f"loop-monitor unreachable at {args.url}: {e}", file=sys.stderr)
@@ -155,8 +463,9 @@ def main(argv: list[str] | None = None) -> int:
     try:
         while True:
             try:
-                snapshot = render_snapshot(args.url)
-                sys.stdout.write(CLEAR + snapshot + "\n")
+                snapshot = render_snapshot(args.url, use_color)
+                prefix = CLEAR if use_color else ""
+                sys.stdout.write(prefix + snapshot + "\n")
                 sys.stdout.flush()
             except (urllib.error.URLError, urllib.error.HTTPError, ConnectionError, OSError) as e:
                 print(f"loop-monitor unreachable at {args.url}: {e}", file=sys.stderr)

--- a/server/routes/issues_cost.py
+++ b/server/routes/issues_cost.py
@@ -3,7 +3,7 @@ import re
 import sqlite3
 import subprocess
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Any, Optional
 
 from fastapi import APIRouter, Depends
 
@@ -197,3 +197,160 @@ def get_issues_cost(
 
     result.sort(key=lambda r: (-r["rework_factor"], -r["actual_runs"]))
     return result
+
+
+def _median(values: list[float]) -> Optional[float]:
+    """Compute median of a list of floats. Returns None for empty list."""
+    if not values:
+        return None
+    s = sorted(values)
+    n = len(s)
+    mid = n // 2
+    if n % 2 == 0:
+        return round((s[mid - 1] + s[mid]) / 2, 4)
+    return round(s[mid], 4)
+
+
+def _linear_trend_slope(values: list[float]) -> float:
+    """Return slope from simple linear regression over evenly-spaced points."""
+    n = len(values)
+    if n < 2:
+        return 0.0
+    xs = list(range(n))
+    x_mean = sum(xs) / n
+    y_mean = sum(values) / n
+    num = sum((xs[i] - x_mean) * (values[i] - y_mean) for i in range(n))
+    den = sum((xs[i] - x_mean) ** 2 for i in range(n))
+    return num / den if den != 0 else 0.0
+
+
+@router.get("/api/cost/trend")
+def get_cost_trend(
+    days: int = 30,
+    project: Optional[str] = None,
+    priority: Optional[str] = None,
+    conn: sqlite3.Connection = Depends(db_dep),
+) -> dict[str, Any]:
+    since_dt = datetime.now(timezone.utc) - timedelta(days=days)
+    since_iso = since_dt.isoformat()
+
+    # Fetch all events in the window to compute per-issue rework factors per day
+    rows = conn.execute(
+        """
+        SELECT
+            date(created_at)   AS day,
+            project,
+            issue_number,
+            SUM(CASE WHEN event_type LIKE '%_start' THEN 1 ELSE 0 END) AS actual_runs
+        FROM events
+        WHERE issue_number IS NOT NULL
+          AND created_at >= ?
+          AND (? IS NULL OR project = ?)
+        GROUP BY day, project, issue_number
+        HAVING actual_runs > 0
+        """,
+        (since_iso, project, project),
+    ).fetchall()
+
+    # Build a map of day -> list of rework_factors
+    # rework_factor per (day, issue) = actual_runs_that_day / 5  (simplified happy path = 5, no child info here)
+    # We use the same formula as _build_row but without child_count (would require GH API per day per issue)
+    day_factors: dict[str, list[float]] = {}
+    for row in rows:
+        day: str = row["day"]
+        actual: int = row["actual_runs"] or 0
+        if actual == 0:
+            continue
+        # simple rework factor without child lookup (consistent for trend)
+        rf = round(actual / 5, 4)
+        day_factors.setdefault(day, []).append(rf)
+
+    # Apply priority filter if given — we need to know which (project, issue_number) have that priority
+    # We fetch all issues in window and then filter by priority via GH meta
+    if priority:
+        # collect all unique (project, issue_number) in the window
+        meta_rows = conn.execute(
+            """
+            SELECT DISTINCT project, issue_number
+            FROM events
+            WHERE issue_number IS NOT NULL
+              AND created_at >= ?
+              AND (? IS NULL OR project = ?)
+            """,
+            (since_iso, project, project),
+        ).fetchall()
+        allowed: set[tuple[str, int]] = set()
+        for mr in meta_rows:
+            meta = _fetch_gh_meta(mr["project"], mr["issue_number"])
+            if meta.get("priority") == priority:
+                allowed.add((mr["project"], mr["issue_number"]))
+
+        # rebuild day_factors filtered to allowed issues
+        day_factors = {}
+        for row in rows:
+            key = (row["project"], row["issue_number"])
+            if key not in allowed:
+                continue
+            day: str = row["day"]
+            actual = row["actual_runs"] or 0
+            if actual == 0:
+                continue
+            rf = round(actual / 5, 4)
+            day_factors.setdefault(day, []).append(rf)
+
+    # Build sorted list of days in the window
+    today_dt = datetime.now(timezone.utc).date()
+    all_days = [(today_dt - timedelta(days=i)).isoformat() for i in range(days - 1, -1, -1)]
+
+    buckets: list[dict[str, Any]] = []
+    for d in all_days:
+        factors = day_factors.get(d, [])
+        med = _median(factors)
+        buckets.append({
+            "date": d,
+            "median_rework_factor": med,
+            "issue_count": len(factors),
+        })
+
+    # today's stats
+    today_factors = day_factors.get(today_dt.isoformat(), [])
+    today_median = _median(today_factors)
+    today_count = len(today_factors)
+
+    # comparison helpers
+    def _median_for_day(offset_days: int) -> Optional[float]:
+        d = (today_dt - timedelta(days=offset_days)).isoformat()
+        return _median(day_factors.get(d, []))
+
+    def _delta(ref: Optional[float]) -> Optional[float]:
+        if today_median is None or ref is None:
+            return None
+        return round(today_median - ref, 4)
+
+    vs_7d = _delta(_median_for_day(7))
+    vs_30d = _delta(_median_for_day(30))
+
+    # trend from linear regression on last 14 buckets that have data
+    recent_medians = [b["median_rework_factor"] for b in buckets[-14:] if b["median_rework_factor"] is not None]
+    if len(recent_medians) >= 3:
+        slope = _linear_trend_slope(recent_medians)
+        if slope < -0.01:
+            trend = "improving"
+        elif slope > 0.01:
+            trend = "degrading"
+        else:
+            trend = "stable"
+    else:
+        trend = "stable"
+
+    return {
+        "window_days": days,
+        "today": {
+            "median_rework_factor": today_median,
+            "issue_count": today_count,
+        },
+        "vs_7d": vs_7d,
+        "vs_30d": vs_30d,
+        "trend": trend,
+        "buckets": buckets,
+    }

--- a/tests/test_cost_trend.py
+++ b/tests/test_cost_trend.py
@@ -1,0 +1,178 @@
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+import server
+import server.db
+import server.routes.issues_cost as issues_cost_module
+from server.routes.issues_cost import _linear_trend_slope, _median
+
+
+def _make_client(monkeypatch, tmp_path, gh_meta_fn=None):
+    monkeypatch.setattr(server.db, "DB_PATH", str(tmp_path / "test.db"))
+    server.db.apply_pending_migrations()
+    issues_cost_module._gh_cache.clear()
+    if gh_meta_fn is not None:
+        monkeypatch.setattr(issues_cost_module, "_fetch_gh_meta", gh_meta_fn)
+    return TestClient(server.app)
+
+
+def _open_meta(project, issue_number):
+    return {"title": f"Issue {issue_number}", "state": "open", "priority": None, "body": "", "merged": False}
+
+
+def _insert_events(db_path: str, events: list) -> None:
+    conn = sqlite3.connect(db_path)
+    for ev in events:
+        conn.execute(
+            "INSERT INTO events (project, role, event_type, issue_number, created_at) VALUES (?,?,?,?,?)",
+            (ev["project"], ev["role"], ev["event_type"], ev["issue_number"], ev["created_at"]),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _ts(offset_days: int = 0) -> str:
+    dt = datetime.now(timezone.utc) - timedelta(days=offset_days)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+
+
+# ── _median ───────────────────────────────────────────────────────────────────
+
+def test_median_empty():
+    assert _median([]) is None
+
+
+def test_median_single():
+    assert _median([3.0]) == 3.0
+
+
+def test_median_odd():
+    assert _median([3.0, 1.0, 2.0]) == 2.0
+
+
+def test_median_even():
+    assert _median([1.0, 2.0, 3.0, 4.0]) == 2.5
+
+
+def test_median_rounded_to_4dp():
+    result = _median([1.0, 2.0])
+    assert result == round(1.5, 4)
+
+
+# ── _linear_trend_slope ───────────────────────────────────────────────────────
+
+def test_slope_single_value():
+    assert _linear_trend_slope([5.0]) == 0.0
+
+
+def test_slope_flat():
+    assert _linear_trend_slope([2.0, 2.0, 2.0, 2.0]) == 0.0
+
+
+def test_slope_strictly_increasing():
+    assert _linear_trend_slope([1.0, 2.0, 3.0, 4.0]) > 0
+
+
+def test_slope_strictly_decreasing():
+    assert _linear_trend_slope([4.0, 3.0, 2.0, 1.0]) < 0
+
+
+# ── GET /api/cost/trend ───────────────────────────────────────────────────────
+
+def test_trend_response_shape(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    resp = client.get("/api/cost/trend")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "window_days" in data
+    assert "today" in data
+    assert "median_rework_factor" in data["today"]
+    assert "issue_count" in data["today"]
+    assert "vs_7d" in data
+    assert "vs_30d" in data
+    assert "trend" in data
+    assert "buckets" in data
+    assert isinstance(data["buckets"], list)
+
+
+def test_trend_default_30_buckets(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    resp = client.get("/api/cost/trend")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["window_days"] == 30
+    assert len(data["buckets"]) == 30
+
+
+def test_trend_days_param(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    resp = client.get("/api/cost/trend?days=7")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["window_days"] == 7
+    assert len(data["buckets"]) == 7
+
+
+def test_trend_today_median_computed(tmp_path, monkeypatch):
+    """10 _start events for one issue today → rf = 10/5 = 2.0."""
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    events = [
+        {"project": "p", "role": "dev", "event_type": "dev_start",
+         "issue_number": 1, "created_at": _ts(0)}
+        for _ in range(10)
+    ]
+    _insert_events(server.db.DB_PATH, events)
+    resp = client.get("/api/cost/trend")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["today"]["median_rework_factor"] == 2.0
+    assert data["today"]["issue_count"] == 1
+
+
+def test_trend_project_filter_isolates(tmp_path, monkeypatch):
+    """Only proj-a events counted when project=proj-a."""
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    today = _ts(0)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-a", "role": "dev", "event_type": "dev_start",
+         "issue_number": 10, "created_at": today},
+        {"project": "proj-b", "role": "dev", "event_type": "dev_start",
+         "issue_number": 20, "created_at": today},
+        {"project": "proj-b", "role": "dev", "event_type": "dev_start",
+         "issue_number": 20, "created_at": today},
+    ])
+    resp = client.get("/api/cost/trend?project=proj-a")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["today"]["issue_count"] == 1
+    assert data["today"]["median_rework_factor"] == round(1 / 5, 4)
+
+
+def test_trend_field_values(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    resp = client.get("/api/cost/trend")
+    assert resp.status_code == 200
+    assert resp.json()["trend"] in ("improving", "degrading", "stable")
+
+
+def test_trend_bucket_schema(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    resp = client.get("/api/cost/trend")
+    assert resp.status_code == 200
+    for bucket in resp.json()["buckets"]:
+        assert "date" in bucket
+        assert "median_rework_factor" in bucket
+        assert "issue_count" in bucket
+
+
+def test_trend_empty_db_returns_nulls(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    resp = client.get("/api/cost/trend")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["today"]["median_rework_factor"] is None
+    assert data["vs_7d"] is None
+    assert data["vs_30d"] is None
+    assert all(b["median_rework_factor"] is None for b in data["buckets"])

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,24 +1,19 @@
 from scripts.dashboard import (
-    _since,
-    _event_glyph,
-    _hbar,
-    _colorize,
-    _role_color,
-    render_feed_items,
-    render_leaderboard_items,
-    render_banner,
-    CARD_INNER,
-    NARROW_COLS,
-    _V,
     _H,
-    _TL,
-    _TR,
-    _BL,
-    _BR,
     _LT,
     _RT,
+    _TL,
+    _TR,
+    _colorize,
+    _event_glyph,
+    _hbar,
+    _role_color,
+    _since,
+    render_banner,
+    render_cards,
+    render_feed_items,
+    render_leaderboard_items,
 )
-
 
 # ── _since ────────────────────────────────────────────────────────────────────
 
@@ -187,3 +182,35 @@ def test_render_banner_all_lines_same_width():
     # Unicode box chars are 1 display column each; line length == cols
     for line in lines:
         assert len(line) == cols, f"Expected width {cols}, got {len(line)}: {line!r}"
+
+
+# ── render_cards ──────────────────────────────────────────────────────────────
+
+def test_render_cards_idle_status():
+    board = [{"project": "proj-a", "total_points": 5}]
+    lines = render_cards(board, set(), {}, set(), 80, False)
+    combined = "\n".join(lines)
+    assert "idle" in combined
+    assert "proj-a" in combined
+
+
+def test_render_cards_busy_status():
+    board = [{"project": "proj-b", "total_points": 10}]
+    lines = render_cards(board, {"proj-b"}, {}, set(), 80, False)
+    combined = "\n".join(lines)
+    assert "busy" in combined
+
+
+def test_render_cards_wait_status():
+    board = [{"project": "proj-c", "total_points": 3}]
+    lines = render_cards(board, set(), {}, {"proj-c"}, 80, False)
+    combined = "\n".join(lines)
+    assert "wait" in combined
+
+
+def test_render_cards_wait_takes_priority_over_busy():
+    board = [{"project": "proj-d", "total_points": 7}]
+    lines = render_cards(board, {"proj-d"}, {}, {"proj-d"}, 80, False)
+    combined = "\n".join(lines)
+    assert "wait" in combined
+    assert "busy" not in combined

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,82 +1,26 @@
-from scripts.dashboard import _since, format_active, format_board, format_feed
+from scripts.dashboard import (
+    _since,
+    _event_glyph,
+    _hbar,
+    _colorize,
+    _role_color,
+    render_feed_items,
+    render_leaderboard_items,
+    render_banner,
+    CARD_INNER,
+    NARROW_COLS,
+    _V,
+    _H,
+    _TL,
+    _TR,
+    _BL,
+    _BR,
+    _LT,
+    _RT,
+)
 
 
-def test_format_active_empty():
-    out = format_active([])
-    assert "ACTIVE WORKERS" in out
-    assert "No active workers." in out
-
-
-def test_format_active_rows():
-    rows = [
-        {"project": "loop-monitor", "role": "builder", "model": "sonnet",
-         "event_type": "dev_start", "issue_number": 42, "pr_number": None,
-         "detail": "working", "created_at": "2026-04-30T12:00:00+00:00"},
-    ]
-    out = format_active(rows)
-    assert "loop-monitor" in out
-    assert "builder" in out
-    assert "dev_start" in out
-    assert "#42" in out
-
-
-def test_format_active_handles_missing_fields():
-    rows = [{"project": "p", "role": "r"}]  # no event_type, model, ids, etc.
-    out = format_active(rows)
-    assert "p" in out
-    assert "r" in out
-
-
-def test_format_board_empty():
-    out = format_board([])
-    assert "PROJECT STATUS" in out
-    assert "No project scores yet." in out
-
-
-def test_format_board_rows():
-    rows = [
-        {"project": "loop-monitor", "role": "builder", "model": "sonnet",
-         "total_points": 185, "verdict_count": 7},
-    ]
-    out = format_board(rows)
-    assert "185" in out
-    assert "7" in out
-
-
-def test_format_board_handles_none_points():
-    rows = [{"project": "p", "role": "r", "model": None,
-             "total_points": None, "verdict_count": None}]
-    out = format_board(rows)
-    assert "p" in out
-    assert "0" in out
-
-
-def test_format_feed_empty():
-    out = format_feed([])
-    assert "RECENT FEED" in out
-    assert "No recent events." in out
-
-
-def test_format_feed_rows_truncates_to_limit():
-    rows = [
-        {"project": f"p{i}", "role": "builder", "event_type": "dev_done",
-         "issue_number": i, "detail": "ok", "age_seconds": i, "status": "done"}
-        for i in range(10)
-    ]
-    out = format_feed(rows, limit=5)
-    # 1 header + 5 rows
-    assert len(out.splitlines()) == 6
-    assert "p0" in out
-    assert "p4" in out
-    assert "p5" not in out
-
-
-def test_format_feed_uses_age_seconds():
-    rows = [{"project": "p", "role": "r", "event_type": "x_done",
-             "age_seconds": 90, "status": "done"}]
-    out = format_feed(rows)
-    assert "1m" in out
-
+# ── _since ────────────────────────────────────────────────────────────────────
 
 def test_since_seconds_minutes_hours_days():
     assert _since({"age_seconds": 5}) == "5s"
@@ -90,6 +34,156 @@ def test_since_unknown():
 
 
 def test_since_falls_back_to_created_at():
-    # any valid ISO timestamp parses without crashing
     out = _since({"created_at": "2026-04-30T12:00:00+00:00"})
     assert out and out != "?"
+
+
+# ── _event_glyph ──────────────────────────────────────────────────────────────
+
+def test_event_glyph_known_suffixes():
+    assert _event_glyph("dev_done") == "✓"
+    assert _event_glyph("dev_fail") == "✗"
+    assert _event_glyph("dev_start") == "◉"
+    assert _event_glyph("qa_pass") == "✓"
+    assert _event_glyph("qa_skip") == "→"
+
+
+def test_event_glyph_judge():
+    assert _event_glyph("judge") == "★"
+
+
+def test_event_glyph_unknown_returns_bullet():
+    assert _event_glyph("something_unknown") == "•"
+    assert _event_glyph("") == "•"
+    assert _event_glyph(None) == "•"
+
+
+# ── _hbar ─────────────────────────────────────────────────────────────────────
+
+def test_hbar_default_corners():
+    bar = _hbar(10)
+    assert bar.startswith(_TL)
+    assert bar.endswith(_TR)
+    assert len(bar) == 10  # Unicode chars are single code-points
+
+
+def test_hbar_custom_corners():
+    bar = _hbar(6, _LT, _RT)
+    assert bar.startswith(_LT)
+    assert bar.endswith(_RT)
+    assert _H * 4 in bar
+
+
+# ── _colorize ─────────────────────────────────────────────────────────────────
+
+def test_colorize_with_color():
+    out = _colorize("\x1b[34m", "hello", True)
+    assert "\x1b[34m" in out
+    assert "hello" in out
+    assert "\x1b[0m" in out
+
+
+def test_colorize_without_color():
+    out = _colorize("\x1b[34m", "hello", False)
+    assert out == "hello"
+
+
+# ── _role_color ───────────────────────────────────────────────────────────────
+
+def test_role_color_known_roles():
+    assert _role_color("dev") == "\x1b[34m"
+    assert _role_color("judge") == "\x1b[35m"
+    assert _role_color("qa") == "\x1b[36m"
+    assert _role_color("builder") == "\x1b[32m"
+
+
+def test_role_color_unknown_returns_default():
+    assert _role_color("unknown") == "\x1b[37m"
+    assert _role_color("") == "\x1b[37m"
+    assert _role_color(None) == "\x1b[37m"
+
+
+# ── render_feed_items ─────────────────────────────────────────────────────────
+
+def test_render_feed_items_empty():
+    assert render_feed_items([]) == []
+
+
+def test_render_feed_items_truncates_to_8():
+    rows = [{"role": "dev", "event_type": "dev_done", "issue_number": i} for i in range(12)]
+    items = render_feed_items(rows)
+    assert len(items) == 8
+
+
+def test_render_feed_items_includes_role_and_glyph():
+    rows = [{"role": "builder", "event_type": "dev_start", "issue_number": 42}]
+    items = render_feed_items(rows)
+    assert len(items) == 1
+    line, role = items[0]
+    assert role == "builder"
+    assert "◉" in line
+    assert "builder" in line
+    assert "#42" in line
+
+
+def test_render_feed_items_pr_number():
+    rows = [{"role": "qa", "event_type": "qa_pass", "pr_number": 99}]
+    items = render_feed_items(rows)
+    line, _ = items[0]
+    assert "PR99" in line
+
+
+# ── render_leaderboard_items ──────────────────────────────────────────────────
+
+def test_render_leaderboard_empty():
+    lines = render_leaderboard_items([])
+    assert lines == ["  No scores yet."]
+
+
+def test_render_leaderboard_top_5():
+    board = [{"role": f"r{i}", "total_points": 100 - i * 10} for i in range(10)]
+    lines = render_leaderboard_items(board)
+    assert len(lines) == 5
+    assert "1." in lines[0]
+    assert "r0" in lines[0]
+
+
+def test_render_leaderboard_handles_none_points():
+    board = [{"role": "dev", "total_points": None}]
+    lines = render_leaderboard_items(board)
+    assert "0" in lines[0]
+
+
+# ── render_banner ─────────────────────────────────────────────────────────────
+
+def test_render_banner_structure():
+    lines = render_banner("http://localhost:18792", 80, False)
+    assert len(lines) == 5
+    # top border
+    assert lines[0].startswith(_TL)
+    assert lines[0].endswith(_TR)
+    # divider at bottom
+    assert lines[4].startswith(_LT)
+    assert lines[4].endswith(_RT)
+
+
+def test_render_banner_contains_title_and_url():
+    lines = render_banner("http://localhost:18792", 80, False)
+    combined = "\n".join(lines)
+    assert "LOOP MONITOR" in combined
+    assert "localhost:18792" in combined
+
+
+def test_render_banner_contains_utc_and_local():
+    lines = render_banner("http://testhost", 80, False)
+    combined = "\n".join(lines)
+    assert "UTC" in combined
+    assert "Local" in combined
+
+
+def test_render_banner_all_lines_same_width():
+    cols = 80
+    lines = render_banner("http://x", cols, False)
+    # Unicode box chars are 1 display column each; line length == cols
+    for line in lines:
+        assert len(line) == cols, f"Expected width {cols}, got {len(line)}: {line!r}"

--- a/web/src/components/CostTrendStrip.tsx
+++ b/web/src/components/CostTrendStrip.tsx
@@ -1,0 +1,213 @@
+import type { CostTrend, CostTrendBucket } from '../lib/types';
+
+interface CostTrendStripProps {
+  today: CostTrend['today'];
+  vs_7d: number | null;
+  vs_30d: number | null;
+  buckets: CostTrendBucket[];
+}
+
+function reworkColor(v: number): string {
+  if (v <= 1.0) return 'var(--role-ok)';
+  if (v < 2.0)  return 'var(--fg-2)';
+  if (v < 4.0)  return 'var(--role-warn)';
+  return 'var(--role-err)';
+}
+
+/**
+ * Color for a delta value (negative = improving = green, positive = degrading = red,
+ * within ±5% relative to a baseline is treated as gray/stable).
+ */
+function deltaColor(delta: number | null, baseline: number | null): string {
+  if (delta == null) return 'var(--fg-3)';
+  const threshold = baseline != null && baseline !== 0 ? Math.abs(baseline) * 0.05 : 0.05;
+  if (Math.abs(delta) <= threshold) return 'var(--fg-3)';
+  return delta < 0 ? 'var(--pass)' : 'var(--fail)';
+}
+
+function formatDelta(delta: number | null): string {
+  if (delta == null) return '—';
+  const sign = delta > 0 ? '+' : '';
+  return `${sign}${delta.toFixed(2)}`;
+}
+
+interface SparklineProps {
+  buckets: CostTrendBucket[];
+  width?: number;
+  height?: number;
+}
+
+function Sparkline({ buckets, width = 120, height = 32 }: SparklineProps) {
+  const withData = buckets.filter(b => b.median_rework_factor != null);
+  if (withData.length < 2) {
+    return (
+      <svg
+        width={width}
+        height={height}
+        aria-label="Sparkline — not enough data"
+        style={{ display: 'block', flexShrink: 0 }}
+      >
+        <line
+          x1={0} y1={height / 2}
+          x2={width} y2={height / 2}
+          stroke="var(--border)"
+          strokeWidth={1}
+          strokeDasharray="2 3"
+        />
+      </svg>
+    );
+  }
+
+  const values = withData.map(b => b.median_rework_factor as number);
+  const minVal = Math.min(...values);
+  const maxVal = Math.max(...values);
+  const range = maxVal - minVal || 1;
+
+  const pad = 2;
+  const innerW = width - pad * 2;
+  const innerH = height - pad * 2;
+
+  const toX = (i: number) => pad + (i / (withData.length - 1)) * innerW;
+  const toY = (v: number) => pad + innerH - ((v - minVal) / range) * innerH;
+
+  const points = withData.map((b, i) => `${toX(i)},${toY(b.median_rework_factor as number)}`).join(' ');
+
+  const minIdx = values.indexOf(minVal);
+  const maxIdx = values.indexOf(maxVal);
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      aria-label="30-day median rework factor sparkline"
+      style={{ display: 'block', flexShrink: 0, overflow: 'visible' }}
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke="var(--fg-3)"
+        strokeWidth={1}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      {withData.map((b, i) => {
+        const isMin = i === minIdx;
+        const isMax = i === maxIdx;
+        if (!isMin && !isMax) return null;
+        const cx = toX(i);
+        const cy = toY(b.median_rework_factor as number);
+        const dotColor = isMax ? 'var(--fail)' : 'var(--pass)';
+        return (
+          <circle key={b.date} cx={cx} cy={cy} r={2.5} fill={dotColor}>
+            <title>{`${b.date}: ${(b.median_rework_factor as number).toFixed(2)}`}</title>
+          </circle>
+        );
+      })}
+    </svg>
+  );
+}
+
+export default function CostTrendStrip({ today, vs_7d, vs_30d, buckets }: CostTrendStripProps) {
+  const med = today.median_rework_factor;
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--pad-4)',
+        padding: 'var(--pad-3) var(--pad-4)',
+        borderBottom: '1px solid var(--border)',
+        background: 'var(--bg-1)',
+        flexWrap: 'wrap',
+      }}
+    >
+      {/* Today's median */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 2, minWidth: 80 }}>
+        <span
+          className="muted mono"
+          style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em' }}
+        >
+          today median
+        </span>
+        <span
+          className="num"
+          style={{
+            fontSize: 28,
+            fontFamily: 'var(--font-mono)',
+            fontWeight: 600,
+            color: med != null ? reworkColor(med) : 'var(--fg-3)',
+            lineHeight: 1,
+          }}
+        >
+          {med != null ? med.toFixed(2) : '—'}
+        </span>
+        {today.issue_count > 0 && (
+          <span className="muted mono" style={{ fontSize: 10, color: 'var(--fg-3)' }}>
+            {today.issue_count} issue{today.issue_count !== 1 ? 's' : ''}
+          </span>
+        )}
+      </div>
+
+      {/* Separator */}
+      <div style={{ width: 1, height: 40, background: 'var(--border)', flexShrink: 0 }} />
+
+      {/* Deltas */}
+      <div style={{ display: 'flex', gap: 'var(--pad-3)' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <span
+            className="muted mono"
+            style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em' }}
+          >
+            vs 7d
+          </span>
+          <span
+            className="num"
+            style={{
+              fontSize: 16,
+              fontFamily: 'var(--font-mono)',
+              fontWeight: 500,
+              color: deltaColor(vs_7d, med),
+            }}
+          >
+            {formatDelta(vs_7d)}
+          </span>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <span
+            className="muted mono"
+            style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em' }}
+          >
+            vs 30d
+          </span>
+          <span
+            className="num"
+            style={{
+              fontSize: 16,
+              fontFamily: 'var(--font-mono)',
+              fontWeight: 500,
+              color: deltaColor(vs_30d, med),
+            }}
+          >
+            {formatDelta(vs_30d)}
+          </span>
+        </div>
+      </div>
+
+      {/* Separator */}
+      <div style={{ width: 1, height: 40, background: 'var(--border)', flexShrink: 0 }} />
+
+      {/* Sparkline */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+        <span
+          className="muted mono"
+          style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em' }}
+        >
+          30d trend
+        </span>
+        <Sparkline buckets={buckets} width={120} height={32} />
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -25,6 +25,7 @@ import type {
   CycleTimesResponse,
   CycleTimeAnalyticsResponse,
   SloConfig,
+  CostTrend,
 } from './types';
 import * as fx from './fixtures';
 
@@ -169,6 +170,15 @@ export interface IssuesCostParams {
   since?: string;
   limit?: number;
   offset?: number;
+}
+
+export async function fetchCostTrend(params: { days?: number; project?: string; priority?: string } = {}): Promise<CostTrend> {
+  const p = new URLSearchParams();
+  if (params.days != null)    p.set('days', String(params.days));
+  if (params.project)         p.set('project', params.project);
+  if (params.priority)        p.set('priority', params.priority);
+  const qs = p.size ? `?${p.toString()}` : '';
+  return get<CostTrend>(`/api/cost/trend${qs}`);
 }
 
 export async function fetchIssuesCost(params: IssuesCostParams = {}): Promise<IssueCostRow[]> {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -273,3 +273,21 @@ export interface IssueCostRow {
   last_event_at: string | null;
   github_url: string | null;
 }
+
+export interface CostTrendBucket {
+  date: string;
+  median_rework_factor: number | null;
+  issue_count: number;
+}
+
+export interface CostTrend {
+  window_days: number;
+  today: {
+    median_rework_factor: number | null;
+    issue_count: number;
+  };
+  vs_7d: number | null;
+  vs_30d: number | null;
+  trend: 'improving' | 'degrading' | 'stable';
+  buckets: CostTrendBucket[];
+}

--- a/web/src/screens/Cost.tsx
+++ b/web/src/screens/Cost.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { fetchIssuesCost } from '../lib/api';
+import { fetchIssuesCost, fetchCostTrend } from '../lib/api';
 import type { IssueCostRow } from '../lib/types';
+import CostTrendStrip from '../components/CostTrendStrip';
 
 const LIMIT = 50;
 
@@ -74,6 +75,17 @@ export default function Cost({ globalProjectFilter }: CostProps) {
     staleTime: 0,
   });
 
+  const trendQuery = useQuery({
+    queryKey: ['cost-trend', filterProject, filterPriority],
+    queryFn: () => fetchCostTrend({
+      days: 30,
+      project: filterProject || undefined,
+      priority: filterPriority || undefined,
+    }),
+    refetchInterval: 60_000,
+    staleTime: 0,
+  });
+
   const visible = allRows.filter(r => {
     if (filterProject && r.project !== filterProject) return false;
     if (filterPriority && r.priority !== filterPriority) return false;
@@ -112,6 +124,15 @@ export default function Cost({ globalProjectFilter }: CostProps) {
           </div>
         )}
       </div>
+
+      {trendQuery.data && (
+        <CostTrendStrip
+          today={trendQuery.data.today}
+          vs_7d={trendQuery.data.vs_7d}
+          vs_30d={trendQuery.data.vs_30d}
+          buckets={trendQuery.data.buckets}
+        />
+      )}
 
       <div style={{ display: 'flex', gap: 'var(--pad-2)', padding: 'var(--pad-3) var(--pad-4)', borderBottom: '1px solid var(--border)', alignItems: 'center' }}>
         <select


### PR DESCRIPTION
Closes #270

## Changes

Rewrote `scripts/dashboard.py` to match the ASCII mockup from the pre-v0.3.0 README:

- **Top banner**: Unicode box-drawing `┌─┐│└┘├┤` bordered header showing `LOOP MONITOR`, base URL, and current time (UTC + local).
- **Project cards row**: one box per project with name, `◉ idle|busy` status, total pts, last event age. Cards wrap to next row when total width exceeds terminal columns. Active projects (from `/api/active`) are marked `busy`.
- **Two-column body**: `LIVE FEED` (last 6-8 events, role glyph, ANSI color by role) on the left + `LEADERBOARD` (top 5: rank, role, pts) on the right.
- **Bottom callout**: latest judge verdict from `/api/verdicts`, single-line truncated to terminal width.
- **ANSI color**: used only when `sys.stdout.isatty()`; piped output is plain ASCII.
- **Narrow fallback**: terminal width < 80 cols → single-column simple layout (no boxes, stacked sections).
- **Preserved behaviours**: `--once` and `--interval` work exactly as before. No new dependencies (stdlib-only).

Only file changed: `scripts/dashboard.py`.

## Test Plan

- [ ] Run `python scripts/dashboard.py --once` against a live server — verify box-drawn banner, project cards, two-column feed + leaderboard, optional verdict callout.
- [ ] Pipe output: `python scripts/dashboard.py --once | cat` — verify no ANSI escape codes in output.
- [ ] Resize terminal to < 80 cols, run `--once` — verify fallback to single-column layout.
- [ ] `python scripts/dashboard.py --interval 5` — verify refresh-in-place behavior (clear-and-home on TTY).
- [ ] `ruff check scripts/dashboard.py` — all checks pass.