### PR TITLE
[LM-257] Dedicated service checkout + redeploy script + sha-mismatch banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,41 @@ cp config/projects.yaml.example config/projects.yaml   # then edit
 
 Open http://127.0.0.1:18792.
 
+## Production service setup (macOS LaunchAgent)
+
+For a stable production install, run the service from a **dedicated checkout** that your pipeline never writes to. This decouples service uptime from any branch checkouts or in-progress work in the pipeline working tree.
+
+### One-time bootstrap
+
+```bash
+# 1. Clone to a dedicated location outside your pipeline working tree
+git clone https://github.com/svv2014/loop-monitor.git \
+    ~/.openclaw/workspace/services/loop-monitor
+
+# 2. Build the frontend
+cd ~/.openclaw/workspace/services/loop-monitor/web
+npm ci && npm run build
+cd ..
+
+# 3. Install and load the LaunchAgent
+cp scripts/com.user.loop-monitor.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.user.loop-monitor.plist
+launchctl start com.user.loop-monitor
+```
+
+The service starts at `http://127.0.0.1:18792`. The dashboard's TopBar shows an update banner when the running commit differs from the latest `main`.
+
+### Redeploy (pull latest main)
+
+```bash
+# From any checkout of the repo:
+scripts/redeploy.sh
+```
+
+This fetches `origin/main`, resets the service checkout, reinstalls dependencies, rebuilds the frontend, and restarts via `launchctl kickstart`. Exits non-zero on any failure.
+
+Override the service directory with `LOOP_MONITOR_SERVICE_DIR=/path/to/checkout scripts/redeploy.sh`.
+
 ## Bring your own pipeline
 
 loop-monitor is wire-compatible with any system that can POST a small JSON payload per stage transition. Three configuration files cover the common reuse cases:

--- a/scripts/com.user.loop-monitor.plist
+++ b/scripts/com.user.loop-monitor.plist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  loop-monitor service — FastAPI dashboard server.
+  Runs from a dedicated service checkout that the pipeline never touches.
+
+  Bootstrap (one-time):
+    git clone https://github.com/svv2014/loop-monitor.git \
+        ~/.openclaw/workspace/services/loop-monitor
+    cd ~/.openclaw/workspace/services/loop-monitor/web && npm ci && npm run build
+    cp scripts/com.user.loop-monitor.plist ~/Library/LaunchAgents/
+    launchctl load ~/Library/LaunchAgents/com.user.loop-monitor.plist
+    launchctl start com.user.loop-monitor
+
+  Redeploy (pull latest main + rebuild + restart):
+    scripts/redeploy.sh
+
+  Disable:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-monitor.plist
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-monitor</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/vadim/.openclaw/workspace/services/loop-monitor/run.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/vadim/.openclaw/workspace/services/loop-monitor</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/loop-monitor.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/loop-monitor.err.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/com.user.loop-watch.plist
+++ b/scripts/com.user.loop-watch.plist
@@ -13,8 +13,11 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/vadim/.openclaw/workspace/projects/loop-monitor/scripts/loop-watch.sh</string>
+        <string>/Users/vadim/.openclaw/workspace/services/loop-monitor/scripts/loop-watch.sh</string>
     </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/vadim/.openclaw/workspace/services/loop-monitor</string>
 
     <key>StartInterval</key>
     <integer>7200</integer>

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# redeploy.sh — pull latest main into the dedicated service checkout and restart.
+#
+# One-time bootstrap (not scripted — do this once, then use this script):
+#   git clone https://github.com/svv2014/loop-monitor.git \
+#       ~/.openclaw/workspace/services/loop-monitor
+#
+# Usage:  scripts/redeploy.sh [--service-dir <path>]
+#
+# Exits non-zero on any failed step (set -e).
+
+set -euo pipefail
+
+SERVICE_DIR="${LOOP_MONITOR_SERVICE_DIR:-${HOME}/.openclaw/workspace/services/loop-monitor}"
+PLIST_LABEL="com.user.loop-monitor"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --service-dir) SERVICE_DIR="${2:?--service-dir needs a path}"; shift 2 ;;
+        -h|--help)
+            sed -n '2,10p' "$0"
+            exit 0
+            ;;
+        *) echo "Unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+log() { printf '[redeploy] %s\n' "$*"; }
+
+if [[ ! -d "${SERVICE_DIR}/.git" ]]; then
+    echo "ERROR: ${SERVICE_DIR} is not a git repository." >&2
+    echo "Bootstrap with: git clone https://github.com/svv2014/loop-monitor.git ${SERVICE_DIR}" >&2
+    exit 1
+fi
+
+cd "${SERVICE_DIR}"
+
+log "Fetching latest main..."
+git fetch origin
+
+log "Resetting to origin/main..."
+git reset --hard origin/main
+
+if [[ -f requirements.txt ]]; then
+    log "Installing Python dependencies..."
+    pip install -r requirements.txt --quiet
+fi
+
+log "Building frontend..."
+cd web
+npm ci --silent
+npm run build
+cd ..
+
+log "Restarting service (${PLIST_LABEL})..."
+launchctl kickstart -k "gui/$(id -u)/${PLIST_LABEL}"
+
+log "Done. Service restarted from $(git rev-parse --short HEAD)."

--- a/server/routes/health.py
+++ b/server/routes/health.py
@@ -1,5 +1,6 @@
 import sqlite3
 import subprocess
+from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import APIRouter, Depends
@@ -10,6 +11,10 @@ from server.db import db_dep
 router = APIRouter()
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+_REMOTE_URL = "https://github.com/svv2014/loop-monitor.git"
+_LATEST_SHA_TTL = 60  # seconds
+
+_latest_sha_cache: dict = {"sha": None, "fetched_at": None}
 
 
 def _git_sha() -> str:
@@ -29,6 +34,34 @@ def _git_sha() -> str:
     return sha or "unknown"
 
 
+def _latest_main_sha() -> str:
+    """Fetch the current HEAD sha of origin/main via git ls-remote. Cached for TTL seconds."""
+    fetched: datetime | None = _latest_sha_cache["fetched_at"]
+    if fetched is not None and _latest_sha_cache["sha"] is not None:
+        age = (datetime.now(timezone.utc) - fetched).total_seconds()
+        if age < _LATEST_SHA_TTL:
+            return _latest_sha_cache["sha"]  # type: ignore[return-value]
+
+    try:
+        result = subprocess.run(
+            ["git", "ls-remote", _REMOTE_URL, "refs/heads/main"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:
+        return _latest_sha_cache["sha"] or "unknown"
+
+    if result.returncode != 0 or not result.stdout.strip():
+        return _latest_sha_cache["sha"] or "unknown"
+
+    full_sha = result.stdout.split()[0]
+    sha = full_sha[:7]
+    _latest_sha_cache["sha"] = sha
+    _latest_sha_cache["fetched_at"] = datetime.now(timezone.utc)
+    return sha
+
+
 @router.get("/api/health")
 def health(conn: sqlite3.Connection = Depends(db_dep)):
     rows = conn.execute(
@@ -43,6 +76,7 @@ def health(conn: sqlite3.Connection = Depends(db_dep)):
         "status": "ok",
         "monitor_version": MONITOR_VERSION,
         "git_sha": _git_sha(),
+        "latest_main_sha": _latest_main_sha(),
         "supported_bounty_api": f"{SUPPORTED_API_MAJOR}.x",
         "core_version_counts": core_version_counts,
         "loop_ids": loop_ids,

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -92,6 +92,34 @@ def test_health_git_sha_field(isolated_client):
     assert sha == "unknown" or re.match(r"^[0-9a-f]{7}$", sha)
 
 
+def test_health_latest_main_sha_field(isolated_client):
+    resp = isolated_client.get("/api/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "latest_main_sha" in data
+    sha = data["latest_main_sha"]
+    assert sha == "unknown" or re.match(r"^[0-9a-f]{7}$", sha)
+
+
+def test_health_latest_main_sha_cached(isolated_client, monkeypatch):
+    import server.routes.health as health_mod
+
+    call_count = 0
+
+    def fake_fetch():
+        nonlocal call_count
+        call_count += 1
+        return "abc1234"
+
+    monkeypatch.setattr(health_mod, "_latest_main_sha", fake_fetch)
+
+    isolated_client.get("/api/health")
+    isolated_client.get("/api/health")
+
+    resp = isolated_client.get("/api/health")
+    assert resp.status_code == 200
+
+
 def test_health_loop_ids_empty_db(isolated_client):
     resp = isolated_client.get("/api/health")
     assert resp.status_code == 200

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -104,6 +104,8 @@ export default function App() {
   }));
   const online = !activeQuery.isError;
   const version = healthQuery.data?.monitor_version ?? '…';
+  const gitSha = healthQuery.data?.git_sha;
+  const latestMainSha = healthQuery.data?.latest_main_sha;
 
   return (
     <div className="app">
@@ -112,6 +114,8 @@ export default function App() {
         events={events}
         online={online}
         version={version}
+        gitSha={gitSha}
+        latestMainSha={latestMainSha}
         allProjectIds={allProjectIds}
         projectFilter={projectFilter}
         onProjectFilterChange={setProjectFilter}

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -30,9 +30,14 @@ function useTick(ms = 1000) {
   }, [ms]);
 }
 
+const BANNER_DISMISS_KEY = 'lm_sha_banner_dismissed_for';
+
 export default function TopBar({ events, online, version, gitSha, latestMainSha, allProjectIds, projectFilter, onProjectFilterChange }: TopBarProps) {
   useTick(1000);
-  const [bannerDismissed, setBannerDismissed] = useState(false);
+  // Store the mismatch key (running:latest) that was dismissed — reappears when either sha changes.
+  const [dismissedFor, setDismissedFor] = useState(
+    () => sessionStorage.getItem(BANNER_DISMISS_KEY) ?? '',
+  );
   const now = new Date();
   const eventsLastMin = events.filter(e => Date.now() - e.ts < 60_000).length;
   const isFiltered = !!projectFilter;
@@ -44,7 +49,8 @@ export default function TopBar({ events, online, version, gitSha, latestMainSha,
     latestMainSha !== 'unknown' &&
     gitSha !== latestMainSha;
 
-  const showBanner = shaMismatch && !bannerDismissed;
+  const mismatchKey = shaMismatch ? `${gitSha}:${latestMainSha}` : '';
+  const showBanner = shaMismatch && dismissedFor !== mismatchKey;
 
   return (
     <>
@@ -103,7 +109,10 @@ export default function TopBar({ events, online, version, gitSha, latestMainSha,
             Run <code style={{ background: 'var(--bg-2)', padding: '1px 5px', borderRadius: 3 }}>scripts/redeploy.sh</code> to update.
           </span>
           <button
-            onClick={() => setBannerDismissed(true)}
+            onClick={() => {
+              sessionStorage.setItem(BANNER_DISMISS_KEY, mismatchKey);
+              setDismissedFor(mismatchKey);
+            }}
             style={{
               background: 'none',
               border: 'none',

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -8,6 +8,8 @@ interface TopBarProps {
   events: TopBarEvent[];
   online: boolean;
   version: string;
+  gitSha?: string;
+  latestMainSha?: string;
   allProjectIds: string[];
   projectFilter: string | null;
   onProjectFilterChange: (v: string | null) => void;
@@ -28,46 +30,95 @@ function useTick(ms = 1000) {
   }, [ms]);
 }
 
-export default function TopBar({ events, online, version, allProjectIds, projectFilter, onProjectFilterChange }: TopBarProps) {
+export default function TopBar({ events, online, version, gitSha, latestMainSha, allProjectIds, projectFilter, onProjectFilterChange }: TopBarProps) {
   useTick(1000);
+  const [bannerDismissed, setBannerDismissed] = useState(false);
   const now = new Date();
   const eventsLastMin = events.filter(e => Date.now() - e.ts < 60_000).length;
   const isFiltered = !!projectFilter;
+
+  const shaMismatch =
+    gitSha != null &&
+    latestMainSha != null &&
+    gitSha !== 'unknown' &&
+    latestMainSha !== 'unknown' &&
+    gitSha !== latestMainSha;
+
+  const showBanner = shaMismatch && !bannerDismissed;
+
   return (
-    <div className="topbar">
-      <div className="left">
-        <span className="mono" style={{ color: 'var(--fg)', fontWeight: 500 }}>
-          PIPELINE
-          <span style={{ color: 'var(--fg-4)', marginLeft: 6 }}>v{version}</span>
-        </span>
-        <span style={{ width: 1, height: 14, background: 'var(--border)' }}></span>
-        <span><span className="dot"></span> &nbsp;{online ? 'CONNECTED' : 'OFFLINE'}</span>
-        <span>: 127.0.0.1:18792</span>
+    <>
+      <div className="topbar">
+        <div className="left">
+          <span className="mono" style={{ color: 'var(--fg)', fontWeight: 500 }}>
+            PIPELINE
+            <span style={{ color: 'var(--fg-4)', marginLeft: 6 }}>v{version}</span>
+          </span>
+          <span style={{ width: 1, height: 14, background: 'var(--border)' }}></span>
+          <span><span className="dot"></span> &nbsp;{online ? 'CONNECTED' : 'OFFLINE'}</span>
+          <span>: 127.0.0.1:18792</span>
+        </div>
+        <div className="right">
+          <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+            <label className="muted mono" style={{ fontSize: 11 }}>Project:</label>
+            <select
+              className="btn"
+              value={projectFilter ?? ''}
+              onChange={e => onProjectFilterChange(e.target.value || null)}
+              style={{
+                cursor: 'pointer',
+                border: isFiltered ? '1px solid var(--accent)' : undefined,
+                background: isFiltered ? 'color-mix(in srgb, var(--accent) 15%, var(--bg-1))' : undefined,
+                color: isFiltered ? 'var(--accent)' : undefined,
+              }}
+            >
+              <option value="">All</option>
+              {allProjectIds.map(id => (
+                <option key={id} value={id}>{id}</option>
+              ))}
+            </select>
+          </span>
+          <span>{eventsLastMin}/min</span>
+          <span>· {events.length.toLocaleString()} events</span>
+          <span>· {timeFmt(now)}</span>
+        </div>
       </div>
-      <div className="right">
-        <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-          <label className="muted mono" style={{ fontSize: 11 }}>Project:</label>
-          <select
-            className="btn"
-            value={projectFilter ?? ''}
-            onChange={e => onProjectFilterChange(e.target.value || null)}
+      {showBanner && (
+        <div
+          className="mono"
+          style={{
+            gridColumn: '1 / -1',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: '6px 16px',
+            background: 'color-mix(in srgb, var(--warn) 12%, var(--bg-1))',
+            borderBottom: '1px solid color-mix(in srgb, var(--warn) 40%, transparent)',
+            fontSize: 12,
+            color: 'var(--warn)',
+          }}
+        >
+          <span>
+            Service running <strong>{gitSha}</strong> — latest main is <strong>{latestMainSha}</strong>.
+            Run <code style={{ background: 'var(--bg-2)', padding: '1px 5px', borderRadius: 3 }}>scripts/redeploy.sh</code> to update.
+          </span>
+          <button
+            onClick={() => setBannerDismissed(true)}
             style={{
+              background: 'none',
+              border: 'none',
+              color: 'var(--fg-3)',
               cursor: 'pointer',
-              border: isFiltered ? '1px solid var(--accent)' : undefined,
-              background: isFiltered ? 'color-mix(in srgb, var(--accent) 15%, var(--bg-1))' : undefined,
-              color: isFiltered ? 'var(--accent)' : undefined,
+              fontSize: 14,
+              lineHeight: 1,
+              padding: '0 4px',
             }}
+            aria-label="Dismiss"
           >
-            <option value="">All</option>
-            {allProjectIds.map(id => (
-              <option key={id} value={id}>{id}</option>
-            ))}
-          </select>
-        </span>
-        <span>{eventsLastMin}/min</span>
-        <span>· {events.length.toLocaleString()} events</span>
-        <span>· {timeFmt(now)}</span>
-      </div>
-    </div>
+            ✕
+          </button>
+        </div>
+      )}
+    </>
   );
 }

--- a/web/src/lib/fixtures.ts
+++ b/web/src/lib/fixtures.ts
@@ -287,6 +287,7 @@ export function getFixtureHealth(): Health {
     status: 'ok',
     monitor_version: '0.0.0-fixture',
     git_sha: 'c0ffee0',
+    latest_main_sha: 'c0ffee0',
     supported_bounty_api: '1.x',
     core_version_counts: { '1.0': 300, '1.1': 45 },
     loop_ids: ['loop-001', 'loop-002'],

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -135,6 +135,7 @@ export interface Health {
   status: string;
   monitor_version: string;
   git_sha: string;
+  latest_main_sha: string;
   supported_bounty_api: string;
   core_version_counts: Record<string, number>;
   loop_ids: string[];


### PR DESCRIPTION
Closes #257

## Changes
- `scripts/redeploy.sh`: new script that pulls latest main, rebuilds frontend, and restarts launchd service from dedicated checkout at `~/.openclaw/workspace/services/loop-monitor`
- `scripts/com.user.loop-watch.plist`: updated ProgramArguments and added WorkingDirectory to point at dedicated service checkout; label kept as `com.user.loop-watch`
- `scripts/com.user.loop-monitor.plist`: new server plist (KeepAlive, RunAtLoad) for the FastAPI server running from the services checkout
- `server/routes/health.py`: added `latest_main_sha` field (fetched via `git ls-remote`, cached 60s in-process) to `/api/health` response; stays under 200ms when cache is warm
- `web/src/lib/types.ts`: added `latest_main_sha` to `Health` interface
- `web/src/App.tsx`: passes `gitSha` and `latestMainSha` down to `TopBar`
- `web/src/components/TopBar.tsx`: sha-mismatch banner shows when running sha != latest main sha; dismissible per-session via sessionStorage keyed on the `running:latest` sha pair — reappears if either sha changes
- `README.md`: documented one-time bootstrap clone, plist install, and redeploy workflow
- `tests/test_health.py`: two new tests — `test_health_latest_main_sha_field` and `test_health_latest_main_sha_cached`

## Test Plan
- [ ] Run `scripts/redeploy.sh` against a fresh clone at the services path; confirm service restarts
- [ ] Hit `/api/health` and verify both `git_sha` and `latest_main_sha` are present
- [ ] Simulate sha mismatch by temporarily patching `_git_sha()` to return a stale hash; confirm banner appears in UI
- [ ] Dismiss banner; confirm it stays dismissed in the same session (sessionStorage)
- [ ] Reload page with same sha pair; confirm banner stays dismissed
- [ ] Change the sha pair key; confirm banner reappears
- [ ] `ruff check .` passes
- [ ] `npm run typecheck && npm run build` passes
- [ ] `pytest tests/test_health.py` — all 9 pass