### PR TITLE
[LM-214] restore clickable #N issue/PR refs on Overview, NowStrip, ActivityFeed, ProjectDetail

### DIFF
--- a/server/routes/feed.py
+++ b/server/routes/feed.py
@@ -5,10 +5,22 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends
 
+from server.constants import PROJECTS
 from server.db import db_dep
 from server.helpers.event_mapping import remap_legacy_judge_event
 
 router = APIRouter()
+
+
+def _github_url(project: str, issue_number: Optional[int], pr_number: Optional[int]) -> Optional[str]:
+    repo = PROJECTS.get(project)
+    if not repo:
+        return None
+    if issue_number is not None:
+        return f"https://github.com/{repo}/issues/{issue_number}"
+    if pr_number is not None:
+        return f"https://github.com/{repo}/pull/{pr_number}"
+    return None
 
 
 @router.get("/api/history")
@@ -56,7 +68,12 @@ def history(limit: int = 50, loop_id: Optional[str] = None, conn: sqlite3.Connec
         ORDER BY d.id DESC
         LIMIT ?
     """, params).fetchall()
-    return [remap_legacy_judge_event(dict(r)) for r in rows]
+    result = []
+    for r in rows:
+        entry = remap_legacy_judge_event(dict(r))
+        entry["github_url"] = _github_url(entry["project"], entry.get("issue_number"), entry.get("pr_number"))
+        result.append(entry)
+    return result
 
 
 @router.get("/api/active")
@@ -150,6 +167,7 @@ def feed(
         except Exception:
             entry["age_seconds"] = None
         entry["status"] = _derive_status(entry["event_type"])
+        entry["github_url"] = _github_url(entry["project"], entry.get("issue_number"), entry.get("pr_number"))
         result.append(entry)
     return result
 

--- a/tests/test_feed_github_url.py
+++ b/tests/test_feed_github_url.py
@@ -6,7 +6,6 @@ import server
 import server.db
 from server.routes.feed import _github_url
 
-
 # --- Unit tests for _github_url helper ---
 
 def test_github_url_issue_number():

--- a/tests/test_feed_github_url.py
+++ b/tests/test_feed_github_url.py
@@ -1,0 +1,102 @@
+"""QA-driven tests for PR #297 — _github_url helper and github_url in feed/history."""
+import sqlite3
+from unittest.mock import patch
+
+import server
+import server.db
+from server.routes.feed import _github_url
+
+
+# --- Unit tests for _github_url helper ---
+
+def test_github_url_issue_number():
+    with patch("server.routes.feed.PROJECTS", {"myproj": "owner/repo"}):
+        result = _github_url("myproj", issue_number=42, pr_number=None)
+    assert result == "https://github.com/owner/repo/issues/42"
+
+
+def test_github_url_pr_number():
+    with patch("server.routes.feed.PROJECTS", {"myproj": "owner/repo"}):
+        result = _github_url("myproj", issue_number=None, pr_number=7)
+    assert result == "https://github.com/owner/repo/pull/7"
+
+
+def test_github_url_issue_takes_priority_over_pr():
+    with patch("server.routes.feed.PROJECTS", {"myproj": "owner/repo"}):
+        result = _github_url("myproj", issue_number=1, pr_number=2)
+    assert result == "https://github.com/owner/repo/issues/1"
+
+
+def test_github_url_no_numbers_returns_none():
+    with patch("server.routes.feed.PROJECTS", {"myproj": "owner/repo"}):
+        result = _github_url("myproj", issue_number=None, pr_number=None)
+    assert result is None
+
+
+def test_github_url_unknown_project_returns_none():
+    with patch("server.routes.feed.PROJECTS", {}):
+        result = _github_url("unknown-proj", issue_number=5, pr_number=None)
+    assert result is None
+
+
+# --- Integration tests: github_url present on feed and history endpoints ---
+
+def test_feed_includes_github_url_field(isolated_client):
+    server._insert_event(server.ReportPayload(
+        project="proj-gurl", role="dev", event_type="dev_done"
+    ))
+    resp = isolated_client.get("/api/feed")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) >= 1
+    item = next((i for i in data if i["project"] == "proj-gurl"), None)
+    assert item is not None
+    assert "github_url" in item
+
+
+def test_feed_github_url_is_none_when_no_project_config(isolated_client):
+    """Events for projects not in PROJECTS config get github_url=null."""
+    with patch("server.routes.feed.PROJECTS", {}):
+        server._insert_event(server.ReportPayload(
+            project="unregistered-proj", role="dev", event_type="dev_done"
+        ))
+        resp = isolated_client.get("/api/feed")
+    assert resp.status_code == 200
+    data = resp.json()
+    item = next((i for i in data if i["project"] == "unregistered-proj"), None)
+    assert item is not None
+    assert item["github_url"] is None
+
+
+def test_feed_github_url_populated_when_issue_number_and_project_known(isolated_client, monkeypatch):
+    monkeypatch.setattr("server.routes.feed.PROJECTS", {"proj-linked": "myorg/myrepo"})
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        "INSERT INTO events (project, role, event_type, issue_number, created_at) "
+        "VALUES (?, ?, ?, ?, datetime('now'))",
+        ("proj-linked", "dev", "dev_done", 99),
+    )
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/feed")
+    assert resp.status_code == 200
+    item = next((i for i in resp.json() if i["project"] == "proj-linked"), None)
+    assert item is not None
+    assert item["github_url"] == "https://github.com/myorg/myrepo/issues/99"
+
+
+def test_history_includes_github_url_field(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        "INSERT INTO events (project, role, event_type, issue_number, created_at) "
+        "VALUES (?, ?, ?, ?, datetime('now'))",
+        ("proj-hist-url", "dev", "dev_done", None),
+    )
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/history")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert all("github_url" in i for i in data)

--- a/web/src/components/IssueRef.tsx
+++ b/web/src/components/IssueRef.tsx
@@ -1,0 +1,28 @@
+interface IssueRefProps {
+  number: number;
+  url?: string | null;
+}
+
+export default function IssueRef({ number, url }: IssueRefProps) {
+  if (url) {
+    return (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mono"
+        style={{
+          fontSize: 'inherit',
+          color: 'var(--fg-3)',
+          textDecoration: 'none',
+          cursor: 'pointer',
+        }}
+        onMouseEnter={e => (e.currentTarget.style.textDecoration = 'underline')}
+        onMouseLeave={e => (e.currentTarget.style.textDecoration = 'none')}
+      >
+        #{number}
+      </a>
+    );
+  }
+  return <span className="mono">#{number}</span>;
+}

--- a/web/src/lib/fixtures.ts
+++ b/web/src/lib/fixtures.ts
@@ -222,6 +222,7 @@ export function getFixtureFeed(): FeedItem[] {
     created_at: e.created_at,
     age_seconds: Math.floor((Date.now() - e.ts) / 1000),
     status: e.event_type.endsWith('_fail') ? 'fail' : e.event_type.endsWith('_pass') ? 'pass' : 'done',
+    github_url: null,
   }));
 }
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -43,6 +43,7 @@ export interface FeedItem {
   created_at: string;
   age_seconds: number | null;
   status: string;
+  github_url: string | null;
 }
 
 export interface LoopEvent {
@@ -59,6 +60,7 @@ export interface LoopEvent {
   started_at?: string | null;
   duration_seconds?: number | null;
   points?: number | null;
+  github_url?: string | null;
 }
 
 export interface StatusEntry {

--- a/web/src/panels/ActivityFeed.tsx
+++ b/web/src/panels/ActivityFeed.tsx
@@ -4,6 +4,7 @@ import { relTime } from '../lib/utils';
 import RoleTag from '../components/RoleTag';
 import EventGlyph from '../components/EventGlyph';
 import { useRoleIds } from '../lib/useRoles';
+import IssueRef from '../components/IssueRef';
 
 interface ActivityFeedProps {
   events: FeedItem[];
@@ -48,7 +49,9 @@ export default function ActivityFeed({ events }: ActivityFeedProps) {
                   <span className="mono" style={{ fontSize: 12 }}>{e.event_type}</span>
                   <span className="muted mono" style={{ fontSize: 11 }}>
                     · {e.project}
-                    {e.issue_number != null ? `#${e.issue_number}` : ''}
+                    {e.issue_number != null && (
+                      <IssueRef number={e.issue_number} url={e.github_url} />
+                    )}
                   </span>
                 </div>
                 <div className="muted" style={{ fontSize: 11, marginTop: 2 }}>

--- a/web/src/panels/NowStrip.tsx
+++ b/web/src/panels/NowStrip.tsx
@@ -1,6 +1,7 @@
 import type { Worker, FeedItem } from '../lib/types';
 import { relTime, durationFmt, absoluteUtc, useTick } from '../lib/utils';
 import EventGlyph from '../components/EventGlyph';
+import IssueRef from '../components/IssueRef';
 
 interface NowStripProps {
   workers: Worker[];
@@ -39,7 +40,9 @@ export default function NowStrip({ workers, events }: NowStripProps) {
               <span className="muted">·</span>
               <span className="muted mono">
                 {lastEvent.project}
-                {lastEvent.issue_number != null ? `#${lastEvent.issue_number}` : ''}
+                {lastEvent.issue_number != null && (
+                  <IssueRef number={lastEvent.issue_number} url={lastEvent.github_url} />
+                )}
               </span>
               <span className="muted">·</span>
               <span className="muted" title={absoluteUtc(lastTs) + ' (' + relTime(lastTs) + ')'}>{relTime(lastTs)}</span>

--- a/web/src/screens/Overview.tsx
+++ b/web/src/screens/Overview.tsx
@@ -15,6 +15,7 @@ import { relTime, durationFmt, matchesProjectFilter, parseServerTs } from '../li
 import Charts from '../panels/Charts';
 import ClaudeUsage from '../panels/ClaudeUsage';
 import { useRoleIds } from '../lib/useRoles';
+import IssueRef from '../components/IssueRef';
 
 const COMPLETED_TYPES = new Set([
   'merge_done', 'judge_done', 'review_done', 'dev_done', 'po_done',
@@ -159,7 +160,9 @@ export default function Overview({ globalProjectFilter }: OverviewProps) {
                       </div>
                       <div className="muted mono" style={{ fontSize: 11, marginTop: 2 }}>
                         {e.event_type}
-                        {e.issue_number != null ? ` · #${e.issue_number}` : ''}
+                        {e.issue_number != null && (
+                          <> · <IssueRef number={e.issue_number} url={e.github_url} /></>
+                        )}
                         {durMs > 0 ? ` · ${durationFmt(durMs)}` : ''}
                       </div>
                     </div>

--- a/web/src/screens/ProjectDetail.tsx
+++ b/web/src/screens/ProjectDetail.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import PrMonitorTable from '../components/PrMonitorTable';
+import IssueRef from '../components/IssueRef';
 import type { Worker, FeedItem, PipelineRun, PRMonitorEntry, CycleTimesResponse, SloConfig } from '../lib/types';
 import { fetchCycleTimes, fetchSlo } from '../lib/api';
 
@@ -443,7 +444,9 @@ export default function ProjectDetail({ projectId, allProjectIds, onBack, onProj
                     </span>
                     <span className="mono">{e.event_type}</span>
                     {e.issue_number != null && (
-                      <span className="muted mono" style={{ fontSize: 11 }}>· #{e.issue_number}</span>
+                      <span className="muted mono" style={{ fontSize: 11 }}>
+                        · <IssueRef number={e.issue_number} url={e.github_url} />
+                      </span>
                     )}
                     {e.model && (
                       <span className="muted mono" style={{ fontSize: 11 }}>· {e.model}</span>


### PR DESCRIPTION
Closes #214

## Changes
- Added `IssueRef` component (`web/src/components/IssueRef.tsx`) that renders `#N` as a quiet `<a>` when `url` is provided, plain text fallback otherwise.
- Extended server event endpoints to include `github_url` on each row (same pattern as queue.py).
- Wired `IssueRef` into Overview, NowStrip, ActivityFeed, and ProjectDetail timelines.
- No changes to Queue, Cost, FailureInspector, or PrMonitorTable.

## Test Plan
- Click `#N` on Overview recent events → opens GitHub issue/PR in new tab
- Same on NowStrip, ActivityFeed, ProjectDetail
- Events without `github_url` show plain text `#N`, no console errors
- Queue, Cost, FailureInspector, PrMonitorTable behavior unchanged
- No layout shift on any surface