### PR TITLE
fix(lint): unused import + long line in check-no-operator-leaks.py

### DIFF
--- a/scripts/check-no-operator-leaks.py
+++ b/scripts/check-no-operator-leaks.py
@@ -10,7 +10,6 @@ CHANGELOG.md is exempt (historical references are allowed to stand).
 """
 from __future__ import annotations
 
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -46,7 +45,10 @@ def tracked_files() -> list[str]:
 def main() -> int:
     names = load_names()
     if not names:
-        print("check-no-operator-leaks: no names configured (scripts/.operator-names.local.txt empty or missing) — skipping")
+        print(
+            "check-no-operator-leaks: no names configured "
+            "(scripts/.operator-names.local.txt empty or missing) — skipping"
+        )
         return 0
 
     files = tracked_files()


### PR DESCRIPTION
Restores green CI on main. Trivial ruff fixes for F401 (unused `import os`) and E501 (long line) introduced by #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)