### PR TITLE
[LM-257] dedicated service checkout, redeploy script, sha-lag banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,34 @@ Events tied to an in-progress pipeline run are never pruned, regardless of age.
 
 ## Scripts
 
+### `scripts/redeploy.sh` — update and restart the service
+
+Pulls the latest `main` from GitHub into the dedicated service checkout, rebuilds the web bundle, and restarts the launchd service. Run this whenever the dashboard shows the "behind main" banner.
+
+**One-time bootstrap** (creates the dedicated service checkout):
+
+```bash
+git clone https://github.com/svv2014/loop-monitor.git \
+  ~/.openclaw/workspace/services/loop-monitor
+cd ~/.openclaw/workspace/services/loop-monitor/web && npm ci && npm run build && cd ..
+cp scripts/com.user.loop-monitor.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.user.loop-monitor.plist
+```
+
+The service runs from `~/.openclaw/workspace/services/loop-monitor` — a separate clone that the pipeline working tree never touches. The pipeline continues to use its own working tree at `projects/loop-monitor`.
+
+**Redeploy** (pull latest main + restart):
+
+```bash
+scripts/redeploy.sh
+```
+
+The script is idempotent and exits non-zero on any failed step. You can also override the checkout path or launchd label:
+
+```bash
+scripts/redeploy.sh --checkout /some/other/path --label com.user.loop-monitor
+```
+
 ### `scripts/release.sh patch|minor|major`
 
 Bumps VERSION, updates CHANGELOG.md, commits, tags, and creates a GitHub release with extracted changelog notes.

--- a/scripts/com.user.loop-monitor.plist
+++ b/scripts/com.user.loop-monitor.plist
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  loop-monitor server — runs from the dedicated service checkout so the
+  autonomous pipeline working tree can change branches freely without
+  affecting the running service.
+
+  Bootstrap (one-time):
+    git clone https://github.com/svv2014/loop-monitor.git \
+      ~/.openclaw/workspace/services/loop-monitor
+    cd ~/.openclaw/workspace/services/loop-monitor/web && npm ci && npm run build && cd ..
+
+  Install:
+    cp scripts/com.user.loop-monitor.plist ~/Library/LaunchAgents/
+    launchctl load ~/Library/LaunchAgents/com.user.loop-monitor.plist
+
+  Update (pull latest + restart):
+    scripts/redeploy.sh
+
+  Disable:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-monitor.plist
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-monitor</string>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/vadim/.openclaw/workspace/services/loop-monitor</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/vadim/.openclaw/workspace/services/loop-monitor/run.sh</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/loop-monitor.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/loop-monitor.err.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# scripts/redeploy.sh — Pull latest main and restart the loop-monitor service.
+#
+# Operates on the dedicated service checkout at:
+#   ~/.openclaw/workspace/services/loop-monitor
+#
+# Bootstrap (one-time, before first run):
+#   git clone https://github.com/svv2014/loop-monitor.git \
+#     ~/.openclaw/workspace/services/loop-monitor
+#
+# Usage:
+#   scripts/redeploy.sh [--checkout <path>] [--label <plist-label>]
+#
+# Defaults:
+#   checkout: ~/.openclaw/workspace/services/loop-monitor
+#   label:    com.user.loop-monitor
+
+set -euo pipefail
+
+CHECKOUT="${LOOP_MONITOR_SERVICE_DIR:-$HOME/.openclaw/workspace/services/loop-monitor}"
+PLIST_LABEL="com.user.loop-monitor"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --checkout) CHECKOUT="$2"; shift 2 ;;
+    --label)    PLIST_LABEL="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ ! -d "$CHECKOUT/.git" ]]; then
+  echo "ERROR: $CHECKOUT is not a git repository." >&2
+  echo "Bootstrap: git clone https://github.com/svv2014/loop-monitor.git $CHECKOUT" >&2
+  exit 1
+fi
+
+echo "==> Updating checkout: $CHECKOUT"
+cd "$CHECKOUT"
+git fetch --quiet origin
+git reset --hard origin/main
+
+echo "==> Installing Python dependencies"
+if [[ -f requirements.txt ]]; then
+  pip install -r requirements.txt --quiet
+fi
+
+echo "==> Building web bundle"
+cd web
+npm ci --silent
+npm run build
+cd ..
+
+echo "==> Restarting service: $PLIST_LABEL"
+launchctl kickstart -k "gui/$(id -u)/$PLIST_LABEL"
+
+echo "==> Done. Service is running on latest main."

--- a/server/routes/health.py
+++ b/server/routes/health.py
@@ -1,6 +1,8 @@
 import sqlite3
 import subprocess
+import time
 from pathlib import Path
+from typing import Optional
 
 from fastapi import APIRouter, Depends
 
@@ -10,6 +12,11 @@ from server.db import db_dep
 router = APIRouter()
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+_REMOTE_URL = "https://github.com/svv2014/loop-monitor.git"
+_LATEST_SHA_TTL = 60  # seconds
+
+_latest_sha_cache: Optional[str] = None
+_latest_sha_fetched_at: float = 0.0
 
 
 def _git_sha() -> str:
@@ -29,6 +36,50 @@ def _git_sha() -> str:
     return sha or "unknown"
 
 
+def _latest_main_sha() -> Optional[str]:
+    global _latest_sha_cache, _latest_sha_fetched_at
+    now = time.monotonic()
+    if _latest_sha_cache is not None and now - _latest_sha_fetched_at < _LATEST_SHA_TTL:
+        return _latest_sha_cache
+    try:
+        result = subprocess.run(
+            ["git", "ls-remote", _REMOTE_URL, "refs/heads/main"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except Exception:
+        return _latest_sha_cache
+    if result.returncode != 0 or not result.stdout.strip():
+        return _latest_sha_cache
+    full_sha = result.stdout.split()[0]
+    short_sha = full_sha[:7]
+    _latest_sha_cache = short_sha
+    _latest_sha_fetched_at = now
+    return short_sha
+
+
+def _commit_delta(running: str, latest: str) -> Optional[int]:
+    if running == "unknown" or latest is None:
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "rev-list", "--count", f"{running}..{latest}"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            cwd=_REPO_ROOT,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        return int(result.stdout.strip())
+    except ValueError:
+        return None
+
+
 @router.get("/api/health")
 def health(conn: sqlite3.Connection = Depends(db_dep)):
     rows = conn.execute(
@@ -39,10 +90,15 @@ def health(conn: sqlite3.Connection = Depends(db_dep)):
         "SELECT DISTINCT COALESCE(loop_id, '(unknown)') AS loop_id FROM events ORDER BY loop_id"
     ).fetchall()
     loop_ids = [r["loop_id"] for r in loop_rows]
+    running_sha = _git_sha()
+    latest_sha = _latest_main_sha()
+    delta = _commit_delta(running_sha, latest_sha) if latest_sha and running_sha != latest_sha else None
     return {
         "status": "ok",
         "monitor_version": MONITOR_VERSION,
-        "git_sha": _git_sha(),
+        "git_sha": running_sha,
+        "latest_main_sha": latest_sha,
+        "commit_delta": delta,
         "supported_bounty_api": f"{SUPPORTED_API_MAJOR}.x",
         "core_version_counts": core_version_counts,
         "loop_ids": loop_ids,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -104,6 +104,9 @@ export default function App() {
   }));
   const online = !activeQuery.isError;
   const version = healthQuery.data?.monitor_version ?? '…';
+  const gitSha = healthQuery.data?.git_sha ?? null;
+  const latestMainSha = healthQuery.data?.latest_main_sha ?? null;
+  const commitDelta = healthQuery.data?.commit_delta ?? null;
 
   return (
     <div className="app">
@@ -112,6 +115,9 @@ export default function App() {
         events={events}
         online={online}
         version={version}
+        gitSha={gitSha}
+        latestMainSha={latestMainSha}
+        commitDelta={commitDelta}
         allProjectIds={allProjectIds}
         projectFilter={projectFilter}
         onProjectFilterChange={setProjectFilter}

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -8,6 +8,9 @@ interface TopBarProps {
   events: TopBarEvent[];
   online: boolean;
   version: string;
+  gitSha: string | null;
+  latestMainSha: string | null;
+  commitDelta: number | null;
   allProjectIds: string[];
   projectFilter: string | null;
   onProjectFilterChange: (v: string | null) => void;
@@ -28,46 +31,94 @@ function useTick(ms = 1000) {
   }, [ms]);
 }
 
-export default function TopBar({ events, online, version, allProjectIds, projectFilter, onProjectFilterChange }: TopBarProps) {
+export default function TopBar({ events, online, version, gitSha, latestMainSha, commitDelta, allProjectIds, projectFilter, onProjectFilterChange }: TopBarProps) {
   useTick(1000);
   const now = new Date();
   const eventsLastMin = events.filter(e => Date.now() - e.ts < 60_000).length;
   const isFiltered = !!projectFilter;
+
+  const isBehind = gitSha != null && latestMainSha != null && gitSha !== latestMainSha;
+  const [bannerDismissedFor, setBannerDismissedFor] = useState<string | null>(null);
+  const showBanner = isBehind && bannerDismissedFor !== latestMainSha;
+
   return (
-    <div className="topbar">
-      <div className="left">
-        <span className="mono" style={{ color: 'var(--fg)', fontWeight: 500 }}>
-          PIPELINE
-          <span style={{ color: 'var(--fg-4)', marginLeft: 6 }}>v{version}</span>
-        </span>
-        <span style={{ width: 1, height: 14, background: 'var(--border)' }}></span>
-        <span><span className="dot"></span> &nbsp;{online ? 'CONNECTED' : 'OFFLINE'}</span>
-        <span>: 127.0.0.1:18792</span>
-      </div>
-      <div className="right">
-        <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-          <label className="muted mono" style={{ fontSize: 11 }}>Project:</label>
-          <select
-            className="btn"
-            value={projectFilter ?? ''}
-            onChange={e => onProjectFilterChange(e.target.value || null)}
+    <>
+      {showBanner && (
+        <div
+          className="mono"
+          style={{
+            gridArea: 'topbar',
+            marginTop: 32,
+            background: 'color-mix(in srgb, var(--amber, #f59e0b) 15%, var(--bg-1))',
+            borderBottom: '1px solid color-mix(in srgb, var(--amber, #f59e0b) 40%, transparent)',
+            color: 'var(--amber, #f59e0b)',
+            fontSize: 11,
+            padding: '4px 12px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+          }}
+        >
+          <span>
+            &#9650; Running <strong>{gitSha}</strong> — latest main is <strong>{latestMainSha}</strong>
+            {commitDelta != null && commitDelta > 0 && ` (${commitDelta} commit${commitDelta === 1 ? '' : 's'} behind)`}
+            {'. Run '}
+            <code>scripts/redeploy.sh</code>
+            {' to update.'}
+          </span>
+          <button
+            onClick={() => setBannerDismissedFor(latestMainSha)}
             style={{
+              marginLeft: 'auto',
+              background: 'none',
+              border: 'none',
+              color: 'inherit',
               cursor: 'pointer',
-              border: isFiltered ? '1px solid var(--accent)' : undefined,
-              background: isFiltered ? 'color-mix(in srgb, var(--accent) 15%, var(--bg-1))' : undefined,
-              color: isFiltered ? 'var(--accent)' : undefined,
+              fontSize: 13,
+              lineHeight: 1,
+              padding: '0 4px',
             }}
+            aria-label="Dismiss"
           >
-            <option value="">All</option>
-            {allProjectIds.map(id => (
-              <option key={id} value={id}>{id}</option>
-            ))}
-          </select>
-        </span>
-        <span>{eventsLastMin}/min</span>
-        <span>· {events.length.toLocaleString()} events</span>
-        <span>· {timeFmt(now)}</span>
+            ✕
+          </button>
+        </div>
+      )}
+      <div className="topbar">
+        <div className="left">
+          <span className="mono" style={{ color: 'var(--fg)', fontWeight: 500 }}>
+            PIPELINE
+            <span style={{ color: 'var(--fg-4)', marginLeft: 6 }}>v{version}</span>
+          </span>
+          <span style={{ width: 1, height: 14, background: 'var(--border)' }}></span>
+          <span><span className="dot"></span> &nbsp;{online ? 'CONNECTED' : 'OFFLINE'}</span>
+          <span>: 127.0.0.1:18792</span>
+        </div>
+        <div className="right">
+          <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+            <label className="muted mono" style={{ fontSize: 11 }}>Project:</label>
+            <select
+              className="btn"
+              value={projectFilter ?? ''}
+              onChange={e => onProjectFilterChange(e.target.value || null)}
+              style={{
+                cursor: 'pointer',
+                border: isFiltered ? '1px solid var(--accent)' : undefined,
+                background: isFiltered ? 'color-mix(in srgb, var(--accent) 15%, var(--bg-1))' : undefined,
+                color: isFiltered ? 'var(--accent)' : undefined,
+              }}
+            >
+              <option value="">All</option>
+              {allProjectIds.map(id => (
+                <option key={id} value={id}>{id}</option>
+              ))}
+            </select>
+          </span>
+          <span>{eventsLastMin}/min</span>
+          <span>· {events.length.toLocaleString()} events</span>
+          <span>· {timeFmt(now)}</span>
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/web/src/lib/fixtures.ts
+++ b/web/src/lib/fixtures.ts
@@ -287,6 +287,8 @@ export function getFixtureHealth(): Health {
     status: 'ok',
     monitor_version: '0.0.0-fixture',
     git_sha: 'c0ffee0',
+    latest_main_sha: 'c0ffee0',
+    commit_delta: null,
     supported_bounty_api: '1.x',
     core_version_counts: { '1.0': 300, '1.1': 45 },
     loop_ids: ['loop-001', 'loop-002'],

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -135,6 +135,8 @@ export interface Health {
   status: string;
   monitor_version: string;
   git_sha: string;
+  latest_main_sha?: string | null;
+  commit_delta?: number | null;
   supported_bounty_api: string;
   core_version_counts: Record<string, number>;
   loop_ids: string[];


### PR DESCRIPTION
Closes #257

## Changes

### `scripts/redeploy.sh` (new)
Idempotent deploy script for the dedicated service checkout:
1. `git fetch && git reset --hard origin/main`
2. `pip install -r requirements.txt --quiet` (skipped if no requirements.txt)
3. `cd web && npm ci --silent && npm run build`
4. `launchctl kickstart -k gui/$(id -u)/com.user.loop-monitor`

Exits non-zero on any failed step. Accepts `--checkout` and `--label` overrides.

### `scripts/com.user.loop-monitor.plist` (new)
launchd plist for the loop-monitor server pointing at the dedicated service checkout `~/.openclaw/workspace/services/loop-monitor`. Label is `com.user.loop-monitor`. `KeepAlive=true`, `RunAtLoad=true`. The pipeline working tree is never touched by this plist.

### `server/routes/health.py`
Extends `/api/health` with:
- `latest_main_sha` — fetched via `git ls-remote` (no auth, no rate-limit issues), cached in-process with 60s TTL. Returns `null` on network error (cache stays warm).
- `commit_delta` — `git rev-list --count <running>..<latest>` locally; `null` when unavailable or SHAs match.

### `web/src/components/TopBar.tsx`
Adds a stale-build banner rendered above the TopBar when `git_sha != latest_main_sha`. Banner shows running sha, latest sha, and commit count (when available). Dismissible per-session (stored in component state keyed on `latestMainSha`); reappears automatically on the next distinct mismatch.

### `web/src/lib/types.ts` + `fixtures.ts`
`Health` interface extended with optional `latest_main_sha` and `commit_delta` fields. Fixture updated to match.

### `README.md`
New `scripts/redeploy.sh` section with one-time bootstrap steps and usage.

## Test Plan
- [ ] `GET /api/health` returns `latest_main_sha` (7-char sha) and `commit_delta` (int or null)
- [ ] Response is under 200ms when cache is warm (second request within 60s)
- [ ] Banner appears in the UI when `git_sha != latest_main_sha`; dismiss button hides it for the session; refreshing the page with a fresh mismatch shows it again
- [ ] `scripts/redeploy.sh` exits 0 against a bootstrapped service checkout; verify service restarts on latest main and `/api/health` reports matching shas
- [ ] `scripts/redeploy.sh` exits non-zero when run against a non-existent checkout (prints bootstrap hint)
- [ ] ruff check passes, tsc --noEmit passes, vite build succeeds