### PR TITLE
[LM-269] fix TopBar event rate: source events from /api/feed instead of /api/active

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import Cost from './screens/Cost';
 import Analytics from './screens/Analytics';
 import Timeline from './screens/Timeline';
 import { useHashRoute } from './router';
-import { fetchActive, fetchHealth } from './lib/api';
+import { fetchActive, fetchFeed, fetchHealth } from './lib/api';
 
 const SCREEN_KEYS: Record<string, string> = {
   '1': 'overview',
@@ -91,6 +91,13 @@ export default function App() {
     staleTime: 60_000,
   });
 
+  const feedQuery = useQuery({
+    queryKey: ['feed'],
+    queryFn: () => fetchFeed({ limit: 200 }),
+    refetchInterval: 5000,
+    staleTime: 0,
+  });
+
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
@@ -101,8 +108,8 @@ export default function App() {
     return () => window.removeEventListener('keydown', onKey);
   }, []);
 
-  const events = (activeQuery.data ?? []).map((w) => ({
-    ts: new Date(w.created_at).getTime(),
+  const events = (feedQuery.data ?? []).map((f) => ({
+    ts: new Date(f.created_at).getTime(),
   }));
   const online = !activeQuery.isError;
   const version = healthQuery.data?.monitor_version ?? '…';

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -59,6 +59,7 @@ export interface FeedParams {
   loop_id?: string;
   role?: string;
   status?: string;
+  limit?: number;
 }
 
 export async function fetchFeed(params: FeedParams = {}): Promise<FeedItem[]> {
@@ -67,6 +68,7 @@ export async function fetchFeed(params: FeedParams = {}): Promise<FeedItem[]> {
   if (params.loop_id) p.set('loop_id', params.loop_id);
   if (params.role)    p.set('role', params.role);
   if (params.status)  p.set('status', params.status);
+  if (params.limit != null) p.set('limit', String(params.limit));
   const qs = p.size ? `?${p.toString()}` : '';
   return get<FeedItem[]>(`/api/feed${qs}`);
 }


### PR DESCRIPTION
Closes #269

## Changes

**`web/src/App.tsx`**
- Added `feedQuery` using `useQuery` with `fetchFeed({ limit: 200 })`, `refetchInterval: 5000`, `staleTime: 0` — same cadence as `activeQuery`
- Replaced the `events` derivation from `activeQuery.data` (active workers) to `feedQuery.data` (timestamped feed items)
- Kept `online` derived from `activeQuery.isError` — connectivity semantics are independent of rate display

**`web/src/lib/api.ts`**
- Added `limit?: number` to `FeedParams` and wired it into the URL query string so `fetchFeed({ limit: 200 })` works correctly

**Root cause:** `activeQuery` polls `/api/active` (currently running workers). When no workers are running this returns an empty array, making `events.length === 0` and `eventsLastMin === 0`. The fix queries `/api/feed` instead, which contains all recent timestamped events. TopBar's existing `eventsLastMin` filter (`Date.now() - e.ts < 60_000`) then correctly computes a non-zero rate when events have arrived in the last minute.

## Test Plan
- Verify TopBar shows a non-zero `N/min` rate when the Activity Feed contains events with `created_at` within the last 60s
- Verify TopBar shows `0/min · 0 events` when the feed is empty or all events are older than 60s
- Verify `total events` count reflects the feed length (up to 200), not active worker count
- Confirm no regression: online/offline indicator still reflects `/api/active` connectivity
- `npm run typecheck` passes
- `npm run build` passes