### PR TITLE
[LM-269] fix TopBar events/min rate by sourcing events from feed query

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,7 +11,7 @@ import WorkerDetail from './screens/WorkerDetail';
 import Cost from './screens/Cost';
 import Analytics from './screens/Analytics';
 import { useHashRoute } from './router';
-import { fetchActive, fetchHealth } from './lib/api';
+import { fetchActive, fetchFeed, fetchHealth } from './lib/api';
 
 const SCREEN_KEYS: Record<string, string> = {
   '1': 'overview',
@@ -83,6 +83,13 @@ export default function App() {
     staleTime: 0,
   });
 
+  const feedQuery = useQuery({
+    queryKey: ['feed'],
+    queryFn: () => fetchFeed(),
+    refetchInterval: 5000,
+    staleTime: 0,
+  });
+
   const healthQuery = useQuery({
     queryKey: ['health'],
     queryFn: () => fetchHealth(),
@@ -99,8 +106,8 @@ export default function App() {
     return () => window.removeEventListener('keydown', onKey);
   }, []);
 
-  const events = (activeQuery.data ?? []).map((w) => ({
-    ts: new Date(w.created_at).getTime(),
+  const events = (feedQuery.data ?? []).map((f) => ({
+    ts: new Date(f.created_at).getTime(),
   }));
   const online = !activeQuery.isError;
   const version = healthQuery.data?.monitor_version ?? '…';


### PR DESCRIPTION
Closes #269

## Changes

`web/src/App.tsx`: Added a `feedQuery` using `useQuery` that fetches from `/api/feed` with `refetchInterval: 5000`. The `events` prop passed to `<TopBar>` is now derived from `feedQuery.data` instead of `activeQuery.data`.

**Root cause:** `activeQuery` fetches `/api/active` (currently running workers). When no workers are running, this array is empty, so `events` was always empty and TopBar always displayed `0/min`. The `/api/feed` endpoint returns recent timestamped events regardless of worker activity.

**What changed:**
- Import `fetchFeed` alongside existing imports
- Add `feedQuery` (same `refetchInterval: 5000`, `staleTime: 0` as `activeQuery`)
- Map `feedQuery.data` → `{ ts: number }[]` using `created_at` field (same pattern as before)
- `online` still derives from `activeQuery.isError` — connectivity semantics unchanged

## Test Plan
- Start the server with some recent feed events; TopBar should display a non-zero `N/min` count if any events arrived in the last 60s
- With no recent events, TopBar should display `0/min · <total> events`
- Verify `npm run typecheck` and `npm run build` pass (both confirmed locally)