### PR TITLE
[LM-294-295] config-driven fixtures + strip operator absolute paths

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,9 @@ jobs:
       - name: pyright
         run: pyright server/
 
+      - name: No operator-specific names leak into tracked files
+        run: python scripts/check-no-operator-leaks.py
+
   web:
     runs-on: ubuntu-latest
     defaults:

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,10 @@ config/projects.yaml
 
 # Operator-local role vocabulary (see config/roles.yaml.example)
 config/roles.yaml
+
+# Operator-local design-prototype payload (see design/new-design/data.sample.js)
+design/new-design/data.local.js
+
+# Operator-only allow-list for the no-leak check
+scripts/.operator-names.local.txt
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,6 +169,32 @@ is baked into every payload.
 - Any removal or rename of an existing field is a **major API version**
   bump and requires updating the spec in Loop core first.
 
+## Fixture data
+
+Visual harnesses (Storybook, the design prototype, the React app under
+`?fixtures=1`) read from a committed sample file:
+
+- `web/public/fixtures.sample.json` — payload for the React app
+  (`web/src/lib/fixtures.ts` fetches it at module init).
+- `design/new-design/data.sample.js` — payload for the legacy prototype
+  (`design/new-design/data.js` consumes `window.PipelineDataPayload`).
+
+Both files use generic placeholder identifiers (`project-a`, `project-b`,
+…). **Never commit real operator project names back into these files.**
+A CI check (`scripts/check-no-operator-leaks.py`) enforces this by
+grepping the tracked tree against `scripts/.operator-names.local.txt`
+(gitignored — populate locally or via CI secret to activate).
+
+To run the dashboards with your own project names, drop a gitignored
+override beside the sample:
+
+- `web/public/fixtures.local.json` — same schema as the sample; loaded
+  preferentially when present.
+- `design/new-design/data.local.js` — same shape as `data.sample.js`.
+
+Python tests under `tests/` follow the same convention: use
+`project_a`, `project_b`, … (underscores ok in Python).
+
 ## Reporting issues
 
 - Use [GitHub Security Advisories](https://github.com/svv2014/loop-monitor/security/advisories/new)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,39 @@ cp config/projects.yaml.example config/projects.yaml   # then edit
 
 Open http://127.0.0.1:18792.
 
+### Customising fixture data
+
+Screenshots, Storybook, and the design prototype render from a generic fixture
+payload (`web/public/fixtures.sample.json` for the React app,
+`design/new-design/data.sample.js` for the prototype). To use your own project
+names without modifying the repo, drop a sibling override:
+
+- `web/public/fixtures.local.json` — same schema as `fixtures.sample.json`;
+  loaded preferentially at runtime when present.
+- `design/new-design/data.local.js` — assigns `window.PipelineDataPayload` with
+  the same shape as `data.sample.js`.
+
+Both override paths are gitignored. A CI check
+(`scripts/check-no-operator-leaks.py`, configured via
+`scripts/.operator-names.local.txt`) prevents accidental commits of operator
+names back into the tracked tree.
+
+### `scripts/loop-watch.sh` (optional launchd agent)
+
+A bundled launchd plist (`scripts/com.user.loop-watch.plist`) periodically
+runs `loop-watch.sh` for ad-hoc observability. Because the plist needs an
+absolute path to this checkout, it ships with a `{{LOOP_MONITOR_ROOT}}`
+placeholder. Install with:
+
+```bash
+./scripts/install-loop-watch.sh           # auto-detects repo root
+./scripts/install-loop-watch.sh /path/to/loop-monitor   # explicit
+```
+
+The script substitutes the placeholder and copies the result to
+`~/Library/LaunchAgents/`. Unload with
+`launchctl unload ~/Library/LaunchAgents/com.user.loop-watch.plist`.
+
 ## Bring your own pipeline
 
 loop-monitor is wire-compatible with any system that can POST a small JSON payload per stage transition. Three configuration files cover the common reuse cases:

--- a/design/new-design/Pipeline Monitor.html
+++ b/design/new-design/Pipeline Monitor.html
@@ -16,6 +16,8 @@
   <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
   <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
 
+  <script src="data.sample.js"></script>
+  <script>try { document.write('<script src="data.local.js"><\/script>'); } catch (e) {}</script>
   <script src="data.js"></script>
   <script type="text/babel" src="tweaks-panel.jsx"></script>
   <script type="text/babel" src="components.jsx"></script>

--- a/design/new-design/data.js
+++ b/design/new-design/data.js
@@ -3,19 +3,19 @@
 //   events: dev_start, dev_done, po_start, po_done, qa_pass, qa_fail,
 //           review_done, merge_done, judge_done
 //   roles: po, dev, qa, reviewer, merge, judge
+//
+// Project names and worker assignments are loaded from a sibling payload
+// script (data.sample.js — committed, generic; or data.local.js — gitignored)
+// which sets window.PipelineDataPayload. Load order is enforced by the
+// <script> tags in Pipeline Monitor.html.
 
 (function () {
-  const PROJECTS = [
-    { id: 'loop',           color: 'po' },
-    { id: 'loop-monitor',   color: 'dev' },
-    { id: 'boba-event',     color: 'qa' },
-    { id: 'boba-orchestrator', color: 'reviewer' },
-    { id: 'ntc',            color: 'merge' },
-    { id: 'pa-scanner',     color: 'judge' },
-    { id: 'ppl',            color: 'dev' },
-    { id: 'suprun',         color: 'po' },
-    { id: 'vrefm-classifier', color: 'qa' },
-  ];
+  const payload = window.PipelineDataPayload;
+  if (!payload) {
+    throw new Error('PipelineDataPayload missing — load data.sample.js (or data.local.js) before data.js');
+  }
+
+  const PROJECTS = payload.projects;
 
   const ROLES = ['po', 'dev', 'qa', 'reviewer', 'merge', 'judge'];
 
@@ -87,13 +87,18 @@
   }
 
   // Workers — agents currently busy (simulated)
-  const WORKERS_INITIAL = [
-    { id: 'w1', name: 'sonnet-4-6',  agent: 'claude',  model: 'sonnet-4-6',  role: 'dev',      project: 'loop',           task: '#142 implement retry backoff', startedAt: Date.now() - 124_000, status: 'busy' },
-    { id: 'w2', name: 'opus-4-1',    agent: 'claude',  model: 'opus-4-1',    role: 'reviewer', project: 'loop-monitor',   task: '#138 review PR diff',          startedAt: Date.now() - 47_000,  status: 'busy' },
-    { id: 'w3', name: 'gpt-5',       agent: 'gpt',     model: 'gpt-5',       role: 'po',       project: 'ppl',            task: '#150 spec breakdown',          startedAt: Date.now() - 12_000,  status: 'busy' },
-    { id: 'w4', name: 'haiku-4-5',   agent: 'claude',  model: 'haiku-4-5',   role: 'qa',       project: 'vrefm-classifier', task: '#101 run regression suite',  startedAt: Date.now() - 8_000,   status: 'busy' },
-    { id: 'w5', name: 'gemini-2-5',  agent: 'gemini',  model: 'gemini-2-5',  role: 'judge',    project: 'boba-event',     task: '#88 verdict scoring',          startedAt: Date.now() - 2_300,   status: 'busy' },
-  ];
+  const _now = Date.now();
+  const WORKERS_INITIAL = payload.workers.map((w) => ({
+    id: w.id,
+    name: w.name,
+    agent: w.agent,
+    model: w.model,
+    role: w.role,
+    project: w.project,
+    task: w.task,
+    startedAt: _now - w.ageMs,
+    status: 'busy',
+  }));
 
   // Aggregate helpers
   function buildLeaderboard(events, by = 'role') {
@@ -162,18 +167,7 @@
         project: p.id,
         role,
         issue_num: randInt(20, 200),
-        title: pick([
-          'rate-limit handler exceeds budget',
-          'flaky test in pipeline_runs',
-          'spec drift on /api/report v1.2',
-          'judge gives low verdict on small diffs',
-          'memory leak in event ingest loop',
-          'queue starvation under burst load',
-          'webhook timeout retries unbounded',
-          'leaderboard ranks tied agents wrong',
-          'duplicate events from boba-orchestrator',
-          'missing duration on judge_done',
-        ]),
+        title: pick(payload.queueTitles),
         priority: pick(PRIORITIES),
         waiting_ms: randInt(60_000, 6 * 60 * 60 * 1000),
         attempts: randInt(0, 2),

--- a/design/new-design/data.sample.js
+++ b/design/new-design/data.sample.js
@@ -1,0 +1,31 @@
+// Generic placeholder payload for the design prototype.
+// See data.js for how this is loaded. Operators can create data.local.js
+// (gitignored) exporting the same `window.PipelineDataPayload` shape to
+// render the prototype with private project names.
+window.PipelineDataPayload = {
+  projects: [
+    { id: 'project-a', color: 'po' },
+    { id: 'project-b', color: 'dev' },
+    { id: 'project-c', color: 'qa' },
+    { id: 'project-d', color: 'reviewer' },
+  ],
+  workers: [
+    { id: 'w1', name: 'sonnet-4-6', agent: 'claude', model: 'sonnet-4-6', role: 'dev',      project: 'project-a', task: '#142 implement retry backoff', ageMs: 124_000 },
+    { id: 'w2', name: 'opus-4-1',   agent: 'claude', model: 'opus-4-1',   role: 'reviewer', project: 'project-b', task: '#138 review PR diff',          ageMs: 47_000 },
+    { id: 'w3', name: 'gpt-5',      agent: 'gpt',    model: 'gpt-5',      role: 'po',       project: 'project-c', task: '#150 spec breakdown',          ageMs: 12_000 },
+    { id: 'w4', name: 'haiku-4-5',  agent: 'claude', model: 'haiku-4-5',  role: 'qa',       project: 'project-d', task: '#101 run regression suite',    ageMs: 8_000 },
+    { id: 'w5', name: 'gemini-2-5', agent: 'gemini', model: 'gemini-2-5', role: 'judge',    project: 'project-a', task: '#88 verdict scoring',          ageMs: 2_300 },
+  ],
+  queueTitles: [
+    'rate-limit handler exceeds budget',
+    'flaky test in pipeline_runs',
+    'spec drift on /api/report v1.2',
+    'judge gives low verdict on small diffs',
+    'memory leak in event ingest loop',
+    'queue starvation under burst load',
+    'webhook timeout retries unbounded',
+    'leaderboard ranks tied agents wrong',
+    'duplicate events from project-b',
+    'missing duration on judge_done',
+  ],
+};

--- a/scripts/check-no-operator-leaks.py
+++ b/scripts/check-no-operator-leaks.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Fail if any operator-specific project/identity name appears in tracked files.
+
+The list of names to forbid lives in scripts/.operator-names.local.txt
+(gitignored). One name per line; blank lines and `#` comments are ignored.
+The committed default list is empty so the check is a no-op until an operator
+populates it locally / in CI secrets.
+
+CHANGELOG.md is exempt (historical references are allowed to stand).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+NAMES_FILE = ROOT / "scripts" / ".operator-names.local.txt"
+EXEMPT = {"CHANGELOG.md"}
+
+
+def load_names() -> list[str]:
+    if not NAMES_FILE.exists():
+        return []
+    out: list[str] = []
+    for line in NAMES_FILE.read_text().splitlines():
+        s = line.strip()
+        if not s or s.startswith("#"):
+            continue
+        out.append(s)
+    return out
+
+
+def tracked_files() -> list[str]:
+    res = subprocess.run(
+        ["git", "ls-files"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [p for p in res.stdout.splitlines() if p and p not in EXEMPT]
+
+
+def main() -> int:
+    names = load_names()
+    if not names:
+        print("check-no-operator-leaks: no names configured (scripts/.operator-names.local.txt empty or missing) — skipping")
+        return 0
+
+    files = tracked_files()
+    hits: list[tuple[str, str, int, str]] = []
+    for path in files:
+        abs_path = ROOT / path
+        if not abs_path.is_file():
+            continue
+        try:
+            content = abs_path.read_text(errors="replace")
+        except OSError:
+            continue
+        for lineno, line in enumerate(content.splitlines(), start=1):
+            for name in names:
+                if name in line:
+                    hits.append((path, name, lineno, line.strip()))
+
+    if hits:
+        print("check-no-operator-leaks: FAIL — operator-specific names found in tracked files:", file=sys.stderr)
+        for path, name, lineno, snippet in hits:
+            print(f"  {path}:{lineno}  [{name}]  {snippet[:120]}", file=sys.stderr)
+        return 1
+
+    print(f"check-no-operator-leaks: OK ({len(names)} name(s) checked across {len(files)} files)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-version.sh
+++ b/scripts/check-version.sh
@@ -5,7 +5,7 @@
 # Example launchd key: <key>StartInterval</key><integer>3600</integer>
 set -euo pipefail
 
-LOOP_ROOT="${LOOP_ROOT:-/Users/vadim/.openclaw/workspace/projects/loop}"
+LOOP_ROOT="${LOOP_ROOT:-$(cd "$(dirname "$0")/../../loop" 2>/dev/null && pwd)}"
 LOOP_ENV="$LOOP_ROOT/loop.env"
 [[ -f "$LOOP_ENV" ]] && source "$LOOP_ENV"
 

--- a/scripts/com.user.loop-watch.plist
+++ b/scripts/com.user.loop-watch.plist
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   loop-watch — temporary observability for the Loop pipeline.
-  Install:  cp scripts/com.user.loop-watch.plist ~/Library/LaunchAgents/
-            launchctl load ~/Library/LaunchAgents/com.user.loop-watch.plist
+  This is a TEMPLATE — {{LOOP_MONITOR_ROOT}} must be substituted before
+  installing. Use scripts/install-loop-watch.sh which sed-substitutes and
+  installs the rendered plist into ~/Library/LaunchAgents/.
   Disable:  launchctl unload ~/Library/LaunchAgents/com.user.loop-watch.plist
 -->
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -13,7 +14,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/vadim/.openclaw/workspace/projects/loop-monitor/scripts/loop-watch.sh</string>
+        <string>{{LOOP_MONITOR_ROOT}}/scripts/loop-watch.sh</string>
     </array>
 
     <key>StartInterval</key>

--- a/scripts/install-loop-watch.sh
+++ b/scripts/install-loop-watch.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# install-loop-watch.sh — render com.user.loop-watch.plist with the absolute
+# path to this checkout and install it into ~/Library/LaunchAgents/.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [[ $# -ge 1 ]]; then
+    MONITOR_ROOT="$(cd "$1" && pwd)"
+else
+    MONITOR_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
+TEMPLATE="$SCRIPT_DIR/com.user.loop-watch.plist"
+DEST_DIR="$HOME/Library/LaunchAgents"
+DEST="$DEST_DIR/com.user.loop-watch.plist"
+
+mkdir -p "$DEST_DIR"
+
+# sed -i differs between macOS and GNU; write to a temp file and move.
+tmp="$(mktemp)"
+sed "s|{{LOOP_MONITOR_ROOT}}|$MONITOR_ROOT|g" "$TEMPLATE" > "$tmp"
+mv "$tmp" "$DEST"
+
+launchctl unload "$DEST" 2>/dev/null || true
+launchctl load "$DEST"
+
+echo "Installed $DEST"

--- a/tests/test_action_queue.py
+++ b/tests/test_action_queue.py
@@ -13,16 +13,18 @@ def test_action_queue_empty(isolated_client):
     assert resp.json() == []
 
 
-def test_action_queue_blocked_label(isolated_client):
+def test_action_queue_blocked_label(isolated_client, monkeypatch):
+    from server.routes import action_queue as aq_module
+    monkeypatch.setitem(aq_module.PROJECTS, "project_a", "example-org/project-a")
     server._insert_event(server.ReportPayload(
-        project="boba-event", role="dev", event_type="blocked", issue_number=42,
+        project="project_a", role="dev", event_type="blocked", issue_number=42,
         detail="needs human"
     ))
     resp = isolated_client.get("/api/action_queue")
     assert resp.status_code == 200
     data = resp.json()
     assert len(data) == 1
-    assert data[0]["project"] == "boba-event"
+    assert data[0]["project"] == "project_a"
     assert data[0]["kind"] == "issue"
     assert data[0]["number"] == 42
     assert data[0]["stage"] == "blocked"
@@ -259,12 +261,12 @@ def test_infer_label_transition_loop_active_dev_timeout(isolated_client, monkeyp
 # ── Failure-context endpoint ──────────────────────────────────────────────────
 
 _COMMENT_WITH_MARKER = json.dumps({
-    "excerpt": "ModuleNotFoundError: No module named 'boba_orchestrator'",
+    "excerpt": "ModuleNotFoundError: No module named 'project_b'",
     "model": "claude-opus-4-5",
     "run_id": "run-abc123",
     "retry_count": 2,
     "timestamp": "2026-05-02T14:30:00Z",
-    "log_path": "/var/log/loop/boba-orchestrator.log",
+    "log_path": "/var/log/loop/project-b.log",
 })
 
 _GH_COMMENT_BODY = (
@@ -315,12 +317,12 @@ def test_failure_endpoint_with_marker(isolated_client, monkeypatch):
 
     assert resp.status_code == 200
     data = resp.json()
-    assert data["excerpt"] == "ModuleNotFoundError: No module named 'boba_orchestrator'"
+    assert data["excerpt"] == "ModuleNotFoundError: No module named 'project_b'"
     assert data["model"] == "claude-opus-4-5"
     assert data["run_id"] == "run-abc123"
     assert data["retry_count"] == 2
     assert data["timestamp"] == "2026-05-02T14:30:00Z"
-    assert data["log_path"] == "/var/log/loop/boba-orchestrator.log"
+    assert data["log_path"] == "/var/log/loop/project-b.log"
     assert data["github_comment_url"] == "https://gh/c/2"
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,19 +1,18 @@
 from scripts.dashboard import (
+    _box_bot,
+    _box_row,
+    _box_sep,
+    _box_top,
+    _center_padded,
     _since,
     _strip_ansi,
-    _box_top,
-    _box_bot,
-    _box_sep,
-    _box_row,
-    _center_padded,
     render_banner,
     render_cards,
     render_feed,
     render_leaderboard,
-    render_verdict,
     render_simple,
+    render_verdict,
 )
-
 
 # ── _since (unchanged helper) ─────────────────────────────────────────────────
 
@@ -186,7 +185,7 @@ def test_render_feed_respects_limit():
     events = [{"role": "tester", "event_type": "test_done", "age_seconds": i}
               for i in range(10)]
     lines = render_feed(events, col_width=60, limit=3)
-    event_lines = [l for l in lines if "•" in l]
+    event_lines = [line for line in lines if "•" in line]
     assert len(event_lines) == 3
 
 
@@ -214,7 +213,7 @@ def test_render_leaderboard_shows_ranks():
 def test_render_leaderboard_limit():
     board = [{"role": f"r{i}", "total_points": i} for i in range(10)]
     lines = render_leaderboard(board, col_width=30, limit=5)
-    rank_lines = [l for l in lines if l.strip().startswith(tuple("123456789"))]
+    rank_lines = [line for line in lines if line.strip().startswith(tuple("123456789"))]
     assert len(rank_lines) == 5
 
 

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -29,18 +29,18 @@ def test_literal_filter_matches(monkeypatch, tmp_path):
     _patch_logdir(monkeypatch, tmp_path)
     log = tmp_path / "loop-scanner.log"
     log.write_text(
-        "[2026-05-02 10:00:00] [scanner] hello pa-scanner\n"
+        "[2026-05-02 10:00:00] [scanner] hello project_c\n"
         "[2026-05-02 10:00:01] [scanner] unrelated event\n"
-        "[2026-05-02 10:00:02] [scanner] another pa-scanner line\n"
+        "[2026-05-02 10:00:02] [scanner] another project_c line\n"
     )
     with patch.object(logs_module, "_fd_bytes_for_handler", return_value=None):
         resp = client.get(
-            "/api/logs", params={"handler": "scanner", "filter": "pa-scanner", "tail": "200"}
+            "/api/logs", params={"handler": "scanner", "filter": "project_c", "tail": "200"}
         )
     assert resp.status_code == 200
     body = resp.json()
     assert len(body["lines"]) == 2
-    assert all("pa-scanner" in line["raw"] for line in body["lines"])
+    assert all("project_c" in line["raw"] for line in body["lines"])
     assert body["lines"][0]["ts"] == "2026-05-02 10:00:00"
     assert body["lines"][0]["handler"] == "scanner"
 

--- a/tests/visual/test_project_detail.py
+++ b/tests/visual/test_project_detail.py
@@ -14,7 +14,12 @@ import pathlib
 import pytest
 
 REFERENCE_DIR = pathlib.Path(__file__).parents[2] / "design" / "reference-screenshots"
-FIXTURE_PROJECT = os.getenv("LM_FIXTURE_PROJECT", "svv2014/loop-monitor")
+FIXTURE_PROJECT = os.getenv("LM_FIXTURE_PROJECT")
+if not FIXTURE_PROJECT:
+    pytest.skip(
+        "LM_FIXTURE_PROJECT is not set — skipping operator-specific visual snapshots",
+        allow_module_level=True,
+    )
 DIFF_THRESHOLD = 0.005  # 0.5 %
 
 

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,4 @@
+# Local fixture override — operators drop a customised payload here to render
+# screenshots / Storybook with private project names without modifying the
+# repo. See web/public/fixtures.sample.json for the schema.
+public/fixtures.local.json

--- a/web/public/fixtures.sample.json
+++ b/web/public/fixtures.sample.json
@@ -1,0 +1,27 @@
+{
+  "projects": [
+    { "id": "project-a", "repo": "example-org/project-a", "color": "po" },
+    { "id": "project-b", "repo": "example-org/project-b", "color": "dev" },
+    { "id": "project-c", "repo": "example-org/project-c", "color": "qa" },
+    { "id": "project-d", "repo": "example-org/project-d", "color": "reviewer" }
+  ],
+  "workers": [
+    { "project": "project-a", "role": "dev",      "model": "sonnet-4-6", "event_type": "dev_start",   "issue_number": 142, "pr_number": null, "detail": "#142 implement retry backoff", "age_seconds": 124 },
+    { "project": "project-b", "role": "reviewer", "model": "opus-4-1",   "event_type": "review_start","issue_number": 138, "pr_number": 138,  "detail": "#138 review PR diff",          "age_seconds": 47 },
+    { "project": "project-c", "role": "po",       "model": "gpt-5",      "event_type": "po_start",    "issue_number": 150, "pr_number": null, "detail": "#150 spec breakdown",          "age_seconds": 12 },
+    { "project": "project-d", "role": "qa",       "model": "haiku-4-5",  "event_type": "qa_start",    "issue_number": 101, "pr_number": null, "detail": "#101 run regression suite",    "age_seconds": 8 },
+    { "project": "project-a", "role": "judge",    "model": "gemini-2-5", "event_type": "judge_start", "issue_number": 88,  "pr_number": null, "detail": "#88 verdict scoring",          "age_seconds": 2 }
+  ],
+  "queueTitles": [
+    "rate-limit handler exceeds budget",
+    "flaky test in pipeline_runs",
+    "spec drift on /api/report v1.2",
+    "judge gives low verdict on small diffs",
+    "memory leak in event ingest loop",
+    "queue starvation under burst load",
+    "webhook timeout retries unbounded",
+    "leaderboard ranks tied agents wrong",
+    "duplicate events from project-b",
+    "missing duration on judge_done"
+  ]
+}

--- a/web/src/lib/fixtures.ts
+++ b/web/src/lib/fixtures.ts
@@ -1,6 +1,12 @@
 // Deterministic fixture data ported verbatim from design/new-design/data.js.
 // Same LCG seed (0xC0FFEE) and constants ensure byte-identical output across
 // runs — required by the Phase 0 visual-diff harness.
+//
+// Operator-specific project names are not baked into this file. The fixture
+// payload is loaded at module-init time from /fixtures.local.json (preferred,
+// gitignored) or /fixtures.sample.json (committed, generic placeholder data).
+// Operators can drop a fixtures.local.json into web/public/ to customise the
+// screenshot/Storybook data without touching the repo.
 import type {
   Worker,
   BoardEntry,
@@ -22,20 +28,69 @@ import type {
   IssueCostRow,
 } from './types';
 
-// Fixture data — example projects used for screenshots / Storybook / tests.
-// Not the runtime registry. The runtime project list comes from the server's
-// /api/* endpoints, populated from config/projects.yaml.
-const PROJECTS = [
-  { id: 'web-app',         repo: 'example-org/web-app' },
-  { id: 'api-server',      repo: 'example-org/api-server' },
-  { id: 'cli-tool',        repo: 'example-org/cli-tool' },
-  { id: 'docs-site',       repo: 'example-org/docs-site' },
-  { id: 'ml-pipeline',     repo: 'example-org/ml-pipeline' },
-  { id: 'mobile-app',      repo: 'example-org/mobile-app' },
-  { id: 'data-scraper',    repo: 'example-org/data-scraper' },
-  { id: 'analytics',       repo: 'example-org/analytics' },
-  { id: 'auth-service',    repo: 'example-org/auth-service' },
-] as const;
+interface FixtureProject { id: string; repo: string; color?: string }
+interface FixtureWorkerInit {
+  project: string;
+  role: string;
+  model: string;
+  event_type: string;
+  issue_number: number;
+  pr_number: number | null;
+  detail: string;
+  age_seconds: number;
+}
+interface FixturePayload {
+  projects: FixtureProject[];
+  workers: FixtureWorkerInit[];
+  queueTitles: string[];
+}
+
+// Embedded fallback — used when fetch() is unavailable (e.g. node/test envs)
+// or when neither fixtures.local.json nor fixtures.sample.json can be loaded.
+// Kept in sync with web/public/fixtures.sample.json.
+const FALLBACK_PAYLOAD: FixturePayload = {
+  projects: [
+    { id: 'project-a', repo: 'example-org/project-a', color: 'po' },
+    { id: 'project-b', repo: 'example-org/project-b', color: 'dev' },
+    { id: 'project-c', repo: 'example-org/project-c', color: 'qa' },
+    { id: 'project-d', repo: 'example-org/project-d', color: 'reviewer' },
+  ],
+  workers: [
+    { project: 'project-a', role: 'dev',      model: 'sonnet-4-6', event_type: 'dev_start',    issue_number: 142, pr_number: null, detail: '#142 implement retry backoff', age_seconds: 124 },
+    { project: 'project-b', role: 'reviewer', model: 'opus-4-1',   event_type: 'review_start', issue_number: 138, pr_number: 138,  detail: '#138 review PR diff',          age_seconds: 47 },
+    { project: 'project-c', role: 'po',       model: 'gpt-5',      event_type: 'po_start',     issue_number: 150, pr_number: null, detail: '#150 spec breakdown',          age_seconds: 12 },
+    { project: 'project-d', role: 'qa',       model: 'haiku-4-5',  event_type: 'qa_start',     issue_number: 101, pr_number: null, detail: '#101 run regression suite',    age_seconds: 8 },
+    { project: 'project-a', role: 'judge',    model: 'gemini-2-5', event_type: 'judge_start',  issue_number: 88,  pr_number: null, detail: '#88 verdict scoring',          age_seconds: 2 },
+  ],
+  queueTitles: [
+    'rate-limit handler exceeds budget',
+    'flaky test in pipeline_runs',
+    'spec drift on /api/report v1.2',
+    'judge gives low verdict on small diffs',
+    'memory leak in event ingest loop',
+    'queue starvation under burst load',
+    'webhook timeout retries unbounded',
+    'leaderboard ranks tied agents wrong',
+    'duplicate events from project-b',
+    'missing duration on judge_done',
+  ],
+};
+
+async function loadPayload(): Promise<FixturePayload> {
+  if (typeof fetch !== 'function') return FALLBACK_PAYLOAD;
+  for (const url of ['/fixtures.local.json', '/fixtures.sample.json']) {
+    try {
+      const r = await fetch(url);
+      if (r.ok) return (await r.json()) as FixturePayload;
+    } catch {
+      // ignore and try next
+    }
+  }
+  return FALLBACK_PAYLOAD;
+}
+
+const PAYLOAD: FixturePayload = await loadPayload();
+const PROJECTS: readonly FixtureProject[] = PAYLOAD.projects;
 
 const ROLES = ['po', 'dev', 'qa', 'reviewer', 'merge', 'judge'] as const;
 
@@ -114,13 +169,16 @@ function buildHistory(): RawEvent[] {
 resetSeed();
 const HISTORY = buildHistory();
 
-const WORKERS_INITIAL: Worker[] = [
-  { project: 'loop',             role: 'dev',      model: 'sonnet-4-6', event_type: 'dev_start',    issue_number: 142, pr_number: null, detail: '#142 implement retry backoff', created_at: new Date(Date.now() - 124_000).toISOString() },
-  { project: 'loop-monitor',     role: 'reviewer', model: 'opus-4-1',   event_type: 'review_start',  issue_number: 138, pr_number: 138,  detail: '#138 review PR diff',          created_at: new Date(Date.now() - 47_000).toISOString() },
-  { project: 'ppl',              role: 'po',       model: 'gpt-5',      event_type: 'po_start',      issue_number: 150, pr_number: null, detail: '#150 spec breakdown',          created_at: new Date(Date.now() - 12_000).toISOString() },
-  { project: 'vrefm-classifier', role: 'qa',       model: 'haiku-4-5',  event_type: 'qa_start',      issue_number: 101, pr_number: null, detail: '#101 run regression suite',    created_at: new Date(Date.now() - 8_000).toISOString() },
-  { project: 'boba-event',       role: 'judge',    model: 'gemini-2-5', event_type: 'judge_start',   issue_number: 88,  pr_number: null, detail: '#88 verdict scoring',          created_at: new Date(Date.now() - 2_300).toISOString() },
-];
+const WORKERS_INITIAL: Worker[] = PAYLOAD.workers.map((w) => ({
+  project: w.project,
+  role: w.role,
+  model: w.model,
+  event_type: w.event_type,
+  issue_number: w.issue_number,
+  pr_number: w.pr_number,
+  detail: w.detail,
+  created_at: new Date(Date.now() - w.age_seconds * 1000).toISOString(),
+}));
 
 export function getFixtureActive(): Worker[] {
   return WORKERS_INITIAL;
@@ -217,18 +275,7 @@ const QUEUE_REASONS = ['stuck_label', 'timeout', 'qa_fail_repeated'] as const;
 
 export function getFixtureActionQueue(): QueueItem[] {
   resetSeed();
-  const TITLES = [
-    'rate-limit handler exceeds budget',
-    'flaky test in pipeline_runs',
-    'spec drift on /api/report v1.2',
-    'judge gives low verdict on small diffs',
-    'memory leak in event ingest loop',
-    'queue starvation under burst load',
-    'webhook timeout retries unbounded',
-    'leaderboard ranks tied agents wrong',
-    'duplicate events from boba-orchestrator',
-    'missing duration on judge_done',
-  ] as const;
+  const TITLES = PAYLOAD.queueTitles;
   return Array.from({ length: 18 }, (_, i) => {
     const p = pick(PROJECTS);
     return {
@@ -374,8 +421,8 @@ export function getFixtureScannerState(): ScannerState {
       merge:    { in_flight: 0, cap: 2 },
     },
     retries: [
-      { project: 'loop-monitor', kind: 'issue', number: 137, stage: 'po',  count: 1, max: 2 },
-      { project: 'loop',         kind: 'issue', number: 142, stage: 'dev', count: 2, max: 2 },
+      { project: 'project-b', kind: 'issue', number: 137, stage: 'po',  count: 1, max: 2 },
+      { project: 'project-a', kind: 'issue', number: 142, stage: 'dev', count: 2, max: 2 },
     ],
   };
 }

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
   build: {
     outDir: '../static/dist',
     emptyOutDir: true,
+    // ES2022 → top-level await is supported (used by src/lib/fixtures.ts to
+    // load the fixture payload at module init).
+    target: 'es2022',
   },
   server: {
     proxy: {


### PR DESCRIPTION
Closes #294. Closes #295.

## Summary
- **#294** — fixtures and project slugs no longer bake operator-specific names into the repo. Added `web/public/fixtures.sample.json` (generic payload, project-a..d) loaded at module init by `fixtures.ts`, with `fixtures.local.json` as a gitignored override. Same pattern for the design prototype (`data.sample.js` / `data.local.js`). Test fixtures renamed to `project_a/b/c`. New `scripts/check-no-operator-leaks.py` is wired into the lint workflow and fails fast on any name in the gitignored `scripts/.operator-names.local.txt`.
- **#295** — `scripts/check-version.sh` resolves `LOOP_ROOT` relatively; `scripts/com.user.loop-watch.plist` ships as a `{{LOOP_MONITOR_ROOT}}` template with a new `scripts/install-loop-watch.sh` renderer; `tests/visual/test_project_detail.py` skips when `LM_FIXTURE_PROJECT` is unset instead of defaulting to an operator-owned slug.

## Test plan
- [x] `pytest tests/ -q --ignore=tests/visual` — passes (pre-existing test_health failure unrelated, depends on `static/dist`).
- [x] `cd web && npm run typecheck && npm run build` — clean.
- [x] `bash -n` clean on changed shell files.
- [x] `git grep -E 'boba-event|boba-orchestrator|pa-scanner|vrefm-classifier|suprun|ppl-study|NanoTraderCopilot|boba-memory|boba-reconcile'` returns 0 hits outside CHANGELOG.md.
- [x] `git grep '/Users/vadim'` returns 0 hits in tracked files outside CHANGELOG.md.
- [x] `python3 scripts/check-no-operator-leaks.py` — exits 0 (default empty list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)