### PR TITLE
[LM-269] Fix TopBar events/min rate stuck at 0

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,7 +11,7 @@ import WorkerDetail from './screens/WorkerDetail';
 import Cost from './screens/Cost';
 import Analytics from './screens/Analytics';
 import { useHashRoute } from './router';
-import { fetchActive, fetchHealth } from './lib/api';
+import { fetchActive, fetchFeed, fetchHealth } from './lib/api';
 
 const SCREEN_KEYS: Record<string, string> = {
   '1': 'overview',
@@ -83,6 +83,13 @@ export default function App() {
     staleTime: 0,
   });
 
+  const feedQuery = useQuery({
+    queryKey: ['feed'],
+    queryFn: () => fetchFeed(),
+    refetchInterval: 5000,
+    staleTime: 0,
+  });
+
   const healthQuery = useQuery({
     queryKey: ['health'],
     queryFn: () => fetchHealth(),
@@ -99,8 +106,8 @@ export default function App() {
     return () => window.removeEventListener('keydown', onKey);
   }, []);
 
-  const events = (activeQuery.data ?? []).map((w) => ({
-    ts: new Date(w.created_at).getTime(),
+  const events = (feedQuery.data ?? []).map((f) => ({
+    ts: new Date(f.created_at).getTime(),
   }));
   const online = !activeQuery.isError;
   const version = healthQuery.data?.monitor_version ?? '…';


### PR DESCRIPTION
Closes #269

## Changes

**`web/src/App.tsx`**
- Added a `feedQuery` using `useQuery` that calls `fetchFeed()` with `refetchInterval: 5000` and `staleTime: 0`
- Changed the `events` prop derivation from `activeQuery.data` (active workers via `/api/active`) to `feedQuery.data` (timestamped feed items via `/api/feed`)
- Each event now carries a `ts` field parsed from `feed_item.created_at` as epoch ms
- `online` connectivity state still derives from `activeQuery.isError` (unchanged semantics)

**Root cause:** `activeQuery` returns currently-running workers — an empty list when idle. TopBar's rolling-window counter was always fed an empty array, so it always showed `0/min`. Switching to `feedQuery` gives TopBar real timestamped events; its existing `useTick(1000)` loop and `Date.now() - e.ts < 60_000` filter then produce a correct live rate.

## Test Plan
- With recent feed events in the last 60s, TopBar should display a non-zero `N/min` count
- With no recent events (older than 60s or empty feed), TopBar displays `0/min`; total count reflects feed length
- `npm run typecheck` passes
- `npm run build` passes
- `ruff check .` passes