### PR TITLE
[LM-110] Per-ticket timeline view (API + frontend)

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -31,6 +31,7 @@ from server.routes import (  # noqa: E402
     scanner_state,
     slos,
     stats,
+    timeline,
 )
 
 app.include_router(analytics.router)
@@ -48,6 +49,7 @@ app.include_router(logs.router)
 app.include_router(scanner_state.router)
 app.include_router(slos.router)
 app.include_router(config.router)
+app.include_router(timeline.router)
 
 app.mount("/", StaticFiles(directory="static/dist", html=True), name="webapp")
 

--- a/server/routes/timeline.py
+++ b/server/routes/timeline.py
@@ -1,0 +1,63 @@
+import json
+import sqlite3
+
+from fastapi import APIRouter, Depends
+
+from server.db import db_dep
+
+router = APIRouter()
+
+
+@router.get("/api/timeline")
+def timeline(
+    slug: str,
+    num: int,
+    include_skips: bool = False,
+    conn: sqlite3.Connection = Depends(db_dep),
+):
+    """Per-ticket event timeline ordered ascending by created_at.
+
+    By default hides reconcile_check events where payload.decision == 'skip'
+    (workflow-aware skip noise). Pass include_skips=true to reveal them.
+    """
+    skip_clause = (
+        ""
+        if include_skips
+        else "AND NOT (event_type = 'reconcile_check' AND json_extract(payload, '$.decision') = 'skip')"
+    )
+    rows = conn.execute(
+        f"""
+        SELECT id, project, role, model, event_type,
+               issue_number, pr_number, detail, payload, created_at
+        FROM events
+        WHERE project = ?
+          AND (issue_number = ? OR pr_number = ?)
+          {skip_clause}
+        ORDER BY created_at ASC, id ASC
+        """,
+        (slug, num, num),
+    ).fetchall()
+
+    events = []
+    for r in rows:
+        row = dict(r)
+        payload = None
+        if row["payload"]:
+            try:
+                payload = json.loads(row["payload"])
+            except Exception:
+                payload = row["payload"]
+        events.append({
+            "id": row["id"],
+            "ts": row["created_at"],
+            "type": row["event_type"],
+            "payload": payload,
+            "project": row["project"],
+            "role": row["role"],
+            "model": row["model"],
+            "issue_number": row["issue_number"],
+            "pr_number": row["pr_number"],
+            "detail": row["detail"],
+        })
+
+    return {"events": events}

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,0 +1,103 @@
+import json
+import sqlite3
+
+import server.db
+
+TS0 = "2026-01-01T00:00:00+00:00"
+
+
+def _ins(conn, project, role, event_type, issue_number=None, pr_number=None, payload=None, created_at=TS0):
+    conn.execute(
+        "INSERT INTO events (project, role, event_type, issue_number, pr_number, payload, created_at)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (project, role, event_type, issue_number, pr_number, json.dumps(payload) if payload else None, created_at),
+    )
+    conn.commit()
+
+
+def test_timeline_happy_path(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _ins(conn, "proj-tl", "dev", "dev_start", issue_number=42, created_at="2026-01-01T00:00:01+00:00")
+    _ins(conn, "proj-tl", "qa", "qa_pass", issue_number=42, created_at="2026-01-01T00:00:02+00:00")
+    conn.close()
+
+    resp = isolated_client.get("/api/timeline?slug=proj-tl&num=42")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "events" in data
+    events = data["events"]
+    assert len(events) == 2
+    # ascending order
+    assert events[0]["type"] == "dev_start"
+    assert events[1]["type"] == "qa_pass"
+    assert events[0]["ts"] < events[1]["ts"]
+
+
+def test_timeline_empty_result(isolated_client):
+    resp = isolated_client.get("/api/timeline?slug=no-such-project&num=9999")
+    assert resp.status_code == 200
+    assert resp.json() == {"events": []}
+
+
+def test_timeline_skip_filter_hides_by_default(isolated_client):
+    """reconcile_check/skip events are hidden when include_skips is omitted."""
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _ins(conn, "proj-sk", "reconciler", "reconcile_check", issue_number=7,
+         payload={"decision": "skip", "reason": "workflow-aware skip"},
+         created_at="2026-01-01T00:00:01+00:00")
+    _ins(conn, "proj-sk", "dev", "dev_start", issue_number=7,
+         created_at="2026-01-01T00:00:02+00:00")
+    conn.close()
+
+    resp = isolated_client.get("/api/timeline?slug=proj-sk&num=7")
+    assert resp.status_code == 200
+    types = [e["type"] for e in resp.json()["events"]]
+    assert "dev_start" in types
+    assert "reconcile_check" not in types
+
+
+def test_timeline_skip_filter_revealed_with_flag(isolated_client):
+    """With include_skips=true, reconcile_check/skip events are returned."""
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _ins(conn, "proj-sk2", "reconciler", "reconcile_check", issue_number=8,
+         payload={"decision": "skip"},
+         created_at="2026-01-01T00:00:01+00:00")
+    conn.close()
+
+    resp = isolated_client.get("/api/timeline?slug=proj-sk2&num=8&include_skips=true")
+    assert resp.status_code == 200
+    types = [e["type"] for e in resp.json()["events"]]
+    assert "reconcile_check" in types
+
+
+def test_timeline_non_skip_reconcile_always_shown(isolated_client):
+    """reconcile_check events with decision != 'skip' are not filtered."""
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _ins(conn, "proj-sk3", "reconciler", "reconcile_check", issue_number=9,
+         payload={"decision": "act"},
+         created_at="2026-01-01T00:00:01+00:00")
+    conn.close()
+
+    resp = isolated_client.get("/api/timeline?slug=proj-sk3&num=9")
+    assert resp.status_code == 200
+    types = [e["type"] for e in resp.json()["events"]]
+    assert "reconcile_check" in types
+
+
+def test_timeline_event_fields(isolated_client):
+    """Each event includes ts, type, payload, role, and other required fields."""
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _ins(conn, "proj-tf", "dev", "dev_done", issue_number=10,
+         payload={"result": "ok"}, created_at="2026-01-01T00:00:01+00:00")
+    conn.close()
+
+    resp = isolated_client.get("/api/timeline?slug=proj-tf&num=10")
+    events = resp.json()["events"]
+    assert len(events) == 1
+    e = events[0]
+    assert e["ts"] == "2026-01-01T00:00:01+00:00"
+    assert e["type"] == "dev_done"
+    assert e["payload"] == {"result": "ok"}
+    assert e["role"] == "dev"
+    assert "id" in e
+    assert e["issue_number"] == 10

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import Overview from './screens/Overview';
 import Logs from './screens/Logs';
 import ProjectDetail from './screens/ProjectDetail';
 import Queue from './screens/Queue';
+import Timeline from './screens/Timeline';
 import WorkerDetail from './screens/WorkerDetail';
 import Cost from './screens/Cost';
 import Analytics from './screens/Analytics';
@@ -23,7 +24,7 @@ const SCREEN_KEYS: Record<string, string> = {
 };
 
 export default function App() {
-  const { screen: hashScreen, projectId: hashProjectId, projectFilter, navigateTo, setProjectFilter } = useHashRoute();
+  const { screen: hashScreen, projectId: hashProjectId, projectFilter, ticketNum, navigateTo, setProjectFilter } = useHashRoute();
 
   // 'cost' is local-only — not stored in the hash — so we track it separately.
   const [showCost, setShowCost] = useState(false);
@@ -75,6 +76,7 @@ export default function App() {
   }
 
   const isProjectDetail = hashNavScreen === 'projects' && projectId != null;
+  const isTimeline = hashNavScreen === 'timeline';
 
   const activeQuery = useQuery({
     queryKey: ['active'],
@@ -120,6 +122,12 @@ export default function App() {
       <main className="main">
         {showCost ? (
           <Cost globalProjectFilter={projectFilter} />
+        ) : isTimeline ? (
+          <Timeline
+            projectId={projectId ?? ''}
+            ticketNum={ticketNum}
+            onBack={() => projectId ? navigateTo('project', projectId, { pushState: true }) : handleBack()}
+          />
         ) : isProjectDetail && projectId != null ? (
           <ProjectDetail
             projectId={projectId}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -26,6 +26,7 @@ import type {
   CycleTimeAnalyticsResponse,
   SloConfig,
   CostTrend,
+  TimelineResponse,
 } from './types';
 import * as fx from './fixtures';
 
@@ -226,6 +227,12 @@ export async function putSlo(project: string, body: { total_seconds: number | nu
 
 export class LogsDisabledError extends Error {
   constructor() { super('Logs are disabled. Set LOOPMON_EXPOSE_LOGS=1 or access via loopback.'); }
+}
+
+export async function fetchTimeline(slug: string, num: number, includeSkips = false): Promise<TimelineResponse> {
+  const p = new URLSearchParams({ slug, num: String(num) });
+  if (includeSkips) p.set('include_skips', 'true');
+  return get<TimelineResponse>(`/api/timeline?${p.toString()}`);
 }
 
 export async function fetchLogs(handler: string, filter: string, tail: string): Promise<LogsResponse> {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -280,6 +280,23 @@ export interface CostTrendBucket {
   issue_count: number;
 }
 
+export interface TimelineEvent {
+  id: number;
+  ts: string;
+  type: string;
+  payload: Record<string, unknown> | null;
+  project: string;
+  role: string;
+  model: string | null;
+  issue_number: number | null;
+  pr_number: number | null;
+  detail: string | null;
+}
+
+export interface TimelineResponse {
+  events: TimelineEvent[];
+}
+
 export interface CostTrend {
   window_days: number;
   today: {

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
-export type Screen = 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs' | 'analytics';
+export type Screen = 'overview' | 'queue' | 'projects' | 'workers' | 'project' | 'logs' | 'analytics' | 'timeline';
 
 export interface HashRoute {
   screen: Screen;
@@ -140,11 +140,15 @@ export function useHashRoute() {
     [route.screen, route.projectId, route.drawer, unknown],
   );
 
+  const rawNum = unknown['num'];
+  const ticketNum = rawNum != null && /^\d+$/.test(rawNum) ? parseInt(rawNum, 10) : null;
+
   return {
     screen: route.screen,
     projectId: route.projectId,
     drawer: route.drawer,
     projectFilter: unknown['project_filter'] ?? null,
+    ticketNum,
     navigateTo,
     setDrawer,
     setProjectFilter,

--- a/web/src/screens/ProjectDetail.tsx
+++ b/web/src/screens/ProjectDetail.tsx
@@ -336,11 +336,12 @@ export default function ProjectDetail({ projectId, allProjectIds, onBack, onProj
                   <th style={{ textAlign: 'right' }}>Runs</th>
                   <th>Last</th>
                   <th style={{ textAlign: 'right' }}>Pts</th>
+                  <th></th>
                 </tr>
               </thead>
               <tbody>
                 {issues.length === 0 && (
-                  <tr><td colSpan={5} className="muted" style={{ textAlign: 'center', padding: 'var(--pad-3)' }}>No runs yet</td></tr>
+                  <tr><td colSpan={6} className="muted" style={{ textAlign: 'center', padding: 'var(--pad-3)' }}>No runs yet</td></tr>
                 )}
                 {issues.map(i => (
                   <tr key={i.num}>
@@ -358,6 +359,13 @@ export default function ProjectDetail({ projectId, allProjectIds, onBack, onProj
                       {i.lastAt ? relTime(i.lastAt) : '—'}
                     </td>
                     <td className="num" style={{ textAlign: 'right' }}>{i.pts}</td>
+                    <td>
+                      <a
+                        className="muted mono"
+                        href={`#screen=timeline&project=${encodeURIComponent(projectId)}&num=${i.num}`}
+                        style={{ fontSize: 10, textDecoration: 'none' }}
+                      >timeline →</a>
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/web/src/screens/Timeline.tsx
+++ b/web/src/screens/Timeline.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from 'react';
+import type { TimelineEvent, TimelineResponse } from '../lib/types';
+
+interface TimelineProps {
+  projectId: string;
+  ticketNum: number | null;
+  onBack: () => void;
+}
+
+const TYPE_BADGE: Record<string, { label: string; color: string }> = {
+  dev_start:       { label: 'dev:start',    color: 'var(--role-dev)' },
+  dev_done:        { label: 'dev:done',     color: 'var(--role-dev)' },
+  dev_failed:      { label: 'dev:fail',     color: 'var(--fail,#ef4444)' },
+  qa_start:        { label: 'qa:start',     color: 'var(--role-qa)' },
+  qa_pass:         { label: 'qa:pass',      color: 'var(--role-qa)' },
+  qa_fail:         { label: 'qa:fail',      color: 'var(--fail,#ef4444)' },
+  review_start:    { label: 'review:start', color: 'var(--role-reviewer)' },
+  review_done:     { label: 'review:done',  color: 'var(--role-reviewer)' },
+  review_failed:   { label: 'review:fail',  color: 'var(--fail,#ef4444)' },
+  merge_start:     { label: 'merge:start',  color: 'var(--role-merge)' },
+  merge_done:      { label: 'merge:done',   color: 'var(--role-merge)' },
+  po_start:        { label: 'po:start',     color: 'var(--role-po)' },
+  po_done:         { label: 'po:done',      color: 'var(--role-po)' },
+  po_failed:       { label: 'po:fail',      color: 'var(--fail,#ef4444)' },
+  rework_start:    { label: 'rework',       color: 'var(--fg-3)' },
+  rework_done:     { label: 'rework:done',  color: 'var(--fg-2)' },
+  reconcile_check: { label: 'reconcile',    color: 'var(--fg-3)' },
+  label_change:    { label: 'label',        color: 'var(--accent2,#7c3aed)' },
+};
+
+function getTypeBadge(eventType: string): { label: string; color: string } {
+  if (TYPE_BADGE[eventType]) return TYPE_BADGE[eventType];
+  if (eventType.endsWith('_done') || eventType.endsWith('_pass')) {
+    return { label: eventType, color: 'var(--role-merge)' };
+  }
+  if (eventType.endsWith('_fail') || eventType.endsWith('_failed')) {
+    return { label: eventType, color: 'var(--fail,#ef4444)' };
+  }
+  if (eventType.endsWith('_start')) {
+    return { label: eventType, color: 'var(--fg-2)' };
+  }
+  return { label: eventType, color: 'var(--fg-3)' };
+}
+
+function fmtTs(ts: string): string {
+  try {
+    const d = new Date(ts.includes('T') ? ts : ts + 'Z');
+    return d.toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
+  } catch {
+    return ts;
+  }
+}
+
+export default function Timeline({ projectId, ticketNum, onBack }: TimelineProps) {
+  const [events, setEvents] = useState<TimelineEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [includeSkips, setIncludeSkips] = useState(false);
+
+  useEffect(() => {
+    if (!projectId || ticketNum == null) {
+      setEvents([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const p = new URLSearchParams({ slug: projectId, num: String(ticketNum) });
+    if (includeSkips) p.set('include_skips', 'true');
+    fetch(`/api/timeline?${p.toString()}`)
+      .then(r => r.ok ? r.json() : Promise.reject(r.status))
+      .then((data: TimelineResponse) => { setEvents(data.events); setLoading(false); })
+      .catch(() => { setEvents([]); setLoading(false); });
+  }, [projectId, ticketNum, includeSkips]);
+
+  return (
+    <div data-testid="timeline">
+      <div className="screen-h" style={{ display: 'flex', alignItems: 'center', gap: 'var(--pad-3)', padding: 'var(--pad-2) var(--pad-4)' }}>
+        <button className="btn" onClick={onBack}>← Back</button>
+        <h1 style={{ flex: 1, margin: 0, fontFamily: 'var(--font-mono)', fontSize: 13, fontWeight: 500, letterSpacing: '0.04em' }}>
+          <span className="muted">timeline /</span> {projectId}
+          {ticketNum != null && (
+            <span className="muted"> / <span style={{ color: 'var(--fg)' }}>#{ticketNum}</span></span>
+          )}
+        </h1>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, cursor: 'pointer' }}>
+          <input
+            type="checkbox"
+            checked={includeSkips}
+            onChange={e => setIncludeSkips(e.target.checked)}
+          />
+          <span className="muted">Show skip noise</span>
+        </label>
+      </div>
+
+      <div style={{ padding: 'var(--pad-4)' }}>
+        {loading ? (
+          <div className="muted" style={{ fontSize: 12 }}>Loading…</div>
+        ) : events.length === 0 ? (
+          <div className="muted" style={{ fontSize: 13 }}>No events recorded for this ticket.</div>
+        ) : (
+          <div style={{ position: 'relative', paddingLeft: 24 }}>
+            <div style={{
+              position: 'absolute', left: 8, top: 8, bottom: 8,
+              width: 2, background: 'var(--border)',
+            }} />
+            {events.map((e, i) => {
+              const badge = getTypeBadge(e.type);
+              return (
+                <div key={e.id ?? i} style={{ position: 'relative', marginBottom: 'var(--pad-3)', paddingLeft: 'var(--pad-3)' }}>
+                  <div style={{
+                    position: 'absolute', left: -20, top: 6,
+                    width: 8, height: 8, borderRadius: '50%',
+                    background: badge.color, border: '2px solid var(--bg)',
+                  }} />
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                    <span className="tag" style={{ color: badge.color, borderColor: 'currentColor', flexShrink: 0 }}>
+                      {badge.label}
+                    </span>
+                    {e.role && (
+                      <span className="muted mono" style={{ fontSize: 11 }}>{e.role}</span>
+                    )}
+                    {(e.issue_number != null || e.pr_number != null) && (
+                      <span className="muted mono" style={{ fontSize: 11 }}>
+                        {e.issue_number != null ? `#${e.issue_number}` : `PR#${e.pr_number}`}
+                      </span>
+                    )}
+                    <span className="muted mono" style={{ fontSize: 11, marginLeft: 'auto' }}>
+                      {fmtTs(e.ts)}
+                    </span>
+                  </div>
+                  {e.detail && (
+                    <div className="muted" style={{ fontSize: 11, marginTop: 2 }}>{e.detail}</div>
+                  )}
+                  {e.payload != null && Object.keys(e.payload).length > 0 && (
+                    <pre className="mono muted" style={{
+                      fontSize: 10, marginTop: 4, padding: '4px 8px',
+                      background: 'var(--bg-2)', overflow: 'auto',
+                      maxHeight: 80, whiteSpace: 'pre-wrap', wordBreak: 'break-word',
+                    }}>
+                      {JSON.stringify(e.payload, null, 2)}
+                    </pre>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #110

## Changes

**Backend:**
- `server/routes/timeline.py`: New `GET /api/timeline?slug=X&num=N` route returning `{ events: [...] }` ordered ascending by `ts`. Reads from the `events` table (event-audit indexes added in #109). By default filters out `reconcile_check` events with `payload.decision == 'skip'`; pass `include_skips=true` to reveal them.
- `server/app.py`: Register the timeline router.

**Frontend:**
- `web/src/screens/Timeline.tsx`: Vertical timeline with colored type badges, payload preview, and a "Show skip noise" toggle. Shows "No events recorded for this ticket." empty state.
- `web/src/router.tsx`: Added `'timeline'` to the `Screen` type; exposed `ticketNum` from hash unknown params.
- `web/src/App.tsx`: Wire `Timeline` screen; back button returns to project detail.
- `web/src/screens/ProjectDetail.tsx`: Added "timeline →" link per row in the Recent Issues table (`#screen=timeline&project=<slug>&num=<N>`).
- `web/src/lib/types.ts`: Added `TimelineEvent` and `TimelineResponse` interfaces.
- `web/src/lib/api.ts`: Added `fetchTimeline()` helper.

**Tests:**
- `tests/test_timeline.py`: 6 pytest tests covering happy path, empty result, skip-filter default (hides reconcile_check/skip), skip-filter with `include_skips=true`, non-skip reconcile always shown, and required event fields.

## Test Plan
- `ruff check .` — passes clean
- `cd web && npm run typecheck` — no errors
- `cd web && npm run build` — builds successfully
- `pytest tests/test_timeline.py -v` — all 6 tests pass
- Navigate to a project detail page → click "timeline →" on any issue row → timeline page loads
- Toggle "Show skip noise" to reveal/hide reconcile_check/skip events
- Visit `#screen=timeline&project=<slug>&num=<N>` for an issue with no events → shows empty state message