### PR TITLE
[LM-257] add dedicated service checkout, redeploy script, and sha-lag banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,43 @@ LOOPMON_EXPOSE_LOGS=1
 
 loop-monitor is **operator-driven** — currently developed by an autonomous pipeline tied to a single operator account. External PRs are not accepted at this time. See [CONTRIBUTING.md](CONTRIBUTING.md) for details and alternatives (file an issue, fork freely under MIT, file security reports via GitHub Security Advisories).
 
+## Service checkout (recommended install)
+
+The service should run from a **dedicated clone** that the pipeline never touches. This prevents the dashboard from accidentally serving stale code left on a feature branch.
+
+### One-time bootstrap
+
+```bash
+git clone https://github.com/svv2014/loop-monitor.git \
+    ~/.openclaw/workspace/services/loop-monitor
+cd ~/.openclaw/workspace/services/loop-monitor
+pip install -r requirements.txt
+cd web && npm ci && npm run build && cd ..
+```
+
+### Install the LaunchAgent
+
+```bash
+cp scripts/com.user.loop-monitor.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.user.loop-monitor.plist
+```
+
+The plist runs `run.sh` from the service checkout with `KeepAlive = true`, so it restarts automatically on crash.
+
+### Redeploy (update to latest main)
+
+When the dashboard shows an **"Update available"** banner run:
+
+```bash
+~/.openclaw/workspace/services/loop-monitor/scripts/redeploy.sh
+```
+
+This fetches the latest `main`, reinstalls Python deps, rebuilds the web bundle, and restarts the LaunchAgent in one step. The script is idempotent and exits non-zero on any failed step.
+
+Override the service path with `LOOP_MONITOR_SERVICE_DIR` if you cloned elsewhere.
+
+> The `com.user.loop-watch.plist` (the pipeline monitoring script) continues to run from the operator working tree and is unaffected by this setup.
+
 ## Development
 
 ```bash

--- a/scripts/com.user.loop-monitor.plist
+++ b/scripts/com.user.loop-monitor.plist
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  loop-monitor server — runs the FastAPI/uvicorn dashboard from a dedicated
+  service checkout that the pipeline never writes to.
+
+  Bootstrap (one-time):
+    git clone https://github.com/svv2014/loop-monitor.git \
+        ~/.openclaw/workspace/services/loop-monitor
+    cd ~/.openclaw/workspace/services/loop-monitor
+    pip install -r requirements.txt
+    cd web && npm ci && npm run build && cd ..
+
+  Install:
+    cp scripts/com.user.loop-monitor.plist ~/Library/LaunchAgents/
+    launchctl load ~/Library/LaunchAgents/com.user.loop-monitor.plist
+
+  Update to latest main:
+    scripts/redeploy.sh   (fetches, rebuilds, restarts)
+
+  Disable:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-monitor.plist
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-monitor</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/vadim/.openclaw/workspace/services/loop-monitor/run.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/vadim/.openclaw/workspace/services/loop-monitor</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/loop-monitor.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/loop-monitor.err.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# scripts/redeploy.sh — update the service checkout to latest main and restart.
+#
+# Run this whenever the dashboard shows a "Update available" banner.
+# Idempotent: safe to run repeatedly.
+#
+# Prerequisites (one-time setup — see README.md "Service checkout"):
+#   git clone https://github.com/svv2014/loop-monitor.git \
+#       ~/.openclaw/workspace/services/loop-monitor
+
+set -euo pipefail
+
+SERVICE_DIR="${LOOP_MONITOR_SERVICE_DIR:-$HOME/.openclaw/workspace/services/loop-monitor}"
+PLIST_LABEL="com.user.loop-monitor"
+
+if [[ ! -d "$SERVICE_DIR/.git" ]]; then
+  echo "ERROR: service checkout not found at $SERVICE_DIR" >&2
+  echo "Bootstrap it first:" >&2
+  echo "  git clone https://github.com/svv2014/loop-monitor.git $SERVICE_DIR" >&2
+  exit 1
+fi
+
+cd "$SERVICE_DIR"
+
+echo "==> Fetching latest main..."
+git fetch --quiet origin main
+git reset --hard origin/main
+
+echo "==> Installing Python dependencies..."
+if [[ -f requirements.txt ]]; then
+  pip install -r requirements.txt --quiet
+fi
+
+echo "==> Building web bundle..."
+cd web
+npm ci --silent
+npm run build
+cd ..
+
+echo "==> Restarting service..."
+launchctl kickstart -k "gui/$(id -u)/$PLIST_LABEL"
+
+echo "==> Done. Service is running on latest main."

--- a/server/routes/health.py
+++ b/server/routes/health.py
@@ -1,6 +1,9 @@
 import sqlite3
 import subprocess
+import time
 from pathlib import Path
+from threading import Lock
+from typing import Optional
 
 from fastapi import APIRouter, Depends
 
@@ -10,6 +13,10 @@ from server.db import db_dep
 router = APIRouter()
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+_REMOTE_URL = "https://github.com/svv2014/loop-monitor.git"
+_LATEST_SHA_CACHE: Optional[tuple] = None
+_LATEST_SHA_TTL = 60.0
+_LATEST_SHA_LOCK = Lock()
 
 
 def _git_sha() -> str:
@@ -29,6 +36,31 @@ def _git_sha() -> str:
     return sha or "unknown"
 
 
+def _latest_main_sha() -> str:
+    global _LATEST_SHA_CACHE
+    with _LATEST_SHA_LOCK:
+        now = time.monotonic()
+        if _LATEST_SHA_CACHE is not None:
+            sha, ts = _LATEST_SHA_CACHE
+            if now - ts < _LATEST_SHA_TTL:
+                return sha
+        try:
+            result = subprocess.run(
+                ["git", "ls-remote", _REMOTE_URL, "refs/heads/main"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except Exception:
+            return "unknown"
+        if result.returncode != 0 or not result.stdout.strip():
+            return "unknown"
+        full_sha = result.stdout.split()[0]
+        short_sha = full_sha[:7]
+        _LATEST_SHA_CACHE = (short_sha, now)
+        return short_sha
+
+
 @router.get("/api/health")
 def health(conn: sqlite3.Connection = Depends(db_dep)):
     rows = conn.execute(
@@ -43,6 +75,7 @@ def health(conn: sqlite3.Connection = Depends(db_dep)):
         "status": "ok",
         "monitor_version": MONITOR_VERSION,
         "git_sha": _git_sha(),
+        "latest_main_sha": _latest_main_sha(),
         "supported_bounty_api": f"{SUPPORTED_API_MAJOR}.x",
         "core_version_counts": core_version_counts,
         "loop_ids": loop_ids,

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -92,6 +92,41 @@ def test_health_git_sha_field(isolated_client):
     assert sha == "unknown" or re.match(r"^[0-9a-f]{7}$", sha)
 
 
+def test_health_latest_main_sha_field(isolated_client):
+    resp = isolated_client.get("/api/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "latest_main_sha" in data
+    sha = data["latest_main_sha"]
+    # Either "unknown" (network unavailable in test env) or a valid short sha
+    assert sha == "unknown" or re.match(r"^[0-9a-f]{7}$", sha)
+
+
+def test_health_latest_main_sha_cached(isolated_client, monkeypatch):
+    import server.routes.health as h
+    call_count = 0
+    original = h._latest_main_sha
+
+    def counting_latest():
+        nonlocal call_count
+        call_count += 1
+        return "abc1234"
+
+    monkeypatch.setattr(h, "_latest_main_sha", counting_latest)
+    # Reset cache so our mock is used
+    h._LATEST_SHA_CACHE = None
+
+    resp1 = isolated_client.get("/api/health")
+    resp2 = isolated_client.get("/api/health")
+    assert resp1.status_code == 200
+    assert resp2.status_code == 200
+    # Both calls should return "abc1234" from our mock
+    assert resp1.json()["latest_main_sha"] == "abc1234"
+    assert resp2.json()["latest_main_sha"] == "abc1234"
+
+    monkeypatch.setattr(h, "_latest_main_sha", original)
+
+
 def test_health_loop_ids_empty_db(isolated_client):
     resp = isolated_client.get("/api/health")
     assert resp.status_code == 200

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -106,6 +106,8 @@ export default function App() {
   }));
   const online = !activeQuery.isError;
   const version = healthQuery.data?.monitor_version ?? '…';
+  const gitSha = healthQuery.data?.git_sha;
+  const latestMainSha = healthQuery.data?.latest_main_sha;
 
   return (
     <div className="app">
@@ -114,6 +116,8 @@ export default function App() {
         events={events}
         online={online}
         version={version}
+        gitSha={gitSha}
+        latestMainSha={latestMainSha}
         allProjectIds={allProjectIds}
         projectFilter={projectFilter}
         onProjectFilterChange={setProjectFilter}

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -8,6 +8,8 @@ interface TopBarProps {
   events: TopBarEvent[];
   online: boolean;
   version: string;
+  gitSha?: string;
+  latestMainSha?: string;
   allProjectIds: string[];
   projectFilter: string | null;
   onProjectFilterChange: (v: string | null) => void;
@@ -28,46 +30,106 @@ function useTick(ms = 1000) {
   }, [ms]);
 }
 
-export default function TopBar({ events, online, version, allProjectIds, projectFilter, onProjectFilterChange }: TopBarProps) {
+export default function TopBar({ events, online, version, gitSha, latestMainSha, allProjectIds, projectFilter, onProjectFilterChange }: TopBarProps) {
   useTick(1000);
   const now = new Date();
   const eventsLastMin = events.filter(e => Date.now() - e.ts < 60_000).length;
   const isFiltered = !!projectFilter;
+
+  const [bannerKey, setBannerKey] = useState<string | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  const isStale =
+    !!gitSha &&
+    !!latestMainSha &&
+    gitSha !== 'unknown' &&
+    latestMainSha !== 'unknown' &&
+    gitSha !== latestMainSha;
+
+  // Reset dismissed state when a new mismatch pair appears
+  useEffect(() => {
+    if (isStale && gitSha && latestMainSha) {
+      const key = `${gitSha}:${latestMainSha}`;
+      if (key !== bannerKey) {
+        setBannerKey(key);
+        setDismissed(false);
+      }
+    }
+  }, [isStale, gitSha, latestMainSha, bannerKey]);
+
+  const showBanner = isStale && !dismissed;
+
   return (
-    <div className="topbar">
-      <div className="left">
-        <span className="mono" style={{ color: 'var(--fg)', fontWeight: 500 }}>
-          PIPELINE
-          <span style={{ color: 'var(--fg-4)', marginLeft: 6 }}>v{version}</span>
-        </span>
-        <span style={{ width: 1, height: 14, background: 'var(--border)' }}></span>
-        <span><span className="dot"></span> &nbsp;{online ? 'CONNECTED' : 'OFFLINE'}</span>
-        <span>: 127.0.0.1:18792</span>
-      </div>
-      <div className="right">
-        <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-          <label className="muted mono" style={{ fontSize: 11 }}>Project:</label>
-          <select
-            className="btn"
-            value={projectFilter ?? ''}
-            onChange={e => onProjectFilterChange(e.target.value || null)}
+    <>
+      {showBanner && (
+        <div
+          className="mono"
+          style={{
+            gridColumn: '1 / -1',
+            background: 'color-mix(in srgb, var(--amber, #d97706) 15%, var(--bg-1))',
+            borderBottom: '1px solid color-mix(in srgb, var(--amber, #d97706) 40%, transparent)',
+            padding: '4px 16px',
+            fontSize: 11,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            color: 'var(--amber, #d97706)',
+          }}
+        >
+          <span>⚠ Update available — running {gitSha}, latest main is {latestMainSha}. Run <code>scripts/redeploy.sh</code> to update.</span>
+          <button
+            onClick={() => setDismissed(true)}
             style={{
+              marginLeft: 'auto',
+              background: 'none',
+              border: 'none',
               cursor: 'pointer',
-              border: isFiltered ? '1px solid var(--accent)' : undefined,
-              background: isFiltered ? 'color-mix(in srgb, var(--accent) 15%, var(--bg-1))' : undefined,
-              color: isFiltered ? 'var(--accent)' : undefined,
+              color: 'inherit',
+              fontSize: 13,
+              lineHeight: 1,
+              padding: '0 4px',
             }}
+            aria-label="Dismiss"
           >
-            <option value="">All</option>
-            {allProjectIds.map(id => (
-              <option key={id} value={id}>{id}</option>
-            ))}
-          </select>
-        </span>
-        <span>{eventsLastMin}/min</span>
-        <span>· {events.length.toLocaleString()} events</span>
-        <span>· {timeFmt(now)}</span>
+            ×
+          </button>
+        </div>
+      )}
+      <div className="topbar">
+        <div className="left">
+          <span className="mono" style={{ color: 'var(--fg)', fontWeight: 500 }}>
+            PIPELINE
+            <span style={{ color: 'var(--fg-4)', marginLeft: 6 }}>v{version}</span>
+          </span>
+          <span style={{ width: 1, height: 14, background: 'var(--border)' }}></span>
+          <span><span className="dot"></span> &nbsp;{online ? 'CONNECTED' : 'OFFLINE'}</span>
+          <span>: 127.0.0.1:18792</span>
+        </div>
+        <div className="right">
+          <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+            <label className="muted mono" style={{ fontSize: 11 }}>Project:</label>
+            <select
+              className="btn"
+              value={projectFilter ?? ''}
+              onChange={e => onProjectFilterChange(e.target.value || null)}
+              style={{
+                cursor: 'pointer',
+                border: isFiltered ? '1px solid var(--accent)' : undefined,
+                background: isFiltered ? 'color-mix(in srgb, var(--accent) 15%, var(--bg-1))' : undefined,
+                color: isFiltered ? 'var(--accent)' : undefined,
+              }}
+            >
+              <option value="">All</option>
+              {allProjectIds.map(id => (
+                <option key={id} value={id}>{id}</option>
+              ))}
+            </select>
+          </span>
+          <span>{eventsLastMin}/min</span>
+          <span>· {events.length.toLocaleString()} events</span>
+          <span>· {timeFmt(now)}</span>
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/web/src/lib/fixtures.ts
+++ b/web/src/lib/fixtures.ts
@@ -287,6 +287,7 @@ export function getFixtureHealth(): Health {
     status: 'ok',
     monitor_version: '0.0.0-fixture',
     git_sha: 'c0ffee0',
+    latest_main_sha: 'deadbee',
     supported_bounty_api: '1.x',
     core_version_counts: { '1.0': 300, '1.1': 45 },
     loop_ids: ['loop-001', 'loop-002'],

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -135,6 +135,7 @@ export interface Health {
   status: string;
   monitor_version: string;
   git_sha: string;
+  latest_main_sha: string;
   supported_bounty_api: string;
   core_version_counts: Record<string, number>;
   loop_ids: string[];


### PR DESCRIPTION
Closes #257

## Changes
- `scripts/redeploy.sh`: fetch+reset+pip+npm build+kickstart, idempotent
- `scripts/com.user.loop-monitor.plist`: server LaunchAgent pointing to service checkout
- `server/routes/health.py`: `latest_main_sha` via git ls-remote, 60s cache
- `web/`: `latest_main_sha` in Health type, dismissible sha-mismatch banner in TopBar
- `README.md`: service checkout bootstrap + redeploy docs
- `tests/test_health.py`: two new tests for latest_main_sha

## Test Plan
- ruff, typecheck, build, pytest all pass