### PR TITLE
[LM-270] Refresh dashboard.py: box-drawn cards, two-column layout, ANSI color

### DIFF
--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 import time
 import urllib.error
@@ -15,6 +16,71 @@ DEFAULT_URL = "http://127.0.0.1:18792"
 DEFAULT_INTERVAL = 10
 HTTP_TIMEOUT = 5
 CLEAR = "\x1b[2J\x1b[H"
+
+# ANSI colors (basic 8 + bold, TTY-only)
+ANSI_RESET = "\x1b[0m"
+ANSI_BOLD = "\x1b[1m"
+ANSI_GREEN = "\x1b[32m"
+ANSI_YELLOW = "\x1b[33m"
+ANSI_BLUE = "\x1b[34m"
+ANSI_CYAN = "\x1b[36m"
+ANSI_RED = "\x1b[31m"
+ANSI_MAGENTA = "\x1b[35m"
+
+ROLE_COLORS: dict[str, str] = {
+    "dev": ANSI_GREEN,
+    "builder": ANSI_GREEN,
+    "reviewer": ANSI_BLUE,
+    "tester": ANSI_CYAN,
+    "judge": ANSI_YELLOW,
+    "po": ANSI_MAGENTA,
+    "planner": ANSI_MAGENTA,
+}
+
+ROLE_GLYPHS: dict[str, str] = {
+    "dev": "⚙",
+    "builder": "⚙",
+    "reviewer": "◎",
+    "tester": "✓",
+    "judge": "★",
+    "po": "◆",
+    "planner": "◆",
+}
+
+STATUS_GLYPHS: dict[str, str] = {
+    "busy": "◉",
+    "idle": "◉",
+    "wait": "◉",
+}
+
+STATUS_COLORS: dict[str, str] = {
+    "busy": ANSI_GREEN,
+    "idle": ANSI_CYAN,
+    "wait": ANSI_YELLOW,
+}
+
+
+def _use_color() -> bool:
+    return sys.stdout.isatty()
+
+
+def _term_cols() -> int:
+    try:
+        return os.get_terminal_size().columns
+    except OSError:
+        return 80
+
+
+def colorize(color: str, text: str) -> str:
+    if not _use_color():
+        return text
+    return f"{color}{text}{ANSI_RESET}"
+
+
+def bold(text: str) -> str:
+    if not _use_color():
+        return text
+    return f"{ANSI_BOLD}{text}{ANSI_RESET}"
 
 
 def fetch_json(base_url: str, path: str) -> Any:
@@ -53,86 +119,257 @@ def _since(row: dict) -> str:
     return f"{age // 86400}d"
 
 
-def format_active(rows: list[dict]) -> str:
-    header = "ACTIVE WORKERS"
-    if not rows:
-        return f"{header}\n  No active workers."
-    lines = [header]
-    lines.append(f"  {'PROJECT':<18} {'ROLE':<10} {'MODEL':<14} {'EVENT':<18} {'TASK':<10} SINCE")
-    for r in rows:
-        task = ""
-        if r.get("issue_number"):
-            task = f"#{r['issue_number']}"
-        elif r.get("pr_number"):
-            task = f"PR{r['pr_number']}"
-        lines.append(
-            f"  {_truncate(r.get('project',''), 18):<18} "
-            f"{_truncate(r.get('role',''), 10):<10} "
-            f"{_truncate(r.get('model','') or '', 14):<14} "
-            f"{_truncate(r.get('event_type',''), 18):<18} "
-            f"{_truncate(task, 10):<10} "
-            f"{_since(r)}"
-        )
-    return "\n".join(lines)
+# ── Box-drawing helpers ───────────────────────────────────────────────────────
+
+def _box_top(width: int) -> str:
+    return "┌" + "─" * (width - 2) + "┐"
 
 
-def format_board(rows: list[dict]) -> str:
-    header = "PROJECT STATUS"
-    if not rows:
-        return f"{header}\n  No project scores yet."
-    lines = [header]
-    lines.append(f"  {'PROJECT':<18} {'ROLE':<10} {'MODEL':<14} {'PTS':>6} {'VERDICTS':>9}")
-    for r in rows:
-        lines.append(
-            f"  {_truncate(r.get('project',''), 18):<18} "
-            f"{_truncate(r.get('role',''), 10):<10} "
-            f"{_truncate(r.get('model','') or '', 14):<14} "
-            f"{int(r.get('total_points') or 0):>6} "
-            f"{int(r.get('verdict_count') or 0):>9}"
-        )
-    return "\n".join(lines)
+def _box_bot(width: int) -> str:
+    return "└" + "─" * (width - 2) + "┘"
 
 
-def format_feed(rows: list[dict], limit: int = 5) -> str:
-    header = "RECENT FEED"
-    if not rows:
-        return f"{header}\n  No recent events."
-    lines = [header]
-    for r in rows[:limit]:
+def _box_sep(width: int) -> str:
+    return "├" + "─" * (width - 2) + "┤"
+
+
+def _box_row(content: str, width: int) -> str:
+    """Pad content to fit inside a box of given total width."""
+    inner = width - 4  # two border chars + two spaces
+    # strip ANSI for length calculation
+    visible = _strip_ansi(content)
+    pad = max(0, inner - len(visible))
+    return "│ " + content + " " * pad + " │"
+
+
+def _strip_ansi(s: str) -> str:
+    """Remove ANSI escape codes for length calculations."""
+    import re
+    return re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+
+# ── Section renderers ─────────────────────────────────────────────────────────
+
+def render_banner(base_url: str, width: int) -> list[str]:
+    now_utc = datetime.now(timezone.utc).strftime("%H:%M UTC")
+    now_local = datetime.now().strftime("%H:%M local")
+    time_str = f"{now_utc}  {now_local}"
+
+    title = bold("LOOP MONITOR")
+    url_line = base_url
+    lines = [
+        _box_top(width),
+        _box_row(_center_padded(title, width - 4), width),
+        _box_row(_center_padded(url_line, width - 4), width),
+        _box_row(_center_padded(time_str, width - 4), width),
+        _box_sep(width),
+    ]
+    return lines
+
+
+def _center_padded(text: str, width: int) -> str:
+    visible_len = len(_strip_ansi(text))
+    total_pad = max(0, width - visible_len)
+    left_pad = total_pad // 2
+    right_pad = total_pad - left_pad
+    return " " * left_pad + text + " " * right_pad
+
+
+def render_cards(projects: list[dict], width: int) -> list[str]:
+    """One box per project; wrap to next row when line would exceed width."""
+    if not projects:
+        return [_box_row("  No projects.", width), _box_row("", width)]
+
+    CARD_W = 14  # inner width of each card box (total card = CARD_W + 2 borders)
+    CARD_TOTAL = CARD_W + 2
+    GAP = 2
+    cards_per_row = max(1, (width - 2) // (CARD_TOTAL + GAP))
+
+    def make_card(p: dict) -> list[str]:
+        name = _truncate(p.get("project") or p.get("name") or "?", CARD_W)
+        pts = int(p.get("total_points") or p.get("score") or 0)
+        status = (p.get("status") or "idle").lower()
+        glyph = STATUS_GLYPHS.get(status, "◉")
+        sc = STATUS_COLORS.get(status, "")
+        age = _since(p)
+        status_line = colorize(sc, f"{glyph} {status:<4}")
+        pts_line = f"{pts} pts"
+        age_line = age
+
+        rows = [
+            "┌" + "─" * CARD_W + "┐",
+            "│" + _pad_inner(bold(name), CARD_W) + "│",
+            "│" + _pad_inner(status_line, CARD_W) + "│",
+            "│" + _pad_inner(pts_line, CARD_W) + "│",
+            "│" + _pad_inner(age_line, CARD_W) + "│",
+            "└" + "─" * CARD_W + "┘",
+        ]
+        return rows
+
+    def _pad_inner(text: str, w: int) -> str:
+        visible = len(_strip_ansi(text))
+        pad = max(0, w - visible)
+        return " " + text + " " * (pad - 1 if pad > 0 else 0)
+
+    lines: list[str] = []
+    for chunk_start in range(0, len(projects), cards_per_row):
+        chunk = projects[chunk_start : chunk_start + cards_per_row]
+        cards = [make_card(p) for p in chunk]
+        card_height = len(cards[0])
+        for row_i in range(card_height):
+            row_parts = [c[row_i] for c in cards]
+            combined = ("  " + "  ".join(row_parts))
+            # Pad the whole thing to fit box interior
+            inner_w = width - 4
+            vis = len(_strip_ansi(combined))
+            padded = combined + " " * max(0, inner_w - vis)
+            lines.append("│ " + padded + " │")
+        lines.append(_box_row("", width))
+
+    return lines
+
+
+def render_feed(events: list[dict], col_width: int, limit: int = 7) -> list[str]:
+    """Left column: LIVE FEED."""
+    header = bold("LIVE FEED")
+    lines = [header, ""]
+    for ev in events[:limit]:
+        role = (ev.get("role") or "").lower()
+        glyph = ROLE_GLYPHS.get(role, "•")
+        color = ROLE_COLORS.get(role, "")
         target = ""
-        if r.get("issue_number"):
-            target = f" #{r['issue_number']}"
-        elif r.get("pr_number"):
-            target = f" PR{r['pr_number']}"
-        detail = r.get("detail") or ""
-        status = r.get("status") or ""
-        lines.append(
-            f"  [{_since(r):>4}] "
-            f"{_truncate(r.get('project',''), 14):<14} "
-            f"{_truncate(r.get('role',''), 8):<8} "
-            f"{_truncate(r.get('event_type',''), 18):<18}"
-            f"{target}"
-            f"{(' — ' + _truncate(detail, 50)) if detail else ''}"
-            f"{(' [' + status + ']') if status else ''}"
-        )
-    return "\n".join(lines)
+        if ev.get("issue_number"):
+            target = f" #{ev['issue_number']}"
+        elif ev.get("pr_number"):
+            target = f" PR{ev['pr_number']}"
+        etype = _truncate(ev.get("event_type") or "", 14)
+        ago = _since(ev)
+        role_str = colorize(color, f"{glyph} {_truncate(role, 8):<8}")
+        text = f"{role_str} {_truncate(etype, 14)}{target} {ago}"
+        lines.append("• " + _truncate(_strip_ansi(text), col_width - 2) if not _use_color()
+                     else "• " + text)
+    return lines
+
+
+def render_leaderboard(board: list[dict], col_width: int, limit: int = 5) -> list[str]:
+    """Right column: LEADERBOARD."""
+    header = bold("LEADERBOARD")
+    lines = [header, ""]
+    for i, row in enumerate(board[:limit], start=1):
+        role = _truncate(row.get("role") or row.get("project") or "?", 12)
+        pts = int(row.get("total_points") or row.get("score") or 0)
+        color = ROLE_COLORS.get(role.lower(), "")
+        role_colored = colorize(color, role)
+        lines.append(f"{i}. {role_colored:<12} {pts} pts")
+    return lines
+
+
+def render_verdict(feed: list[dict], width: int) -> list[str]:
+    """Optional bottom callout for latest judge verdict."""
+    for ev in feed:
+        role = (ev.get("role") or "").lower()
+        if role == "judge":
+            detail = ev.get("detail") or ev.get("message") or ""
+            if detail:
+                tag = bold("JUDGE VERDICT:")
+                inner = width - 4
+                tag_vis = len(_strip_ansi(tag))
+                avail = inner - tag_vis - 1
+                snippet = _truncate(detail, avail)
+                line = f"{tag} {snippet}"
+                return [_box_sep(width), _box_row(line, width)]
+    return []
+
+
+def render_two_column(feed: list[dict], board: list[dict], width: int) -> list[str]:
+    """Render LIVE FEED | LEADERBOARD side-by-side inside the outer box."""
+    inner = width - 4  # content width between │  and  │
+    left_w = inner * 2 // 3
+    right_w = inner - left_w - 3  # 3 chars for " │ " divider
+
+    feed_lines = render_feed(feed, left_w)
+    board_lines = render_leaderboard(board, right_w)
+
+    # Pad both columns to same height
+    height = max(len(feed_lines), len(board_lines))
+    feed_lines += [""] * (height - len(feed_lines))
+    board_lines += [""] * (height - len(board_lines))
+
+    result: list[str] = []
+    for fl, bl in zip(feed_lines, board_lines):
+        fl_vis = len(_strip_ansi(fl))
+        bl_vis = len(_strip_ansi(bl))
+        fl_padded = fl + " " * max(0, left_w - fl_vis)
+        bl_padded = bl + " " * max(0, right_w - bl_vis)
+        row = fl_padded + " │ " + bl_padded
+        result.append("│ " + row + " │")
+
+    return result
+
+
+def render_simple(base_url: str, active: list[dict], board: list[dict],
+                  feed: list[dict]) -> str:
+    """Narrow-terminal fallback (< 80 cols): plain stacked sections, no boxes."""
+    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    parts = [f"LOOP MONITOR — {base_url}   {now}", ""]
+
+    parts.append("PROJECTS")
+    if board:
+        for r in board[:5]:
+            name = _truncate(r.get("project") or r.get("role") or "?", 18)
+            pts = int(r.get("total_points") or 0)
+            parts.append(f"  {name:<18} {pts} pts")
+    else:
+        parts.append("  No projects.")
+    parts.append("")
+
+    parts.append("LIVE FEED")
+    if feed:
+        for ev in feed[:6]:
+            role = _truncate(ev.get("role") or "", 8)
+            etype = _truncate(ev.get("event_type") or "", 16)
+            parts.append(f"  [{_since(ev):>4}] {role:<8} {etype}")
+    else:
+        parts.append("  No recent events.")
+
+    return "\n".join(parts)
 
 
 def render_snapshot(base_url: str) -> str:
-    active = fetch_json(base_url, "/api/active")
-    board = fetch_json(base_url, "/api/board")
-    feed = fetch_json(base_url, "/api/feed")
-    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    parts = [
-        f"LOOP MONITOR — {base_url}   {now}",
-        "",
-        format_active(active or []),
-        "",
-        format_board(board or []),
-        "",
-        format_feed(feed or [], limit=5),
-    ]
-    return "\n".join(parts)
+    active = fetch_json(base_url, "/api/active") or []
+    board = fetch_json(base_url, "/api/board") or []
+    feed = fetch_json(base_url, "/api/feed") or []
+
+    term_cols = _term_cols()
+
+    if term_cols < 80:
+        return render_simple(base_url, active, board, feed)
+
+    width = min(term_cols, 100)
+
+    lines: list[str] = []
+    lines += render_banner(base_url, width)
+
+    # Project cards (use board rows as proxy for project status)
+    projects = board if board else []
+    if active:
+        # Merge active status into project list
+        active_map = {a.get("project", ""): a for a in active}
+        for p in projects:
+            name = p.get("project") or p.get("name") or ""
+            if name in active_map:
+                p["status"] = "busy"
+    lines += render_cards(projects, width)
+
+    # Two-column: feed + leaderboard
+    lines += render_two_column(feed, board, width)
+
+    # Optional judge verdict
+    lines += render_verdict(feed, width)
+
+    lines.append(_box_bot(width))
+
+    return "\n".join(lines)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -156,7 +393,10 @@ def main(argv: list[str] | None = None) -> int:
         while True:
             try:
                 snapshot = render_snapshot(args.url)
-                sys.stdout.write(CLEAR + snapshot + "\n")
+                if sys.stdout.isatty():
+                    sys.stdout.write(CLEAR + snapshot + "\n")
+                else:
+                    sys.stdout.write(snapshot + "\n")
                 sys.stdout.flush()
             except (urllib.error.URLError, urllib.error.HTTPError, ConnectionError, OSError) as e:
                 print(f"loop-monitor unreachable at {args.url}: {e}", file=sys.stderr)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,82 +1,21 @@
-from scripts.dashboard import _since, format_active, format_board, format_feed
+from scripts.dashboard import (
+    _since,
+    _strip_ansi,
+    _box_top,
+    _box_bot,
+    _box_sep,
+    _box_row,
+    _center_padded,
+    render_banner,
+    render_cards,
+    render_feed,
+    render_leaderboard,
+    render_verdict,
+    render_simple,
+)
 
 
-def test_format_active_empty():
-    out = format_active([])
-    assert "ACTIVE WORKERS" in out
-    assert "No active workers." in out
-
-
-def test_format_active_rows():
-    rows = [
-        {"project": "loop-monitor", "role": "builder", "model": "sonnet",
-         "event_type": "dev_start", "issue_number": 42, "pr_number": None,
-         "detail": "working", "created_at": "2026-04-30T12:00:00+00:00"},
-    ]
-    out = format_active(rows)
-    assert "loop-monitor" in out
-    assert "builder" in out
-    assert "dev_start" in out
-    assert "#42" in out
-
-
-def test_format_active_handles_missing_fields():
-    rows = [{"project": "p", "role": "r"}]  # no event_type, model, ids, etc.
-    out = format_active(rows)
-    assert "p" in out
-    assert "r" in out
-
-
-def test_format_board_empty():
-    out = format_board([])
-    assert "PROJECT STATUS" in out
-    assert "No project scores yet." in out
-
-
-def test_format_board_rows():
-    rows = [
-        {"project": "loop-monitor", "role": "builder", "model": "sonnet",
-         "total_points": 185, "verdict_count": 7},
-    ]
-    out = format_board(rows)
-    assert "185" in out
-    assert "7" in out
-
-
-def test_format_board_handles_none_points():
-    rows = [{"project": "p", "role": "r", "model": None,
-             "total_points": None, "verdict_count": None}]
-    out = format_board(rows)
-    assert "p" in out
-    assert "0" in out
-
-
-def test_format_feed_empty():
-    out = format_feed([])
-    assert "RECENT FEED" in out
-    assert "No recent events." in out
-
-
-def test_format_feed_rows_truncates_to_limit():
-    rows = [
-        {"project": f"p{i}", "role": "builder", "event_type": "dev_done",
-         "issue_number": i, "detail": "ok", "age_seconds": i, "status": "done"}
-        for i in range(10)
-    ]
-    out = format_feed(rows, limit=5)
-    # 1 header + 5 rows
-    assert len(out.splitlines()) == 6
-    assert "p0" in out
-    assert "p4" in out
-    assert "p5" not in out
-
-
-def test_format_feed_uses_age_seconds():
-    rows = [{"project": "p", "role": "r", "event_type": "x_done",
-             "age_seconds": 90, "status": "done"}]
-    out = format_feed(rows)
-    assert "1m" in out
-
+# ── _since (unchanged helper) ─────────────────────────────────────────────────
 
 def test_since_seconds_minutes_hours_days():
     assert _since({"age_seconds": 5}) == "5s"
@@ -90,6 +29,253 @@ def test_since_unknown():
 
 
 def test_since_falls_back_to_created_at():
-    # any valid ISO timestamp parses without crashing
     out = _since({"created_at": "2026-04-30T12:00:00+00:00"})
     assert out and out != "?"
+
+
+# ── _strip_ansi ───────────────────────────────────────────────────────────────
+
+def test_strip_ansi_removes_codes():
+    assert _strip_ansi("\x1b[32mgreen\x1b[0m") == "green"
+    assert _strip_ansi("plain") == "plain"
+    assert _strip_ansi("\x1b[1m\x1b[33mbold yellow\x1b[0m") == "bold yellow"
+
+
+def test_strip_ansi_empty():
+    assert _strip_ansi("") == ""
+
+
+# ── Box drawing helpers ───────────────────────────────────────────────────────
+
+def test_box_top_width():
+    result = _box_top(10)
+    assert result.startswith("┌")
+    assert result.endswith("┐")
+    assert len(result) == 10
+
+
+def test_box_bot_width():
+    result = _box_bot(10)
+    assert result.startswith("└")
+    assert result.endswith("┘")
+    assert len(result) == 10
+
+
+def test_box_sep_width():
+    result = _box_sep(10)
+    assert result.startswith("├")
+    assert result.endswith("┤")
+    assert len(result) == 10
+
+
+def test_box_row_pads_content():
+    result = _box_row("hi", 10)
+    assert result.startswith("│")
+    assert result.endswith("│")
+    visible = _strip_ansi(result)
+    assert len(visible) == 10
+
+
+def test_center_padded_centers():
+    result = _center_padded("HI", 10)
+    assert "HI" in result
+    assert len(result) == 10
+    assert result.startswith("    ")  # 4 spaces of left padding for 2-char text in 10-wide
+
+
+# ── render_banner ─────────────────────────────────────────────────────────────
+
+def test_render_banner_contains_loop_monitor():
+    lines = render_banner("http://localhost:18792", 80)
+    combined = "\n".join(lines)
+    assert "LOOP MONITOR" in _strip_ansi(combined)
+
+
+def test_render_banner_contains_url():
+    lines = render_banner("http://localhost:18792", 80)
+    combined = "\n".join(lines)
+    assert "http://localhost:18792" in combined
+
+
+def test_render_banner_contains_utc():
+    lines = render_banner("http://localhost:18792", 80)
+    combined = "\n".join(lines)
+    assert "UTC" in combined
+
+
+def test_render_banner_uses_box_chars():
+    lines = render_banner("http://localhost:18792", 80)
+    combined = "\n".join(lines)
+    assert "┌" in combined
+    assert "┘" in combined or "┤" in combined
+
+
+def test_render_banner_width():
+    width = 80
+    lines = render_banner("http://localhost:18792", width)
+    for line in lines:
+        visible = _strip_ansi(line)
+        assert len(visible) == width, f"Expected width {width}, got {len(visible)}: {visible!r}"
+
+
+# ── render_cards ──────────────────────────────────────────────────────────────
+
+def test_render_cards_empty():
+    lines = render_cards([], 80)
+    combined = "\n".join(lines)
+    assert "No projects." in combined
+
+
+def test_render_cards_shows_project_name():
+    projects = [{"project": "Lint", "total_points": 52, "status": "idle",
+                 "age_seconds": 300}]
+    lines = render_cards(projects, 80)
+    combined = _strip_ansi("\n".join(lines))
+    assert "Lint" in combined
+
+
+def test_render_cards_shows_points():
+    projects = [{"project": "Build", "total_points": 185, "status": "busy",
+                 "age_seconds": 60}]
+    lines = render_cards(projects, 80)
+    combined = _strip_ansi("\n".join(lines))
+    assert "185" in combined
+
+
+def test_render_cards_shows_status_glyph():
+    projects = [{"project": "Test", "total_points": 0, "status": "wait",
+                 "age_seconds": 10}]
+    lines = render_cards(projects, 80)
+    combined = "\n".join(lines)
+    assert "◉" in combined
+
+
+# ── render_feed ───────────────────────────────────────────────────────────────
+
+def test_render_feed_empty():
+    lines = render_feed([], col_width=40)
+    combined = "\n".join(lines)
+    assert "LIVE FEED" in _strip_ansi(combined)
+
+
+def test_render_feed_shows_events():
+    events = [
+        {"role": "builder", "event_type": "dev_start", "issue_number": 42, "age_seconds": 30},
+    ]
+    lines = render_feed(events, col_width=40)
+    combined = _strip_ansi("\n".join(lines))
+    assert "builder" in combined
+    assert "#42" in combined
+
+
+def test_render_feed_role_glyph_builder():
+    events = [{"role": "builder", "event_type": "dev_done", "age_seconds": 10}]
+    lines = render_feed(events, col_width=40)
+    combined = "\n".join(lines)
+    assert "⚙" in combined
+
+
+def test_render_feed_role_glyph_judge():
+    events = [{"role": "judge", "event_type": "verdict", "age_seconds": 10}]
+    lines = render_feed(events, col_width=40)
+    combined = "\n".join(lines)
+    assert "★" in combined
+
+
+def test_render_feed_respects_limit():
+    events = [{"role": "tester", "event_type": "test_done", "age_seconds": i}
+              for i in range(10)]
+    lines = render_feed(events, col_width=60, limit=3)
+    event_lines = [l for l in lines if "•" in l]
+    assert len(event_lines) == 3
+
+
+# ── render_leaderboard ────────────────────────────────────────────────────────
+
+def test_render_leaderboard_empty():
+    lines = render_leaderboard([], col_width=30)
+    combined = "\n".join(lines)
+    assert "LEADERBOARD" in _strip_ansi(combined)
+
+
+def test_render_leaderboard_shows_ranks():
+    board = [
+        {"role": "sonnet", "total_points": 185},
+        {"role": "opus", "total_points": 120},
+    ]
+    lines = render_leaderboard(board, col_width=30)
+    combined = _strip_ansi("\n".join(lines))
+    assert "1." in combined
+    assert "2." in combined
+    assert "185" in combined
+    assert "120" in combined
+
+
+def test_render_leaderboard_limit():
+    board = [{"role": f"r{i}", "total_points": i} for i in range(10)]
+    lines = render_leaderboard(board, col_width=30, limit=5)
+    rank_lines = [l for l in lines if l.strip().startswith(tuple("123456789"))]
+    assert len(rank_lines) == 5
+
+
+# ── render_verdict ────────────────────────────────────────────────────────────
+
+def test_render_verdict_no_judge_events():
+    feed = [{"role": "builder", "event_type": "dev_done", "age_seconds": 10}]
+    result = render_verdict(feed, 80)
+    assert result == []
+
+
+def test_render_verdict_extracts_judge():
+    feed = [{"role": "judge", "detail": "Clean merge. Full score.", "age_seconds": 5}]
+    result = render_verdict(feed, 80)
+    assert len(result) > 0
+    combined = _strip_ansi("\n".join(result))
+    assert "Clean merge" in combined
+
+
+def test_render_verdict_truncates_to_width():
+    long_detail = "A" * 500
+    feed = [{"role": "judge", "detail": long_detail, "age_seconds": 1}]
+    result = render_verdict(feed, 80)
+    for line in result:
+        assert len(_strip_ansi(line)) <= 80
+
+
+# ── render_simple ─────────────────────────────────────────────────────────────
+
+def test_render_simple_contains_loop_monitor():
+    out = render_simple("http://localhost:18792", [], [], [])
+    assert "LOOP MONITOR" in out
+
+
+def test_render_simple_no_projects():
+    out = render_simple("http://localhost:18792", [], [], [])
+    assert "No projects." in out
+
+
+def test_render_simple_no_feed():
+    out = render_simple("http://localhost:18792", [], [], [])
+    assert "No recent events." in out
+
+
+def test_render_simple_shows_projects():
+    board = [{"project": "Lint", "total_points": 52, "role": "builder"}]
+    out = render_simple("http://localhost:18792", [], board, [])
+    assert "Lint" in out
+    assert "52" in out
+
+
+def test_render_simple_shows_feed():
+    feed = [{"role": "tester", "event_type": "test_pass", "age_seconds": 60}]
+    out = render_simple("http://localhost:18792", [], [], feed)
+    assert "tester" in out
+    assert "test_pass" in out
+
+
+def test_render_simple_no_box_chars():
+    board = [{"project": "X", "total_points": 1, "role": "dev"}]
+    feed = [{"role": "dev", "event_type": "dev_done", "age_seconds": 10}]
+    out = render_simple("http://localhost:18792", [], board, feed)
+    assert "┌" not in out
+    assert "┐" not in out


### PR DESCRIPTION
Closes #270

## Changes

Rewrote `scripts/dashboard.py` to match the ASCII mockup from the README:

- **Bordered banner**: Unicode box-drawing chars (`┌─┐│└┘├┤`) showing `LOOP MONITOR`, base URL, and current time (UTC + local)
- **Project cards row**: one box per project with name, status glyph (◉ idle/busy/wait), points, last event age; cards wrap to next row when total width exceeds terminal columns
- **Two-column body**: LIVE FEED (last 7 events with role glyphs + ANSI color) on left, LEADERBOARD (top 5 rows) on right
- **Bottom callout**: optional latest judge verdict, truncated to fit terminal width
- **ANSI color**: gated on `sys.stdout.isatty()`; piped/`--once | mail` output is plain ASCII
- **Narrow terminal fallback**: terminals < 80 cols get a simple stacked layout (no boxes)
- **No new deps**: stdlib-only (`os`, `sys`, `re`, `time`, `urllib`, `json`, `argparse`)
- **Preserved behaviours**: `--once` and `--interval` work exactly as before

## Test Plan

- Run `python scripts/dashboard.py --once` against a live loop-monitor instance → verify box layout, cards, two-column feed/leaderboard, and judge callout render correctly
- Pipe output: `python scripts/dashboard.py --once | cat` → verify no ANSI codes appear
- Resize terminal to < 80 cols → verify narrow fallback layout
- Run `python scripts/dashboard.py --interval 5` → verify refresh-in-place works
- Run `ruff check scripts/dashboard.py` → passes