### PR TITLE
[LM-110] Per-ticket timeline view

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -31,6 +31,7 @@ from server.routes import (  # noqa: E402
     scanner_state,
     slos,
     stats,
+    timeline,
 )
 
 app.include_router(analytics.router)
@@ -48,6 +49,7 @@ app.include_router(logs.router)
 app.include_router(scanner_state.router)
 app.include_router(slos.router)
 app.include_router(config.router)
+app.include_router(timeline.router)
 
 app.mount("/", StaticFiles(directory="static/dist", html=True), name="webapp")
 

--- a/server/routes/timeline.py
+++ b/server/routes/timeline.py
@@ -1,0 +1,51 @@
+import json
+import sqlite3
+
+from fastapi import APIRouter, Depends, Query
+
+from server.db import db_dep
+
+router = APIRouter()
+
+
+@router.get("/api/timeline")
+def timeline(
+    slug: str = Query(...),
+    num: int = Query(...),
+    include_skips: bool = Query(False),
+    conn: sqlite3.Connection = Depends(db_dep),
+):
+    """Per-ticket event timeline ordered ascending by timestamp."""
+    where_clauses = ["project = ?", "issue_number = ?"]
+    params: list = [slug, num]
+
+    if not include_skips:
+        where_clauses.append(
+            "NOT (event_type = 'reconcile_check'"
+            " AND json_extract(payload, '$.decision') = 'skip')"
+        )
+
+    where_sql = " AND ".join(where_clauses)
+
+    rows = conn.execute(
+        f"""
+        SELECT id, project, role, model, event_type, issue_number, pr_number,
+               detail, payload, created_at AS ts
+        FROM events
+        WHERE {where_sql}
+        ORDER BY created_at ASC, id ASC
+        """,
+        params,
+    ).fetchall()
+
+    events = []
+    for r in rows:
+        entry = dict(r)
+        if entry["payload"]:
+            try:
+                entry["payload"] = json.loads(entry["payload"])
+            except (json.JSONDecodeError, TypeError):
+                entry["payload"] = None
+        events.append(entry)
+
+    return {"events": events}

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,0 +1,101 @@
+import json
+import sqlite3
+
+import server.db
+
+
+def _insert(conn, *, project, issue_number, event_type, payload=None, created_at="2026-01-01T00:00:00"):
+    conn.execute(
+        "INSERT INTO events (project, role, event_type, issue_number, payload, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+        (project, "dev", event_type, issue_number, json.dumps(payload) if payload else None, created_at),
+    )
+    conn.commit()
+
+
+def test_timeline_happy_path(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _insert(conn, project="proj-tl", issue_number=42, event_type="dev_start", created_at="2026-01-01T00:00:00")
+    _insert(conn, project="proj-tl", issue_number=42, event_type="dev_done", created_at="2026-01-01T00:01:00")
+    conn.close()
+
+    resp = isolated_client.get("/api/timeline?slug=proj-tl&num=42")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "events" in data
+    assert len(data["events"]) == 2
+    types = [e["event_type"] for e in data["events"]]
+    assert types == ["dev_start", "dev_done"]
+    # ascending by ts
+    assert data["events"][0]["ts"] <= data["events"][1]["ts"]
+
+
+def test_timeline_empty(isolated_client):
+    resp = isolated_client.get("/api/timeline?slug=no-such-project&num=9999")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data == {"events": []}
+
+
+def test_timeline_skip_filter_default(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _insert(conn, project="proj-skip", issue_number=1, event_type="dev_start", created_at="2026-01-01T00:00:00")
+    _insert(
+        conn, project="proj-skip", issue_number=1, event_type="reconcile_check",
+        payload={"decision": "skip", "reason": "workflow-aware skip"},
+        created_at="2026-01-01T00:01:00",
+    )
+    _insert(conn, project="proj-skip", issue_number=1, event_type="dev_done", created_at="2026-01-01T00:02:00")
+    conn.close()
+
+    # By default, reconcile_check decision=skip are hidden
+    resp = isolated_client.get("/api/timeline?slug=proj-skip&num=1")
+    assert resp.status_code == 200
+    types = [e["event_type"] for e in resp.json()["events"]]
+    assert "reconcile_check" not in types
+    assert "dev_start" in types
+    assert "dev_done" in types
+
+
+def test_timeline_skip_filter_revealed(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _insert(conn, project="proj-skip2", issue_number=2, event_type="dev_start", created_at="2026-01-01T00:00:00")
+    _insert(
+        conn, project="proj-skip2", issue_number=2, event_type="reconcile_check",
+        payload={"decision": "skip"},
+        created_at="2026-01-01T00:01:00",
+    )
+    conn.close()
+
+    resp = isolated_client.get("/api/timeline?slug=proj-skip2&num=2&include_skips=true")
+    assert resp.status_code == 200
+    types = [e["event_type"] for e in resp.json()["events"]]
+    assert "reconcile_check" in types
+
+
+def test_timeline_non_skip_reconcile_shown_by_default(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _insert(
+        conn, project="proj-rec", issue_number=3, event_type="reconcile_check",
+        payload={"decision": "proceed"},
+        created_at="2026-01-01T00:00:00",
+    )
+    conn.close()
+
+    resp = isolated_client.get("/api/timeline?slug=proj-rec&num=3")
+    assert resp.status_code == 200
+    types = [e["event_type"] for e in resp.json()["events"]]
+    assert "reconcile_check" in types
+
+
+def test_timeline_scope_isolation(isolated_client):
+    """Events from a different issue are not returned."""
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _insert(conn, project="proj-iso", issue_number=10, event_type="dev_start", created_at="2026-01-01T00:00:00")
+    _insert(conn, project="proj-iso", issue_number=20, event_type="dev_start", created_at="2026-01-01T00:00:00")
+    conn.close()
+
+    resp = isolated_client.get("/api/timeline?slug=proj-iso&num=10")
+    assert resp.status_code == 200
+    events = resp.json()["events"]
+    assert all(e["issue_number"] == 10 for e in events)
+    assert len(events) == 1

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import Queue from './screens/Queue';
 import WorkerDetail from './screens/WorkerDetail';
 import Cost from './screens/Cost';
 import Analytics from './screens/Analytics';
+import Timeline from './screens/Timeline';
 import { useHashRoute } from './router';
 import { fetchActive, fetchHealth } from './lib/api';
 
@@ -23,7 +24,7 @@ const SCREEN_KEYS: Record<string, string> = {
 };
 
 export default function App() {
-  const { screen: hashScreen, projectId: hashProjectId, projectFilter, navigateTo, setProjectFilter } = useHashRoute();
+  const { screen: hashScreen, projectId: hashProjectId, issueNum: hashIssueNum, projectFilter, navigateTo, setProjectFilter } = useHashRoute();
 
   // 'cost' is local-only — not stored in the hash — so we track it separately.
   const [showCost, setShowCost] = useState(false);
@@ -75,6 +76,7 @@ export default function App() {
   }
 
   const isProjectDetail = hashNavScreen === 'projects' && projectId != null;
+  const isTimeline = hashScreen === 'timeline' && projectId != null && hashIssueNum != null;
 
   const activeQuery = useQuery({
     queryKey: ['active'],
@@ -120,6 +122,12 @@ export default function App() {
       <main className="main">
         {showCost ? (
           <Cost globalProjectFilter={projectFilter} />
+        ) : isTimeline && projectId != null && hashIssueNum != null ? (
+          <Timeline
+            projectId={projectId}
+            issueNum={hashIssueNum}
+            onBack={() => navigateTo('project', projectId, { drawer: null, pushState: true })}
+          />
         ) : isProjectDetail && projectId != null ? (
           <ProjectDetail
             projectId={projectId}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -25,6 +25,7 @@ import type {
   CycleTimesResponse,
   CycleTimeAnalyticsResponse,
   SloConfig,
+  TimelineResponse,
 } from './types';
 import * as fx from './fixtures';
 
@@ -198,6 +199,12 @@ export async function fetchCycleTimes(project: string): Promise<CycleTimesRespon
 
 export async function fetchAnalyticsCycleTime(days = 30): Promise<CycleTimeAnalyticsResponse> {
   return get<CycleTimeAnalyticsResponse>(`/api/analytics/cycle_time?days=${days}`);
+}
+
+export async function fetchTimeline(slug: string, num: number, includeSkips = false): Promise<TimelineResponse> {
+  const p = new URLSearchParams({ slug, num: String(num) });
+  if (includeSkips) p.set('include_skips', 'true');
+  return get<TimelineResponse>(`/api/timeline?${p.toString()}`);
 }
 
 export async function fetchSlo(project: string): Promise<SloConfig> {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -261,6 +261,23 @@ export interface CycleTimeAnalyticsResponse {
   lead_time: CycleTimePct | null;
 }
 
+export interface TimelineEvent {
+  id: number;
+  project: string;
+  role: string;
+  model: string | null;
+  event_type: string;
+  issue_number: number | null;
+  pr_number: number | null;
+  detail: string | null;
+  payload: Record<string, unknown> | null;
+  ts: string;
+}
+
+export interface TimelineResponse {
+  events: TimelineEvent[];
+}
+
 export interface IssueCostRow {
   project: string;
   issue_number: number;

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useState } from 'react';
 
-export type Screen = 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs' | 'analytics';
+export type Screen = 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs' | 'analytics' | 'timeline';
 
 export interface HashRoute {
   screen: Screen;
   projectId: string | null;
   drawer: string | null;
+  issueNum: number | null;
 }
 
 function parseHash(hash: string): { known: HashRoute; unknown: Record<string, string> } {
@@ -13,7 +14,7 @@ function parseHash(hash: string): { known: HashRoute; unknown: Record<string, st
 
   if (!hash || hash === '#') {
     return {
-      known: { screen: 'overview', projectId: null, drawer: null },
+      known: { screen: 'overview', projectId: null, drawer: null, issueNum: null },
       unknown,
     };
   }
@@ -28,6 +29,7 @@ function parseHash(hash: string): { known: HashRoute; unknown: Record<string, st
   let screen: Screen = 'overview';
   let projectId: string | null = null;
   let drawer: string | null = null;
+  let issueNum: number | null = null;
 
   for (const [key, value] of params.entries()) {
     if (key === 'screen') {
@@ -40,12 +42,15 @@ function parseHash(hash: string): { known: HashRoute; unknown: Record<string, st
       }
     } else if (key === 'drawer') {
       drawer = value;
+    } else if (key === 'num') {
+      const parsed = parseInt(value, 10);
+      issueNum = isNaN(parsed) ? null : parsed;
     } else {
       unknown[key] = value;
     }
   }
 
-  return { known: { screen, projectId, drawer }, unknown };
+  return { known: { screen, projectId, drawer, issueNum }, unknown };
 }
 
 function buildHash(
@@ -53,17 +58,22 @@ function buildHash(
   projectId: string | null,
   drawer: string | null,
   unknown: Record<string, string>,
+  issueNum: number | null = null,
 ): string {
   const params = new URLSearchParams();
 
   // Write screen (omit if it's 'overview' AND everything else is empty — keep URLs clean)
-  const hasOtherKeys = projectId || drawer || Object.keys(unknown).length > 0;
+  const hasOtherKeys = projectId || drawer || issueNum != null || Object.keys(unknown).length > 0;
   if (screen !== 'overview' || hasOtherKeys) {
     params.set('screen', screen);
   }
 
   if (projectId) {
     params.set('project', projectId);
+  }
+
+  if (issueNum != null) {
+    params.set('num', String(issueNum));
   }
 
   if (drawer) {
@@ -93,17 +103,18 @@ export function useHashRoute() {
     (
       screen: Screen,
       projectId: string | null = null,
-      opts?: { drawer?: string | null; pushState?: boolean },
+      opts?: { drawer?: string | null; pushState?: boolean; issueNum?: number | null },
     ) => {
       const drawer = opts?.drawer !== undefined ? opts.drawer : route.drawer;
-      const hash = buildHash(screen, projectId, drawer ?? null, unknown);
+      const issueNum = opts?.issueNum !== undefined ? opts.issueNum : null;
+      const hash = buildHash(screen, projectId, drawer ?? null, unknown, issueNum);
       if (opts?.pushState) {
         history.pushState(null, '', window.location.pathname + window.location.search + hash);
       } else {
         history.replaceState(null, '', window.location.pathname + window.location.search + hash);
       }
       setParsed(prev => ({
-        known: { screen, projectId, drawer: drawer ?? null },
+        known: { screen, projectId, drawer: drawer ?? null, issueNum: issueNum ?? null },
         unknown: prev.unknown,
       }));
     },
@@ -112,14 +123,14 @@ export function useHashRoute() {
 
   const setDrawer = useCallback(
     (drawer: string | null) => {
-      const hash = buildHash(route.screen, route.projectId, drawer, unknown);
+      const hash = buildHash(route.screen, route.projectId, drawer, unknown, route.issueNum);
       history.replaceState(null, '', window.location.pathname + window.location.search + hash);
       setParsed(prev => ({
         known: { ...prev.known, drawer },
         unknown: prev.unknown,
       }));
     },
-    [route.screen, route.projectId, unknown],
+    [route.screen, route.projectId, route.issueNum, unknown],
   );
 
   const setProjectFilter = useCallback(
@@ -130,20 +141,21 @@ export function useHashRoute() {
       } else {
         delete newUnknown['project_filter'];
       }
-      const hash = buildHash(route.screen, route.projectId, route.drawer, newUnknown);
+      const hash = buildHash(route.screen, route.projectId, route.drawer, newUnknown, route.issueNum);
       history.replaceState(null, '', window.location.pathname + window.location.search + hash);
       setParsed(prev => ({
         known: prev.known,
         unknown: newUnknown,
       }));
     },
-    [route.screen, route.projectId, route.drawer, unknown],
+    [route.screen, route.projectId, route.drawer, route.issueNum, unknown],
   );
 
   return {
     screen: route.screen,
     projectId: route.projectId,
     drawer: route.drawer,
+    issueNum: route.issueNum,
     projectFilter: unknown['project_filter'] ?? null,
     navigateTo,
     setDrawer,

--- a/web/src/screens/ProjectDetail.tsx
+++ b/web/src/screens/ProjectDetail.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import PrMonitorTable from '../components/PrMonitorTable';
 import type { Worker, FeedItem, PipelineRun, PRMonitorEntry, CycleTimesResponse, SloConfig } from '../lib/types';
 import { fetchCycleTimes, fetchSlo } from '../lib/api';
+import { useHashRoute } from '../router';
 
 interface IssueRollup {
   num: number;
@@ -163,6 +164,7 @@ function CycleTimePanel({ cycleTimes, slo, runs }: CycleTimePanelProps) {
 }
 
 export default function ProjectDetail({ projectId, allProjectIds, onBack, onProjectChange }: ProjectDetailProps) {
+  const { navigateTo } = useHashRoute();
   const [runs, setRuns] = useState<PipelineRun[]>([]);
   const [prs, setPrs] = useState<PRMonitorEntry[]>([]);
   const [feed, setFeed] = useState<FeedItem[]>([]);
@@ -336,11 +338,12 @@ export default function ProjectDetail({ projectId, allProjectIds, onBack, onProj
                   <th style={{ textAlign: 'right' }}>Runs</th>
                   <th>Last</th>
                   <th style={{ textAlign: 'right' }}>Pts</th>
+                  <th></th>
                 </tr>
               </thead>
               <tbody>
                 {issues.length === 0 && (
-                  <tr><td colSpan={5} className="muted" style={{ textAlign: 'center', padding: 'var(--pad-3)' }}>No runs yet</td></tr>
+                  <tr><td colSpan={6} className="muted" style={{ textAlign: 'center', padding: 'var(--pad-3)' }}>No runs yet</td></tr>
                 )}
                 {issues.map(i => (
                   <tr key={i.num}>
@@ -358,6 +361,16 @@ export default function ProjectDetail({ projectId, allProjectIds, onBack, onProj
                       {i.lastAt ? relTime(i.lastAt) : '—'}
                     </td>
                     <td className="num" style={{ textAlign: 'right' }}>{i.pts}</td>
+                    <td>
+                      <button
+                        className="btn"
+                        style={{ fontSize: 10, padding: '1px 6px' }}
+                        onClick={() => navigateTo('timeline', projectId, { drawer: null, pushState: true, issueNum: i.num })}
+                        title={`Timeline for #${i.num}`}
+                      >
+                        timeline
+                      </button>
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/web/src/screens/Timeline.tsx
+++ b/web/src/screens/Timeline.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useState } from 'react';
+import { fetchTimeline } from '../lib/api';
+import type { TimelineEvent } from '../lib/types';
+
+interface TimelineProps {
+  projectId: string;
+  issueNum: number;
+  onBack: () => void;
+}
+
+const TYPE_BADGE: Record<string, { label: string; color: string }> = {
+  dev_start:        { label: 'dev',       color: 'var(--role-dev)' },
+  dev_done:         { label: 'dev',       color: 'var(--role-dev)' },
+  dev_failed:       { label: 'dev',       color: 'var(--fail)' },
+  review_start:     { label: 'review',    color: 'var(--role-reviewer)' },
+  review_done:      { label: 'review',    color: 'var(--role-reviewer)' },
+  review_failed:    { label: 'review',    color: 'var(--fail)' },
+  qa_start:         { label: 'qa',        color: 'var(--role-qa)' },
+  qa_pass:          { label: 'qa',        color: 'var(--role-qa)' },
+  qa_fail:          { label: 'qa',        color: 'var(--fail)' },
+  merge_start:      { label: 'merge',     color: 'var(--role-merge)' },
+  merge_done:       { label: 'merge',     color: 'var(--role-merge)' },
+  po_start:         { label: 'po',        color: 'var(--role-po)' },
+  po_done:          { label: 'po',        color: 'var(--role-po)' },
+  po_failed:        { label: 'po',        color: 'var(--fail)' },
+  rework_start:     { label: 'rework',    color: 'var(--fg-3)' },
+  rework_done:      { label: 'rework',    color: 'var(--fg-3)' },
+  reconcile_check:  { label: 'reconcile', color: 'var(--fg-3)' },
+  judge:            { label: 'judge',     color: 'var(--role-judge)' },
+};
+
+function badgeFor(eventType: string): { label: string; color: string } {
+  if (TYPE_BADGE[eventType]) return TYPE_BADGE[eventType];
+  // Derive from suffix pattern
+  if (eventType.endsWith('_done') || eventType.endsWith('_pass')) return { label: eventType, color: 'var(--accent)' };
+  if (eventType.endsWith('_failed') || eventType.endsWith('_fail')) return { label: eventType, color: 'var(--fail)' };
+  if (eventType.endsWith('_start')) return { label: eventType, color: 'var(--fg-2)' };
+  return { label: eventType, color: 'var(--fg-3)' };
+}
+
+function fmtTs(isoStr: string): string {
+  try {
+    const d = new Date(isoStr.includes('T') ? isoStr : isoStr + 'Z');
+    return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  } catch {
+    return isoStr;
+  }
+}
+
+function EventRow({ event }: { event: TimelineEvent }) {
+  const badge = badgeFor(event.event_type);
+  const hasPayload = event.payload && Object.keys(event.payload).length > 0;
+
+  return (
+    <div style={{ display: 'flex', gap: 12, padding: '10px 0', borderBottom: '1px solid var(--border)' }}>
+      {/* Timeline spine */}
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', flexShrink: 0, width: 16 }}>
+        <div style={{
+          width: 10, height: 10, borderRadius: '50%',
+          background: badge.color,
+          flexShrink: 0,
+          marginTop: 3,
+        }} />
+      </div>
+
+      {/* Content */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+          <span className="tag" style={{ color: badge.color, borderColor: badge.color, flexShrink: 0 }}>
+            {badge.label}
+          </span>
+          <span className="mono" style={{ fontSize: 12, color: 'var(--fg)' }}>{event.event_type}</span>
+          {event.role && event.role !== badge.label && (
+            <span className="muted mono" style={{ fontSize: 11 }}>· {event.role}</span>
+          )}
+          {event.model && (
+            <span className="muted mono" style={{ fontSize: 11 }}>· {event.model}</span>
+          )}
+          {event.pr_number != null && (
+            <span className="muted mono" style={{ fontSize: 11 }}>· PR #{event.pr_number}</span>
+          )}
+        </div>
+        {event.detail && (
+          <div className="muted" style={{ fontSize: 11, marginTop: 3, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {event.detail}
+          </div>
+        )}
+        {hasPayload && (
+          <div className="muted mono" style={{ fontSize: 10, marginTop: 3, color: 'var(--fg-3)' }}>
+            {Object.entries(event.payload as Record<string, unknown>)
+              .slice(0, 4)
+              .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
+              .join(' · ')}
+          </div>
+        )}
+      </div>
+
+      {/* Timestamp */}
+      <div className="muted mono" style={{ fontSize: 10, textAlign: 'right', flexShrink: 0, paddingTop: 3 }}>
+        {fmtTs(event.ts)}
+      </div>
+    </div>
+  );
+}
+
+export default function Timeline({ projectId, issueNum, onBack }: TimelineProps) {
+  const [events, setEvents] = useState<TimelineEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [includeSkips, setIncludeSkips] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(false);
+    fetchTimeline(projectId, issueNum, includeSkips)
+      .then(data => { setEvents(data.events); setLoading(false); })
+      .catch(() => { setError(true); setLoading(false); });
+  }, [projectId, issueNum, includeSkips]);
+
+  return (
+    <div data-testid="timeline-screen">
+      {/* Header */}
+      <div className="screen-h" style={{ display: 'flex', alignItems: 'center', gap: 'var(--pad-3)', padding: 'var(--pad-2) var(--pad-4)' }}>
+        <button className="btn" onClick={onBack}>← Back</button>
+        <h1 style={{ flex: 1, margin: 0, fontFamily: 'var(--font-mono)', fontSize: 13, fontWeight: 500, letterSpacing: '0.04em' }}>
+          <span className="muted">timeline /</span> {projectId} <span className="muted">·</span> #{issueNum}
+        </h1>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, cursor: 'pointer', color: 'var(--fg-2)' }}>
+          <input
+            type="checkbox"
+            checked={includeSkips}
+            onChange={e => setIncludeSkips(e.target.checked)}
+          />
+          Show reconcile skips
+        </label>
+      </div>
+
+      {/* Body */}
+      <div style={{ padding: 'var(--pad-4)' }}>
+        <div className="panel">
+          <div className="panel-h">
+            <span>Event timeline</span>
+            {!loading && <span className="muted">{events.length} event{events.length !== 1 ? 's' : ''}</span>}
+          </div>
+          <div style={{ padding: '0 var(--pad-4)' }}>
+            {loading && (
+              <div className="muted" style={{ padding: 'var(--pad-3)', textAlign: 'center', fontSize: 12 }}>Loading…</div>
+            )}
+            {error && (
+              <div style={{ padding: 'var(--pad-3)', textAlign: 'center', fontSize: 12, color: 'var(--fail)' }}>Failed to load timeline</div>
+            )}
+            {!loading && !error && events.length === 0 && (
+              <div className="muted" style={{ padding: 'var(--pad-3)', textAlign: 'center', fontSize: 12 }}>
+                No events recorded for this ticket
+              </div>
+            )}
+            {!loading && !error && events.map(e => (
+              <EventRow key={e.id} event={e} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #110

## Changes

**Backend (`server/routes/timeline.py`):**
- New `GET /api/timeline?slug=X&num=N` route returning `{ events: [...] }` ordered ascending by `ts`
- Reads from the existing `events` table (the event-audit table from #109's migration 0004 indexes)
- Query-param `include_skips=true` reveals `reconcile_check` events with `decision=skip`; they are hidden by default to cut down on workflow-aware skip noise (#193/#206)
- Registered in `server/app.py`

**Frontend:**
- `web/src/screens/Timeline.tsx` — vertical timeline with type badges derived from a map (unknown event types get neutral badge, no error)
- `web/src/router.tsx` — added `'timeline'` to `Screen` type and `issueNum` as a known hash param (`#screen=timeline&project=slug&num=N`)
- `web/src/App.tsx` — routes to the Timeline screen
- `web/src/screens/ProjectDetail.tsx` — each issue row in "Recent issues" table now has a **timeline** button linking to `#screen=timeline&project=…&num=…`
- `web/src/lib/types.ts` — added `TimelineEvent` and `TimelineResponse` interfaces
- `web/src/lib/api.ts` — added `fetchTimeline(slug, num, includeSkips?)` helper

**Tests (`tests/test_timeline.py`):**
- Happy path with correct ascending order
- Empty result → HTTP 200 `{ events: [] }`
- Default filter hides `reconcile_check decision=skip`
- `include_skips=true` reveals them
- Non-skip `reconcile_check` events shown by default
- Scope isolation (events from different issue are excluded)

## Test Plan
- [ ] `GET /api/timeline?slug=<project>&num=<issue>` returns events for that ticket in ascending order
- [ ] `reconcile_check` with `decision=skip` absent by default; toggle "Show reconcile skips" reveals them
- [ ] "timeline" button in Project Detail → Recent issues table navigates to the timeline screen
- [ ] Empty state shows "No events recorded for this ticket"
- [ ] `ruff check .` passes; `npm run typecheck` passes; `npm run build` passes; `pytest tests/test_timeline.py` 6/6 pass