### PR TITLE
[LM-110] per-ticket timeline view: API + frontend + tests

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -31,6 +31,7 @@ from server.routes import (  # noqa: E402
     scanner_state,
     slos,
     stats,
+    timeline,
 )
 
 app.include_router(analytics.router)
@@ -48,6 +49,7 @@ app.include_router(logs.router)
 app.include_router(scanner_state.router)
 app.include_router(slos.router)
 app.include_router(config.router)
+app.include_router(timeline.router)
 
 app.mount("/", StaticFiles(directory="static/dist", html=True), name="webapp")
 

--- a/server/routes/timeline.py
+++ b/server/routes/timeline.py
@@ -1,0 +1,49 @@
+import json
+import sqlite3
+
+from fastapi import APIRouter, Depends, Query
+
+from server.db import db_dep
+
+router = APIRouter()
+
+
+@router.get("/api/timeline")
+def timeline(
+    slug: str = Query(...),
+    num: int = Query(...),
+    include_skips: bool = Query(False),
+    conn: sqlite3.Connection = Depends(db_dep),
+):
+    """Per-ticket event timeline ordered ascending by created_at."""
+    skip_clause = (
+        ""
+        if include_skips
+        else "AND NOT (event_type = 'reconcile_check' AND json_extract(payload, '$.decision') = 'skip')"
+    )
+    rows = conn.execute(
+        f"""
+        SELECT id, project, role, model, event_type, issue_number, pr_number,
+               detail, payload, core_version, loop_id, created_at
+        FROM events
+        WHERE project = ?
+          AND (issue_number = ? OR pr_number = ?)
+          {skip_clause}
+        ORDER BY created_at ASC, id ASC
+        """,
+        (slug, num, num),
+    ).fetchall()
+
+    events = []
+    for r in rows:
+        entry = dict(r)
+        entry["ts"] = entry["created_at"]
+        entry["type"] = entry["event_type"]
+        if entry["payload"]:
+            try:
+                entry["payload"] = json.loads(entry["payload"])
+            except (json.JSONDecodeError, TypeError):
+                pass
+        events.append(entry)
+
+    return {"events": events}

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,0 +1,108 @@
+import json
+import sqlite3
+from typing import Optional
+
+import server.db
+
+
+def _insert(conn: sqlite3.Connection, project: str, event_type: str, issue_number: Optional[int] = None,
+            pr_number: Optional[int] = None, payload: Optional[dict] = None, created_at: str = "2026-01-01T00:00:00"):
+    conn.execute(
+        """INSERT INTO events (project, role, event_type, issue_number, pr_number, payload, created_at)
+           VALUES (?, 'dev', ?, ?, ?, ?, ?)""",
+        (project, event_type, issue_number, pr_number,
+         json.dumps(payload) if payload else None, created_at),
+    )
+    conn.commit()
+
+
+def test_timeline_happy_path(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _insert(conn, "proj-tl", "dev_start", issue_number=42, created_at="2026-01-01T00:00:01")
+    _insert(conn, "proj-tl", "dev_done",  issue_number=42, created_at="2026-01-01T00:00:02")
+    conn.close()
+
+    resp = isolated_client.get("/api/timeline?slug=proj-tl&num=42")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "events" in data
+    events = data["events"]
+    assert len(events) == 2
+    # Ordered ascending by ts
+    assert events[0]["ts"] <= events[1]["ts"]
+    assert events[0]["type"] == "dev_start"
+    assert events[1]["type"] == "dev_done"
+    # ts and type aliases present
+    assert "ts" in events[0]
+    assert "type" in events[0]
+
+
+def test_timeline_empty_result(isolated_client):
+    resp = isolated_client.get("/api/timeline?slug=no-such-project&num=999")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data == {"events": []}
+
+
+def test_timeline_filters_reconcile_skip_by_default(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _insert(conn, "proj-skip", "dev_done", issue_number=7,
+            created_at="2026-01-01T00:00:01")
+    _insert(conn, "proj-skip", "reconcile_check", issue_number=7,
+            payload={"decision": "skip"}, created_at="2026-01-01T00:00:02")
+    _insert(conn, "proj-skip", "reconcile_check", issue_number=7,
+            payload={"decision": "run"}, created_at="2026-01-01T00:00:03")
+    conn.close()
+
+    # Default: skip-decision reconcile_check hidden
+    resp = isolated_client.get("/api/timeline?slug=proj-skip&num=7")
+    assert resp.status_code == 200
+    events = resp.json()["events"]
+    types = [e["type"] for e in events]
+    assert "dev_done" in types
+    assert {"decision": "run"} in [e.get("payload") for e in events if e["type"] == "reconcile_check"]
+    skip_events = [e for e in events if e["type"] == "reconcile_check" and
+                   isinstance(e.get("payload"), dict) and e["payload"].get("decision") == "skip"]
+    assert len(skip_events) == 0
+
+
+def test_timeline_include_skips_shows_all(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _insert(conn, "proj-incl", "dev_done", issue_number=8,
+            created_at="2026-01-01T00:00:01")
+    _insert(conn, "proj-incl", "reconcile_check", issue_number=8,
+            payload={"decision": "skip"}, created_at="2026-01-01T00:00:02")
+    conn.close()
+
+    resp = isolated_client.get("/api/timeline?slug=proj-incl&num=8&include_skips=true")
+    assert resp.status_code == 200
+    events = resp.json()["events"]
+    assert len(events) == 2
+    skip_event = next(e for e in events if e["type"] == "reconcile_check")
+    assert skip_event["payload"]["decision"] == "skip"
+
+
+def test_timeline_matches_pr_number(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _insert(conn, "proj-pr", "merge_done", pr_number=55,
+            created_at="2026-01-01T00:00:01")
+    conn.close()
+
+    resp = isolated_client.get("/api/timeline?slug=proj-pr&num=55")
+    assert resp.status_code == 200
+    events = resp.json()["events"]
+    assert len(events) == 1
+    assert events[0]["type"] == "merge_done"
+
+
+def test_timeline_isolates_by_project(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _insert(conn, "proj-a", "dev_done", issue_number=10, created_at="2026-01-01T00:00:01")
+    _insert(conn, "proj-b", "dev_start", issue_number=10, created_at="2026-01-01T00:00:01")
+    conn.close()
+
+    resp = isolated_client.get("/api/timeline?slug=proj-a&num=10")
+    assert resp.status_code == 200
+    events = resp.json()["events"]
+    assert all(e["project"] == "proj-a" for e in events)
+    assert len(events) == 1

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import Queue from './screens/Queue';
 import WorkerDetail from './screens/WorkerDetail';
 import Cost from './screens/Cost';
 import Analytics from './screens/Analytics';
+import Timeline from './screens/Timeline';
 import { useHashRoute } from './router';
 import { fetchActive, fetchHealth } from './lib/api';
 
@@ -23,7 +24,7 @@ const SCREEN_KEYS: Record<string, string> = {
 };
 
 export default function App() {
-  const { screen: hashScreen, projectId: hashProjectId, projectFilter, navigateTo, setProjectFilter } = useHashRoute();
+  const { screen: hashScreen, projectId: hashProjectId, projectFilter, issueNum, navigateTo, setProjectFilter, navigateToTimeline } = useHashRoute();
 
   // 'cost' is local-only — not stored in the hash — so we track it separately.
   const [showCost, setShowCost] = useState(false);
@@ -75,6 +76,7 @@ export default function App() {
   }
 
   const isProjectDetail = hashNavScreen === 'projects' && projectId != null;
+  const isTimeline = hashScreen === 'timeline' && projectId != null && issueNum != null;
 
   const activeQuery = useQuery({
     queryKey: ['active'],
@@ -120,12 +122,19 @@ export default function App() {
       <main className="main">
         {showCost ? (
           <Cost globalProjectFilter={projectFilter} />
+        ) : isTimeline && projectId != null && issueNum != null ? (
+          <Timeline
+            slug={projectId}
+            num={issueNum}
+            onBack={() => navigateTo('project', projectId, { pushState: true })}
+          />
         ) : isProjectDetail && projectId != null ? (
           <ProjectDetail
             projectId={projectId}
             allProjectIds={allProjectIds.length > 0 ? allProjectIds : [projectId]}
             onBack={handleBack}
             onProjectChange={handleProjectChange}
+            onViewTimeline={navigateToTimeline}
           />
         ) : hashNavScreen === 'overview' ? (
           <Overview globalProjectFilter={projectFilter} />

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
-export type Screen = 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs' | 'analytics';
+export type Screen = 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs' | 'analytics' | 'timeline';
 
 export interface HashRoute {
   screen: Screen;
@@ -140,13 +140,28 @@ export function useHashRoute() {
     [route.screen, route.projectId, route.drawer, unknown],
   );
 
+  const navigateToTimeline = useCallback(
+    (slug: string, num: number) => {
+      const newUnknown = { ...unknown, issue_num: String(num) };
+      const hash = buildHash('timeline', slug, null, newUnknown);
+      history.pushState(null, '', window.location.pathname + window.location.search + hash);
+      setParsed({ known: { screen: 'timeline', projectId: slug, drawer: null }, unknown: newUnknown });
+    },
+    [unknown],
+  );
+
+  const rawIssueNum = unknown['issue_num'];
+  const issueNum = rawIssueNum != null ? parseInt(rawIssueNum, 10) : null;
+
   return {
     screen: route.screen,
     projectId: route.projectId,
     drawer: route.drawer,
     projectFilter: unknown['project_filter'] ?? null,
+    issueNum: Number.isNaN(issueNum) ? null : issueNum,
     navigateTo,
     setDrawer,
     setProjectFilter,
+    navigateToTimeline,
   };
 }

--- a/web/src/screens/ProjectDetail.tsx
+++ b/web/src/screens/ProjectDetail.tsx
@@ -16,6 +16,7 @@ interface ProjectDetailProps {
   allProjectIds: string[];
   onBack: () => void;
   onProjectChange: (id: string) => void;
+  onViewTimeline?: (slug: string, num: number) => void;
 }
 
 const ROLE_COLORS: Record<string, string> = {
@@ -162,7 +163,7 @@ function CycleTimePanel({ cycleTimes, slo, runs }: CycleTimePanelProps) {
   );
 }
 
-export default function ProjectDetail({ projectId, allProjectIds, onBack, onProjectChange }: ProjectDetailProps) {
+export default function ProjectDetail({ projectId, allProjectIds, onBack, onProjectChange, onViewTimeline }: ProjectDetailProps) {
   const [runs, setRuns] = useState<PipelineRun[]>([]);
   const [prs, setPrs] = useState<PRMonitorEntry[]>([]);
   const [feed, setFeed] = useState<FeedItem[]>([]);
@@ -336,11 +337,12 @@ export default function ProjectDetail({ projectId, allProjectIds, onBack, onProj
                   <th style={{ textAlign: 'right' }}>Runs</th>
                   <th>Last</th>
                   <th style={{ textAlign: 'right' }}>Pts</th>
+                  {onViewTimeline && <th />}
                 </tr>
               </thead>
               <tbody>
                 {issues.length === 0 && (
-                  <tr><td colSpan={5} className="muted" style={{ textAlign: 'center', padding: 'var(--pad-3)' }}>No runs yet</td></tr>
+                  <tr><td colSpan={onViewTimeline ? 6 : 5} className="muted" style={{ textAlign: 'center', padding: 'var(--pad-3)' }}>No runs yet</td></tr>
                 )}
                 {issues.map(i => (
                   <tr key={i.num}>
@@ -358,6 +360,17 @@ export default function ProjectDetail({ projectId, allProjectIds, onBack, onProj
                       {i.lastAt ? relTime(i.lastAt) : '—'}
                     </td>
                     <td className="num" style={{ textAlign: 'right' }}>{i.pts}</td>
+                    {onViewTimeline && (
+                      <td>
+                        <button
+                          className="btn"
+                          style={{ fontSize: 10, padding: '1px 6px' }}
+                          onClick={() => onViewTimeline(projectId, i.num)}
+                        >
+                          timeline
+                        </button>
+                      </td>
+                    )}
                   </tr>
                 ))}
               </tbody>

--- a/web/src/screens/Timeline.tsx
+++ b/web/src/screens/Timeline.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useState } from 'react';
+
+interface TimelineEvent {
+  id: number;
+  ts: string;
+  type: string;
+  role: string;
+  model: string | null;
+  issue_number: number | null;
+  pr_number: number | null;
+  detail: string | null;
+  payload: Record<string, unknown> | string | null;
+  loop_id: string | null;
+}
+
+interface TimelineResponse {
+  events: TimelineEvent[];
+}
+
+const TYPE_BADGE: Record<string, { label: string; color: string }> = {
+  dev_start:        { label: 'dev',       color: 'var(--role-dev)'      },
+  dev_done:         { label: 'dev ✓',     color: 'var(--role-dev)'      },
+  dev_failed:       { label: 'dev ✗',     color: 'var(--fail,#ef4444)'  },
+  review_start:     { label: 'review',    color: 'var(--role-reviewer)' },
+  review_done:      { label: 'review ✓',  color: 'var(--role-reviewer)' },
+  review_failed:    { label: 'review ✗',  color: 'var(--fail,#ef4444)'  },
+  qa_start:         { label: 'qa',        color: 'var(--role-qa)'       },
+  qa_pass:          { label: 'qa ✓',      color: 'var(--role-qa)'       },
+  qa_fail:          { label: 'qa ✗',      color: 'var(--fail,#ef4444)'  },
+  merge_start:      { label: 'merge',     color: 'var(--role-merge)'    },
+  merge_done:       { label: 'merge ◆',   color: 'var(--role-merge)'    },
+  po_start:         { label: 'po',        color: 'var(--role-po)'       },
+  po_done:          { label: 'po ✓',      color: 'var(--role-po)'       },
+  po_failed:        { label: 'po ✗',      color: 'var(--fail,#ef4444)'  },
+  judge_done:       { label: 'judge ★',   color: 'var(--role-judge)'    },
+  reconcile_check:  { label: 'reconcile', color: 'var(--fg-3)'          },
+  label_change:     { label: 'label',     color: 'var(--accent2,#7c3aed)' },
+  handler_run:      { label: 'handler',   color: 'var(--accent2,#7c3aed)' },
+};
+
+function getBadge(type: string): { label: string; color: string } {
+  return TYPE_BADGE[type] ?? { label: type, color: 'var(--fg-3)' };
+}
+
+function fmtTs(ts: string): string {
+  try {
+    const d = new Date(ts.includes('T') ? ts : ts + 'Z');
+    return d.toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
+  } catch {
+    return ts;
+  }
+}
+
+interface TimelineProps {
+  slug: string;
+  num: number;
+  onBack: () => void;
+}
+
+export default function Timeline({ slug, num, onBack }: TimelineProps) {
+  const [events, setEvents] = useState<TimelineEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [includeSkips, setIncludeSkips] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(false);
+    fetch(`/api/timeline?slug=${encodeURIComponent(slug)}&num=${num}&include_skips=${includeSkips}`)
+      .then(r => r.ok ? r.json() : Promise.reject(r.status))
+      .then((data: TimelineResponse) => { setEvents(data.events); setLoading(false); })
+      .catch(() => { setError(true); setLoading(false); });
+  }, [slug, num, includeSkips]);
+
+  return (
+    <div data-testid="timeline">
+      <div className="screen-h" style={{ display: 'flex', alignItems: 'center', gap: 'var(--pad-3)', padding: 'var(--pad-2) var(--pad-4)' }}>
+        <button className="btn" onClick={onBack}>← Back</button>
+        <h1 style={{ flex: 1, margin: 0, fontFamily: 'var(--font-mono)', fontSize: 13, fontWeight: 500, letterSpacing: '0.04em' }}>
+          <span className="muted">timeline /</span> {slug} <span className="muted">·</span> #{num}
+        </h1>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, cursor: 'pointer' }}>
+          <input
+            type="checkbox"
+            checked={includeSkips}
+            onChange={e => setIncludeSkips(e.target.checked)}
+          />
+          <span className="muted">Show reconcile skips</span>
+        </label>
+      </div>
+
+      <div style={{ padding: 'var(--pad-4)' }}>
+        {loading && (
+          <div className="muted" style={{ textAlign: 'center', padding: 'var(--pad-4)', fontSize: 12 }}>Loading…</div>
+        )}
+        {error && (
+          <div className="muted" style={{ textAlign: 'center', padding: 'var(--pad-4)', fontSize: 12, color: 'var(--fail,#ef4444)' }}>
+            Failed to load timeline
+          </div>
+        )}
+        {!loading && !error && events.length === 0 && (
+          <div className="muted" style={{ textAlign: 'center', padding: 'var(--pad-4)', fontSize: 12 }}>
+            No events recorded for this ticket
+          </div>
+        )}
+        {!loading && !error && events.length > 0 && (
+          <div style={{ position: 'relative', paddingLeft: 24 }}>
+            {/* Vertical line */}
+            <div style={{
+              position: 'absolute', left: 7, top: 8, bottom: 8,
+              width: 2, background: 'var(--border)',
+            }} />
+            {events.map((ev, idx) => {
+              const badge = getBadge(ev.type);
+              return (
+                <div key={ev.id ?? idx} style={{ position: 'relative', marginBottom: 18 }}>
+                  {/* Dot */}
+                  <div style={{
+                    position: 'absolute', left: -20, top: 4,
+                    width: 8, height: 8,
+                    borderRadius: '50%',
+                    background: badge.color,
+                    border: '2px solid var(--bg)',
+                  }} />
+                  <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10, flexWrap: 'wrap' }}>
+                    <span className="tag" style={{ color: badge.color, borderColor: 'currentColor', flexShrink: 0 }}>
+                      {badge.label}
+                    </span>
+                    <span className="mono" style={{ fontSize: 11, color: 'var(--fg-3)', flexShrink: 0, paddingTop: 2 }}>
+                      {fmtTs(ev.ts)}
+                    </span>
+                    {ev.role && (
+                      <span className="muted mono" style={{ fontSize: 11, paddingTop: 2 }}>{ev.role}</span>
+                    )}
+                    {ev.detail && (
+                      <span className="muted" style={{ fontSize: 11, paddingTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 400 }}
+                        title={ev.detail}>
+                        {ev.detail}
+                      </span>
+                    )}
+                  </div>
+                  {ev.payload && typeof ev.payload === 'object' && Object.keys(ev.payload).length > 0 && (
+                    <pre style={{
+                      margin: '4px 0 0',
+                      padding: '4px 8px',
+                      background: 'var(--bg-2)',
+                      fontSize: 10,
+                      fontFamily: 'var(--font-mono)',
+                      color: 'var(--fg-3)',
+                      overflow: 'auto',
+                      maxHeight: 80,
+                    }}>
+                      {JSON.stringify(ev.payload, null, 2)}
+                    </pre>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #110

## Changes

- **`server/routes/timeline.py`** — New `GET /api/timeline?slug=X&num=N&include_skips=false` endpoint. Reads from the existing `events` table (with indexes added by #109 migration `0004_event_audit_indexes`). Returns `{ events: [...] }` ordered ascending by `created_at`. By default hides `reconcile_check` events with `payload.decision == "skip"` via `json_extract`; `include_skips=true` reveals them. Matches both `issue_number` and `pr_number` so the timeline captures the full lifecycle.
- **`server/app.py`** — Registers the timeline router.
- **`web/src/screens/Timeline.tsx`** — Vertical timeline component. Each event gets a type badge derived from a static map (unknown types fall back to a neutral grey badge). Toggle checkbox to show/hide reconcile skips. Empty state: "No events recorded for this ticket".
- **`web/src/router.tsx`** — Adds `'timeline'` to the `Screen` type; exposes `issueNum` and `navigateToTimeline(slug, num)` from `useHashRoute`. Hash URL: `#screen=timeline&project=<slug>&issue_num=<n>`.
- **`web/src/App.tsx`** — Renders `<Timeline>` when `screen=timeline`; passes `onViewTimeline` to `ProjectDetail`.
- **`web/src/screens/ProjectDetail.tsx`** — Adds a "timeline" button per row in the Recent Issues table that navigates to the timeline for that ticket.
- **`tests/test_timeline.py`** — 6 pytest tests: happy path, empty result, skip-filter default, include_skips toggle, PR-number match, project isolation.

## Test Plan

- [ ] `GET /api/timeline?slug=<project>&num=<issue>` returns `{ events: [] }` for unknown tickets (HTTP 200)
- [ ] Returns events in chronological ascending order for known tickets
- [ ] `reconcile_check` events with `decision=skip` are hidden by default, visible with `include_skips=true`
- [ ] In the UI, navigate to a project → click "timeline" on an issue row → vertical timeline renders
- [ ] Toggle "Show reconcile skips" checkbox changes event count
- [ ] Empty state message appears for tickets with no events
- [ ] Back button returns to project detail