### PR TITLE
[LM-269] fix TopBar event rate: wire events from feed query instead of active workers

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import Cost from './screens/Cost';
 import Analytics from './screens/Analytics';
 import Timeline from './screens/Timeline';
 import { useHashRoute } from './router';
-import { fetchActive, fetchHealth } from './lib/api';
+import { fetchActive, fetchFeed, fetchHealth } from './lib/api';
 
 const SCREEN_KEYS: Record<string, string> = {
   '1': 'overview',
@@ -85,6 +85,13 @@ export default function App() {
     staleTime: 0,
   });
 
+  const feedQuery = useQuery({
+    queryKey: ['feed'],
+    queryFn: () => fetchFeed({ limit: 200 }),
+    refetchInterval: 5000,
+    staleTime: 0,
+  });
+
   const healthQuery = useQuery({
     queryKey: ['health'],
     queryFn: () => fetchHealth(),
@@ -101,8 +108,8 @@ export default function App() {
     return () => window.removeEventListener('keydown', onKey);
   }, []);
 
-  const events = (activeQuery.data ?? []).map((w) => ({
-    ts: new Date(w.created_at).getTime(),
+  const events = (feedQuery.data ?? []).map((f) => ({
+    ts: new Date(f.created_at).getTime(),
   }));
   const online = !activeQuery.isError;
   const version = healthQuery.data?.monitor_version ?? '…';

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchFeed } from './api';
+
+// Stub window so isFixtureMode() doesn't throw in node env
+beforeEach(() => {
+  vi.stubGlobal('window', { location: { search: '' } });
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve([]),
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// ── fetchFeed limit param ─────────────────────────────────────────────────────
+
+describe('fetchFeed limit param', () => {
+  it('includes limit in query string when provided', async () => {
+    await fetchFeed({ limit: 200 });
+    const url = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(url).toContain('limit=200');
+  });
+
+  it('omits limit from query string when not provided', async () => {
+    await fetchFeed({});
+    const url = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(url).not.toContain('limit');
+  });
+
+  it('omits limit from query string when limit is undefined', async () => {
+    await fetchFeed({ limit: undefined });
+    const url = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(url).not.toContain('limit');
+  });
+
+  it('combines limit with other params correctly', async () => {
+    await fetchFeed({ role: 'dev', limit: 50 });
+    const url = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(url).toContain('role=dev');
+    expect(url).toContain('limit=50');
+  });
+
+  it('calls /api/feed endpoint', async () => {
+    await fetchFeed({});
+    const url = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(url).toBe('/api/feed');
+  });
+
+  it('appends query string when params are present', async () => {
+    await fetchFeed({ limit: 10 });
+    const url = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(url).toBe('/api/feed?limit=10');
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -59,14 +59,16 @@ export interface FeedParams {
   loop_id?: string;
   role?: string;
   status?: string;
+  limit?: number;
 }
 
 export async function fetchFeed(params: FeedParams = {}): Promise<FeedItem[]> {
   if (isFixtureMode()) return fx.getFixtureFeed();
   const p = new URLSearchParams();
-  if (params.loop_id) p.set('loop_id', params.loop_id);
-  if (params.role)    p.set('role', params.role);
-  if (params.status)  p.set('status', params.status);
+  if (params.loop_id)       p.set('loop_id', params.loop_id);
+  if (params.role)          p.set('role', params.role);
+  if (params.status)        p.set('status', params.status);
+  if (params.limit != null) p.set('limit', String(params.limit));
   const qs = p.size ? `?${p.toString()}` : '';
   return get<FeedItem[]>(`/api/feed${qs}`);
 }


### PR DESCRIPTION
Closes #269

## Changes
- `web/src/App.tsx`: Added a `feedQuery` using `useQuery` that calls `fetchFeed({ limit: 200 })` with `refetchInterval: 5000`. Replaced the `events` mapping from `activeQuery.data` (active workers) to `feedQuery.data` (timestamped feed items), so TopBar receives real `created_at` timestamps.
- `web/src/lib/api.ts`: Added optional `limit` field to `FeedParams` interface and wired it into the query string builder so callers can cap the response size.

The `online` indicator continues to derive from `activeQuery.isError` — connectivity semantics are separate from the event rate display.

## Test Plan
- With active events in the last 60s, TopBar should show a non-zero `N/min · N events` count.
- When feed is empty or all events are older than 60s, TopBar shows `0/min · 0 events`.
- `npm run typecheck` and `npm run build` pass locally.