### PR TITLE
[LM-269] fix TopBar event rate: derive events from feed instead of active workers

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,7 +11,7 @@ import WorkerDetail from './screens/WorkerDetail';
 import Cost from './screens/Cost';
 import Analytics from './screens/Analytics';
 import { useHashRoute } from './router';
-import { fetchActive, fetchHealth } from './lib/api';
+import { fetchActive, fetchFeed, fetchHealth } from './lib/api';
 
 const SCREEN_KEYS: Record<string, string> = {
   '1': 'overview',
@@ -83,6 +83,13 @@ export default function App() {
     staleTime: 0,
   });
 
+  const feedQuery = useQuery({
+    queryKey: ['feed'],
+    queryFn: () => fetchFeed({ limit: 200 }),
+    refetchInterval: 5000,
+    staleTime: 0,
+  });
+
   const healthQuery = useQuery({
     queryKey: ['health'],
     queryFn: () => fetchHealth(),
@@ -99,8 +106,8 @@ export default function App() {
     return () => window.removeEventListener('keydown', onKey);
   }, []);
 
-  const events = (activeQuery.data ?? []).map((w) => ({
-    ts: new Date(w.created_at).getTime(),
+  const events = (feedQuery.data ?? []).map((f) => ({
+    ts: new Date(f.created_at).getTime(),
   }));
   const online = !activeQuery.isError;
   const version = healthQuery.data?.monitor_version ?? '…';

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -59,6 +59,7 @@ export interface FeedParams {
   loop_id?: string;
   role?: string;
   status?: string;
+  limit?: number;
 }
 
 export async function fetchFeed(params: FeedParams = {}): Promise<FeedItem[]> {
@@ -67,6 +68,7 @@ export async function fetchFeed(params: FeedParams = {}): Promise<FeedItem[]> {
   if (params.loop_id) p.set('loop_id', params.loop_id);
   if (params.role)    p.set('role', params.role);
   if (params.status)  p.set('status', params.status);
+  if (params.limit != null) p.set('limit', String(params.limit));
   const qs = p.size ? `?${p.toString()}` : '';
   return get<FeedItem[]>(`/api/feed${qs}`);
 }


### PR DESCRIPTION
Closes #269

## Changes

- **`web/src/App.tsx`**: Added a `feedQuery` using `useQuery` that calls `fetchFeed({ limit: 200 })` with `refetchInterval: 5000`. The `events` prop passed to `<TopBar>` is now derived from `feedQuery.data` (mapping `created_at` → `ts` epoch ms) instead of `activeQuery.data`. The `online` flag still comes from `activeQuery.isError` (connectivity semantics unchanged).
- **`web/src/lib/api.ts`**: Added `limit?: number` to `FeedParams` and wired it into the query string so the limit is forwarded to `/api/feed`.

The root cause was that `activeQuery` hits `/api/active` (currently running workers), which returns an empty array when no workers are active — so the TopBar rate was always 0. The feed endpoint returns timestamped historical events, which TopBar's existing `eventsLastMin` filter uses to compute the rolling 60s rate.

## Test Plan
- Start the dev server with recent feed events; TopBar should show a non-zero `N/min` count within 5s.
- When all feed events are older than 60s (or feed is empty), TopBar displays `0/min`.
- `npm run typecheck` and `npm run build` both pass.