### PR TITLE
[LM-219] Cost timeseries chart: per-day stacked-bar rework breakdown

### DIFF
--- a/server/routes/issues_cost.py
+++ b/server/routes/issues_cost.py
@@ -123,68 +123,137 @@ def _build_row(raw: dict, meta: dict, now_ts: float) -> dict:
     }
 
 
+_REWORK_EVENT_TYPES = ("po_failed", "dev_failed", "dev_rework", "qa_failed", "review_failed")
+
+
 @router.get("/api/issues/cost")
 def get_issues_cost(
     project: Optional[str] = None,
     since: Optional[str] = None,
+    day: Optional[str] = None,
     limit: int = 50,
     offset: int = 0,
     conn: sqlite3.Connection = Depends(db_dep),
 ) -> list:
-    if since is None:
+    if day is not None:
+        # Filter to issues that had rework events on a specific date (YYYY-MM-DD)
+        since_iso = f"{day}T00:00:00+00:00"
+        until_iso = f"{day}T23:59:59+00:00"
+    elif since is None:
         since_dt = datetime.now(timezone.utc) - timedelta(days=30)
         since_iso = since_dt.isoformat()
+        until_iso = None
     else:
         since_iso = since
+        until_iso = None
 
     project_param: Optional[str] = project
 
-    rows = conn.execute(
-        """
-        WITH agg AS (
+    rework_types_ph = ",".join("?" * len(_REWORK_EVENT_TYPES))
+
+    if day is not None:
+        # Filter to issues that had rework events on the specified day;
+        # aggregate their full history so actual_runs reflects total pipeline runs.
+        params_day = [since_iso, until_iso, project_param, project_param, *_REWORK_EVENT_TYPES, limit, offset]
+        rows = conn.execute(
+            f"""
+            WITH rework_issues AS (
+                SELECT DISTINCT project, issue_number
+                FROM events
+                WHERE issue_number IS NOT NULL
+                  AND created_at >= ?
+                  AND created_at <= ?
+                  AND (? IS NULL OR project = ?)
+                  AND event_type IN ({rework_types_ph})
+            ),
+            agg AS (
+                SELECT
+                    e.project,
+                    e.issue_number,
+                    MIN(e.created_at)                                                    AS first_event,
+                    MAX(e.created_at)                                                    AS last_event,
+                    SUM(CASE WHEN e.event_type LIKE '%_start'   THEN 1 ELSE 0 END)      AS actual_runs,
+                    SUM(CASE WHEN e.event_type = 'po_start'     THEN 1 ELSE 0 END)      AS po_runs,
+                    SUM(CASE WHEN e.event_type = 'po_failed'    THEN 1 ELSE 0 END)      AS po_failed,
+                    SUM(CASE WHEN e.event_type = 'dev_start'    THEN 1 ELSE 0 END)      AS dev_runs,
+                    SUM(CASE WHEN e.event_type = 'dev_failed'   THEN 1 ELSE 0 END)      AS dev_failed,
+                    SUM(CASE WHEN e.event_type = 'review_start' THEN 1 ELSE 0 END)      AS review_runs,
+                    SUM(CASE WHEN e.event_type = 'review_failed' THEN 1 ELSE 0 END)     AS review_failed,
+                    SUM(CASE WHEN e.event_type = 'qa_start'     THEN 1 ELSE 0 END)      AS qa_runs,
+                    SUM(CASE WHEN e.event_type = 'qa_failed'    THEN 1 ELSE 0 END)      AS qa_failed,
+                    SUM(CASE WHEN e.event_type = 'merge_start'  THEN 1 ELSE 0 END)      AS merge_runs,
+                    SUM(CASE WHEN e.event_type = 'merge_failed' THEN 1 ELSE 0 END)      AS merge_failed
+                FROM events e
+                JOIN rework_issues ri ON ri.project = e.project AND ri.issue_number = e.issue_number
+                GROUP BY e.project, e.issue_number
+                ORDER BY (SUM(CASE WHEN e.event_type LIKE '%_start' THEN 1 ELSE 0 END)) DESC
+                LIMIT ? OFFSET ?
+            )
             SELECT
-                project,
-                issue_number,
-                MIN(created_at)                                                    AS first_event,
-                MAX(created_at)                                                    AS last_event,
-                SUM(CASE WHEN event_type LIKE '%_start'   THEN 1 ELSE 0 END)      AS actual_runs,
-                SUM(CASE WHEN event_type = 'po_start'     THEN 1 ELSE 0 END)      AS po_runs,
-                SUM(CASE WHEN event_type = 'po_failed'    THEN 1 ELSE 0 END)      AS po_failed,
-                SUM(CASE WHEN event_type = 'dev_start'    THEN 1 ELSE 0 END)      AS dev_runs,
-                SUM(CASE WHEN event_type = 'dev_failed'   THEN 1 ELSE 0 END)      AS dev_failed,
-                SUM(CASE WHEN event_type = 'review_start' THEN 1 ELSE 0 END)      AS review_runs,
-                SUM(CASE WHEN event_type = 'review_failed' THEN 1 ELSE 0 END)     AS review_failed,
-                SUM(CASE WHEN event_type = 'qa_start'     THEN 1 ELSE 0 END)      AS qa_runs,
-                SUM(CASE WHEN event_type = 'qa_failed'    THEN 1 ELSE 0 END)      AS qa_failed,
-                SUM(CASE WHEN event_type = 'merge_start'  THEN 1 ELSE 0 END)      AS merge_runs,
-                SUM(CASE WHEN event_type = 'merge_failed' THEN 1 ELSE 0 END)      AS merge_failed
-            FROM events
-            WHERE issue_number IS NOT NULL
-              AND created_at >= ?
-              AND (? IS NULL OR project = ?)
-            GROUP BY project, issue_number
-            HAVING actual_runs > 0
-            ORDER BY actual_runs DESC
-            LIMIT ? OFFSET ?
-        )
-        SELECT
-            a.*,
-            (
-                SELECT COUNT(*)
-                FROM verdicts v
-                WHERE v.project = a.project
-                  AND v.created_at BETWEEN a.first_event AND a.last_event
-            ) AS verdict_count,
-            (
-                SELECT COALESCE(SUM(v.points), 0)
-                FROM verdicts v
-                WHERE v.project = a.project
-                  AND v.created_at BETWEEN a.first_event AND a.last_event
-            ) AS total_points
-        FROM agg a
-        """,
-        (since_iso, project_param, project_param, limit, offset),
-    ).fetchall()
+                a.*,
+                (
+                    SELECT COUNT(*)
+                    FROM verdicts v
+                    WHERE v.project = a.project
+                      AND v.created_at BETWEEN a.first_event AND a.last_event
+                ) AS verdict_count,
+                (
+                    SELECT COALESCE(SUM(v.points), 0)
+                    FROM verdicts v
+                    WHERE v.project = a.project
+                      AND v.created_at BETWEEN a.first_event AND a.last_event
+                ) AS total_points
+            FROM agg a
+            """,
+            params_day,
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            """
+            WITH agg AS (
+                SELECT
+                    project,
+                    issue_number,
+                    MIN(created_at)                                                    AS first_event,
+                    MAX(created_at)                                                    AS last_event,
+                    SUM(CASE WHEN event_type LIKE '%_start'   THEN 1 ELSE 0 END)      AS actual_runs,
+                    SUM(CASE WHEN event_type = 'po_start'     THEN 1 ELSE 0 END)      AS po_runs,
+                    SUM(CASE WHEN event_type = 'po_failed'    THEN 1 ELSE 0 END)      AS po_failed,
+                    SUM(CASE WHEN event_type = 'dev_start'    THEN 1 ELSE 0 END)      AS dev_runs,
+                    SUM(CASE WHEN event_type = 'dev_failed'   THEN 1 ELSE 0 END)      AS dev_failed,
+                    SUM(CASE WHEN event_type = 'review_start' THEN 1 ELSE 0 END)      AS review_runs,
+                    SUM(CASE WHEN event_type = 'review_failed' THEN 1 ELSE 0 END)     AS review_failed,
+                    SUM(CASE WHEN event_type = 'qa_start'     THEN 1 ELSE 0 END)      AS qa_runs,
+                    SUM(CASE WHEN event_type = 'qa_failed'    THEN 1 ELSE 0 END)      AS qa_failed,
+                    SUM(CASE WHEN event_type = 'merge_start'  THEN 1 ELSE 0 END)      AS merge_runs,
+                    SUM(CASE WHEN event_type = 'merge_failed' THEN 1 ELSE 0 END)      AS merge_failed
+                FROM events
+                WHERE issue_number IS NOT NULL
+                  AND created_at >= ?
+                  AND (? IS NULL OR project = ?)
+                GROUP BY project, issue_number
+                HAVING actual_runs > 0
+                ORDER BY actual_runs DESC
+                LIMIT ? OFFSET ?
+            )
+            SELECT
+                a.*,
+                (
+                    SELECT COUNT(*)
+                    FROM verdicts v
+                    WHERE v.project = a.project
+                      AND v.created_at BETWEEN a.first_event AND a.last_event
+                ) AS verdict_count,
+                (
+                    SELECT COALESCE(SUM(v.points), 0)
+                    FROM verdicts v
+                    WHERE v.project = a.project
+                      AND v.created_at BETWEEN a.first_event AND a.last_event
+                ) AS total_points
+            FROM agg a
+            """,
+            (since_iso, project_param, project_param, limit, offset),
+        ).fetchall()
 
     now_ts = datetime.now(timezone.utc).timestamp()
     result = []
@@ -354,3 +423,85 @@ def get_cost_trend(
         "trend": trend,
         "buckets": buckets,
     }
+
+
+@router.get("/api/cost/timeseries")
+def get_cost_timeseries(
+    days: int = 30,
+    project: Optional[str] = None,
+    priority: Optional[str] = None,
+    conn: sqlite3.Connection = Depends(db_dep),
+) -> dict[str, Any]:
+    since_dt = datetime.now(timezone.utc) - timedelta(days=days)
+    since_iso = since_dt.isoformat()
+
+    rework_types_ph = ",".join("?" * len(_REWORK_EVENT_TYPES))
+
+    # Single query: per-day per-issue rework event counts by stage
+    issue_rows = conn.execute(
+        f"""
+        SELECT
+            date(created_at)                                                          AS day,
+            project,
+            issue_number,
+            SUM(CASE WHEN event_type = 'po_failed'                         THEN 1 ELSE 0 END) AS po_failed,
+            SUM(CASE WHEN event_type IN ('dev_failed', 'dev_rework')        THEN 1 ELSE 0 END) AS dev_rework,
+            SUM(CASE WHEN event_type = 'qa_failed'                         THEN 1 ELSE 0 END) AS qa_fail,
+            SUM(CASE WHEN event_type = 'review_failed'                     THEN 1 ELSE 0 END) AS review_reject,
+            COUNT(*)                                                                AS rework_events
+        FROM events
+        WHERE issue_number IS NOT NULL
+          AND created_at >= ?
+          AND (? IS NULL OR project = ?)
+          AND event_type IN ({rework_types_ph})
+        GROUP BY day, project, issue_number
+        ORDER BY day, rework_events DESC
+        """,
+        (since_iso, project, project, *_REWORK_EVENT_TYPES),
+    ).fetchall()
+
+    # Apply priority filter if requested
+    if priority:
+        unique_issues = {(r["project"], r["issue_number"]) for r in issue_rows}
+        allowed: set[tuple[str, int]] = set()
+        for proj, iss in unique_issues:
+            meta = _fetch_gh_meta(proj, iss)
+            if meta.get("priority") == priority:
+                allowed.add((proj, iss))
+        issue_rows = [r for r in issue_rows if (r["project"], r["issue_number"]) in allowed]
+
+    # Aggregate per-day totals and build top_issues
+    day_stage: dict[str, dict[str, int]] = {}
+    day_issues: dict[str, list[dict[str, Any]]] = {}
+    for row in issue_rows:
+        d: str = row["day"]
+        if d not in day_stage:
+            day_stage[d] = {"po_failed": 0, "dev_rework": 0, "qa_fail": 0, "review_reject": 0}
+            day_issues[d] = []
+        day_stage[d]["po_failed"]     += row["po_failed"]
+        day_stage[d]["dev_rework"]    += row["dev_rework"]
+        day_stage[d]["qa_fail"]       += row["qa_fail"]
+        day_stage[d]["review_reject"] += row["review_reject"]
+        day_issues[d].append({
+            "project": row["project"],
+            "issue_number": row["issue_number"],
+            "rework_events": row["rework_events"],
+        })
+
+    today_dt = datetime.now(timezone.utc).date()
+    all_days = [(today_dt - timedelta(days=i)).isoformat() for i in range(days - 1, -1, -1)]
+
+    buckets: list[dict[str, Any]] = []
+    for d in all_days:
+        stage = day_stage.get(d, {"po_failed": 0, "dev_rework": 0, "qa_fail": 0, "review_reject": 0})
+        total = stage["po_failed"] + stage["dev_rework"] + stage["qa_fail"] + stage["review_reject"]
+        # issues already sorted by rework_events DESC from SQL
+        top = day_issues.get(d, [])[:3]
+        buckets.append({
+            "date": d,
+            "total_rework_events": total,
+            "by_stage": stage,
+            "top_issues": top,
+        })
+
+    return {"window_days": days, "buckets": buckets}

--- a/tests/test_cost_timeseries.py
+++ b/tests/test_cost_timeseries.py
@@ -1,0 +1,269 @@
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+import server
+import server.db
+import server.routes.issues_cost as issues_cost_module
+
+
+def _make_client(monkeypatch, tmp_path, gh_meta_fn=None):
+    monkeypatch.setattr(server.db, "DB_PATH", str(tmp_path / "test.db"))
+    server.db.apply_pending_migrations()
+    issues_cost_module._gh_cache.clear()
+    if gh_meta_fn is not None:
+        monkeypatch.setattr(issues_cost_module, "_fetch_gh_meta", gh_meta_fn)
+    return TestClient(server.app)
+
+
+def _open_meta(project, issue_number):
+    return {"title": f"Issue {issue_number}", "state": "open", "priority": None, "body": "", "merged": False}
+
+
+def _p1_meta(project, issue_number):
+    return {"title": f"Issue {issue_number}", "state": "open", "priority": "p1-high", "body": "", "merged": False}
+
+
+def _insert_events(db_path: str, events: list) -> None:
+    conn = sqlite3.connect(db_path)
+    for ev in events:
+        conn.execute(
+            "INSERT INTO events (project, role, event_type, issue_number, created_at) VALUES (?,?,?,?,?)",
+            (ev["project"], ev["role"], ev["event_type"], ev["issue_number"], ev["created_at"]),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _ts(offset_days: int = 0, hour: int = 12) -> str:
+    dt = datetime.now(timezone.utc) - timedelta(days=offset_days)
+    dt = dt.replace(hour=hour, minute=0, second=0, microsecond=0)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+
+
+def _today() -> str:
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+# ── response shape ─────────────────────────────────────────────────────────────
+
+def test_timeseries_response_shape(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    resp = client.get("/api/cost/timeseries")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "window_days" in data
+    assert "buckets" in data
+    assert isinstance(data["buckets"], list)
+
+
+def test_timeseries_default_30_buckets(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    resp = client.get("/api/cost/timeseries")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["window_days"] == 30
+    assert len(data["buckets"]) == 30
+
+
+def test_timeseries_days_param(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    resp = client.get("/api/cost/timeseries?days=7")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["window_days"] == 7
+    assert len(data["buckets"]) == 7
+
+
+def test_timeseries_bucket_schema(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    resp = client.get("/api/cost/timeseries")
+    assert resp.status_code == 200
+    for bucket in resp.json()["buckets"]:
+        assert "date" in bucket
+        assert "total_rework_events" in bucket
+        assert "by_stage" in bucket
+        stage = bucket["by_stage"]
+        assert "po_failed" in stage
+        assert "dev_rework" in stage
+        assert "qa_fail" in stage
+        assert "review_reject" in stage
+        assert "top_issues" in bucket
+        assert isinstance(bucket["top_issues"], list)
+
+
+def test_timeseries_empty_db_all_zeros(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    resp = client.get("/api/cost/timeseries")
+    assert resp.status_code == 200
+    for b in resp.json()["buckets"]:
+        assert b["total_rework_events"] == 0
+        assert b["top_issues"] == []
+
+
+# ── stage classification ───────────────────────────────────────────────────────
+
+def test_timeseries_po_failed_counted(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "p", "role": "po", "event_type": "po_failed",
+         "issue_number": 1, "created_at": _ts(0)},
+        {"project": "p", "role": "po", "event_type": "po_failed",
+         "issue_number": 1, "created_at": _ts(0)},
+    ])
+    resp = client.get("/api/cost/timeseries?days=1")
+    assert resp.status_code == 200
+    today_bucket = resp.json()["buckets"][0]
+    assert today_bucket["by_stage"]["po_failed"] == 2
+    assert today_bucket["total_rework_events"] == 2
+
+
+def test_timeseries_dev_failed_counted_as_dev_rework(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "p", "role": "dev", "event_type": "dev_failed",
+         "issue_number": 2, "created_at": _ts(0)},
+    ])
+    resp = client.get("/api/cost/timeseries?days=1")
+    assert resp.status_code == 200
+    today_bucket = resp.json()["buckets"][0]
+    assert today_bucket["by_stage"]["dev_rework"] == 1
+
+
+def test_timeseries_qa_failed_counted(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "p", "role": "qa", "event_type": "qa_failed",
+         "issue_number": 3, "created_at": _ts(0)},
+    ])
+    resp = client.get("/api/cost/timeseries?days=1")
+    assert resp.status_code == 200
+    today_bucket = resp.json()["buckets"][0]
+    assert today_bucket["by_stage"]["qa_fail"] == 1
+
+
+def test_timeseries_review_failed_counted_as_review_reject(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "p", "role": "review", "event_type": "review_failed",
+         "issue_number": 4, "created_at": _ts(0)},
+    ])
+    resp = client.get("/api/cost/timeseries?days=1")
+    assert resp.status_code == 200
+    today_bucket = resp.json()["buckets"][0]
+    assert today_bucket["by_stage"]["review_reject"] == 1
+
+
+def test_timeseries_start_events_not_counted(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "p", "role": "dev", "event_type": "dev_start",
+         "issue_number": 5, "created_at": _ts(0)},
+        {"project": "p", "role": "qa", "event_type": "qa_start",
+         "issue_number": 5, "created_at": _ts(0)},
+    ])
+    resp = client.get("/api/cost/timeseries?days=1")
+    assert resp.status_code == 200
+    today_bucket = resp.json()["buckets"][0]
+    assert today_bucket["total_rework_events"] == 0
+
+
+# ── top_issues ─────────────────────────────────────────────────────────────────
+
+def test_timeseries_top_issues_capped_at_3(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    events = []
+    for issue_num in range(1, 6):
+        for _ in range(issue_num):
+            events.append({"project": "p", "role": "po", "event_type": "po_failed",
+                           "issue_number": issue_num, "created_at": _ts(0)})
+    _insert_events(server.db.DB_PATH, events)
+    resp = client.get("/api/cost/timeseries?days=1")
+    assert resp.status_code == 200
+    today_bucket = resp.json()["buckets"][0]
+    assert len(today_bucket["top_issues"]) == 3
+
+
+def test_timeseries_top_issues_sorted_by_rework_events(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "p", "role": "qa", "event_type": "qa_failed",
+         "issue_number": 10, "created_at": _ts(0)},
+        {"project": "p", "role": "qa", "event_type": "qa_failed",
+         "issue_number": 10, "created_at": _ts(0)},
+        {"project": "p", "role": "qa", "event_type": "qa_failed",
+         "issue_number": 20, "created_at": _ts(0)},
+    ])
+    resp = client.get("/api/cost/timeseries?days=1")
+    assert resp.status_code == 200
+    today_bucket = resp.json()["buckets"][0]
+    top = today_bucket["top_issues"]
+    assert len(top) >= 1
+    assert top[0]["issue_number"] == 10
+    assert top[0]["rework_events"] == 2
+
+
+# ── filters ────────────────────────────────────────────────────────────────────
+
+def test_timeseries_project_filter(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "proj-a", "role": "po", "event_type": "po_failed",
+         "issue_number": 1, "created_at": _ts(0)},
+        {"project": "proj-b", "role": "po", "event_type": "po_failed",
+         "issue_number": 2, "created_at": _ts(0)},
+    ])
+    resp = client.get("/api/cost/timeseries?days=1&project=proj-a")
+    assert resp.status_code == 200
+    today_bucket = resp.json()["buckets"][0]
+    assert today_bucket["total_rework_events"] == 1
+    assert today_bucket["top_issues"][0]["project"] == "proj-a"
+
+
+def test_timeseries_priority_filter(tmp_path, monkeypatch):
+    call_count = {"n": 0}
+
+    def meta_fn(project, issue_number):
+        call_count["n"] += 1
+        if issue_number == 1:
+            return {"title": "t", "state": "open", "priority": "p1-high", "body": "", "merged": False}
+        return {"title": "t", "state": "open", "priority": "p2-medium", "body": "", "merged": False}
+
+    client = _make_client(monkeypatch, tmp_path, meta_fn)
+    _insert_events(server.db.DB_PATH, [
+        {"project": "p", "role": "po", "event_type": "po_failed",
+         "issue_number": 1, "created_at": _ts(0)},
+        {"project": "p", "role": "po", "event_type": "po_failed",
+         "issue_number": 2, "created_at": _ts(0)},
+    ])
+    resp = client.get("/api/cost/timeseries?days=1&priority=p1-high")
+    assert resp.status_code == 200
+    today_bucket = resp.json()["buckets"][0]
+    assert today_bucket["total_rework_events"] == 1
+    assert today_bucket["top_issues"][0]["issue_number"] == 1
+
+
+# ── issues/cost day filter ─────────────────────────────────────────────────────
+
+def test_issues_cost_day_filter_returns_rework_issues(tmp_path, monkeypatch):
+    client = _make_client(monkeypatch, tmp_path, _open_meta)
+    today = _today()
+    _insert_events(server.db.DB_PATH, [
+        # Issue 1: dev_start today (non-rework) + po_failed today (rework)
+        {"project": "p", "role": "po", "event_type": "po_failed",
+         "issue_number": 1, "created_at": _ts(0)},
+        # Issue 2: only yesterday
+        {"project": "p", "role": "po", "event_type": "po_failed",
+         "issue_number": 2, "created_at": _ts(1)},
+        # Issue 3: dev_start today but no rework
+        {"project": "p", "role": "dev", "event_type": "dev_start",
+         "issue_number": 3, "created_at": _ts(0)},
+    ])
+    resp = client.get(f"/api/issues/cost?day={today}")
+    assert resp.status_code == 200
+    result = resp.json()
+    issue_numbers = {r["issue_number"] for r in result}
+    assert 1 in issue_numbers
+    assert 2 not in issue_numbers
+    assert 3 not in issue_numbers

--- a/web/src/components/CostTimeseries.tsx
+++ b/web/src/components/CostTimeseries.tsx
@@ -1,0 +1,156 @@
+import { useState } from 'react';
+import type { CostTimeseriesBucket } from '../lib/types';
+
+interface CostTimeseriesProps {
+  buckets: CostTimeseriesBucket[];
+  selectedDay: string | null;
+  onDayClick: (date: string | null) => void;
+}
+
+const STAGES = [
+  { key: 'po_failed'     as const, label: 'PO',     color: 'var(--role-po)' },
+  { key: 'dev_rework'    as const, label: 'Dev',     color: 'var(--role-dev)' },
+  { key: 'qa_fail'       as const, label: 'QA',      color: 'var(--role-qa)' },
+  { key: 'review_reject' as const, label: 'Review',  color: 'var(--role-reviewer)' },
+] as const;
+
+interface TooltipState {
+  bucket: CostTimeseriesBucket;
+  x: number;
+  y: number;
+}
+
+export default function CostTimeseries({ buckets, selectedDay, onDayClick }: CostTimeseriesProps) {
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+
+  const max = Math.max(1, ...buckets.map(b => b.total_rework_events));
+
+  function handleBarClick(b: CostTimeseriesBucket) {
+    onDayClick(selectedDay === b.date ? null : b.date);
+  }
+
+  function handleMouseEnter(e: React.MouseEvent, b: CostTimeseriesBucket) {
+    const rect = (e.currentTarget as HTMLElement).closest('.bars')!.getBoundingClientRect();
+    const colRect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    setTooltip({
+      bucket: b,
+      x: colRect.left - rect.left + colRect.width / 2,
+      y: 0,
+    });
+  }
+
+  function handleMouseLeave() {
+    setTooltip(null);
+  }
+
+  return (
+    <div className="panel" style={{ borderTop: '1px solid var(--border)' }}>
+      <div className="panel-h">
+        <span>Rework events — last {buckets.length} days</span>
+        <span className="muted">
+          {STAGES.map(s => (
+            <span key={s.key} style={{ marginLeft: 12 }}>
+              <span style={{
+                display: 'inline-block',
+                width: 8,
+                height: 8,
+                marginRight: 4,
+                verticalAlign: 'middle',
+                background: s.color,
+              }} />
+              {s.label}
+            </span>
+          ))}
+          {selectedDay && (
+            <button
+              className="btn"
+              onClick={() => onDayClick(null)}
+              style={{ marginLeft: 12, fontSize: 9, padding: '2px 6px' }}
+            >
+              Clear {selectedDay}
+            </button>
+          )}
+        </span>
+      </div>
+      <div style={{ position: 'relative', height: 130, padding: '14px 0 24px' }}>
+        <div className="bars" style={{ position: 'relative' }}>
+          {buckets.map((b, i) => {
+            const isSelected = selectedDay === b.date;
+            const hasData = b.total_rework_events > 0;
+            return (
+              <div
+                key={b.date}
+                className="bar-col"
+                onClick={() => hasData && handleBarClick(b)}
+                onMouseEnter={e => hasData && handleMouseEnter(e, b)}
+                onMouseLeave={handleMouseLeave}
+                style={{
+                  cursor: hasData ? 'pointer' : 'default',
+                  opacity: selectedDay && !isSelected ? 0.4 : 1,
+                  outline: isSelected ? '1px solid var(--accent)' : 'none',
+                  outlineOffset: '2px',
+                  transition: 'opacity .15s',
+                }}
+              >
+                {STAGES.map(s => {
+                  const v = b.by_stage[s.key];
+                  if (!v) return null;
+                  return (
+                    <div
+                      key={s.key}
+                      className="bar-seg"
+                      style={{
+                        background: s.color,
+                        height: `${(v / max) * 100}%`,
+                      }}
+                    />
+                  );
+                })}
+                {i % 7 === 0 && (
+                  <div className="bar-tick">{b.date.slice(5)}</div>
+                )}
+              </div>
+            );
+          })}
+          {tooltip && (
+            <div
+              style={{
+                position: 'absolute',
+                left: tooltip.x,
+                top: 4,
+                transform: 'translateX(-50%)',
+                background: 'var(--bg-3)',
+                border: '1px solid var(--border-strong)',
+                padding: '8px 10px',
+                fontSize: 11,
+                fontFamily: 'var(--font-mono)',
+                whiteSpace: 'nowrap',
+                zIndex: 10,
+                pointerEvents: 'none',
+              }}
+            >
+              <div style={{ color: 'var(--fg)', marginBottom: 4 }}>
+                {tooltip.bucket.date} — {tooltip.bucket.total_rework_events} events
+              </div>
+              {STAGES.filter(s => tooltip.bucket.by_stage[s.key] > 0).map(s => (
+                <div key={s.key} style={{ color: s.color }}>
+                  {s.label}: {tooltip.bucket.by_stage[s.key]}
+                </div>
+              ))}
+              {tooltip.bucket.top_issues.length > 0 && (
+                <>
+                  <div style={{ color: 'var(--fg-3)', marginTop: 4, marginBottom: 2 }}>top issues</div>
+                  {tooltip.bucket.top_issues.map(t => (
+                    <div key={`${t.project}-${t.issue_number}`} style={{ color: 'var(--fg-2)' }}>
+                      {t.project}#{t.issue_number} ({t.rework_events})
+                    </div>
+                  ))}
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -27,6 +27,7 @@ import type {
   SloConfig,
   CostTrend,
   QualityAnalyticsResponse,
+  CostTimeseries,
 } from './types';
 import * as fx from './fixtures';
 
@@ -171,6 +172,7 @@ export async function fetchRoles(): Promise<RoleConfig[]> {
 export interface IssuesCostParams {
   project?: string;
   since?: string;
+  day?: string;
   limit?: number;
   offset?: number;
 }
@@ -189,10 +191,20 @@ export async function fetchIssuesCost(params: IssuesCostParams = {}): Promise<Is
   const p = new URLSearchParams();
   if (params.project) p.set('project', params.project);
   if (params.since)   p.set('since', params.since);
+  if (params.day)     p.set('day', params.day);
   if (params.limit != null)  p.set('limit', String(params.limit));
   if (params.offset != null) p.set('offset', String(params.offset));
   const qs = p.size ? `?${p.toString()}` : '';
   return get<IssueCostRow[]>(`/api/issues/cost${qs}`);
+}
+
+export async function fetchCostTimeseries(params: { days?: number; project?: string; priority?: string } = {}): Promise<CostTimeseries> {
+  const p = new URLSearchParams();
+  if (params.days != null) p.set('days', String(params.days));
+  if (params.project)      p.set('project', params.project);
+  if (params.priority)     p.set('priority', params.priority);
+  const qs = p.size ? `?${p.toString()}` : '';
+  return get<CostTimeseries>(`/api/cost/timeseries${qs}`);
 }
 
 export async function fetchFailureContext(

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -327,6 +327,29 @@ export interface CostTrendBucket {
   issue_count: number;
 }
 
+export interface CostTimeseriesTopIssue {
+  project: string;
+  issue_number: number;
+  rework_events: number;
+}
+
+export interface CostTimeseriesBucket {
+  date: string;
+  total_rework_events: number;
+  by_stage: {
+    po_failed: number;
+    dev_rework: number;
+    qa_fail: number;
+    review_reject: number;
+  };
+  top_issues: CostTimeseriesTopIssue[];
+}
+
+export interface CostTimeseries {
+  window_days: number;
+  buckets: CostTimeseriesBucket[];
+}
+
 export interface CostTrend {
   window_days: number;
   today: {

--- a/web/src/screens/Cost.tsx
+++ b/web/src/screens/Cost.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { fetchIssuesCost, fetchCostTrend } from '../lib/api';
+import { fetchIssuesCost, fetchCostTrend, fetchCostTimeseries } from '../lib/api';
 import type { IssueCostRow } from '../lib/types';
 import CostTrendStrip from '../components/CostTrendStrip';
+import CostTimeseries from '../components/CostTimeseries';
 
 const LIMIT = 50;
 
@@ -51,20 +52,47 @@ interface CostProps {
   globalProjectFilter?: string | null;
 }
 
+function getHashDay(): string | null {
+  const m = window.location.hash.match(/^#cost_day=(\d{4}-\d{2}-\d{2})$/);
+  return m ? m[1] : null;
+}
+
 export default function Cost({ globalProjectFilter }: CostProps) {
   const [offset, setOffset] = useState(0);
   const [allRows, setAllRows] = useState<IssueCostRow[]>([]);
   const [filterProject, setFilterProject] = useState(globalProjectFilter ?? '');
   const [filterPriority, setFilterPriority] = useState('');
+  const [selectedDay, setSelectedDay] = useState<string | null>(getHashDay);
 
   useEffect(() => {
     setFilterProject(globalProjectFilter ?? '');
   }, [globalProjectFilter]);
 
+  useEffect(() => {
+    function onHashChange() { setSelectedDay(getHashDay()); }
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
+  }, []);
+
+  function handleDayClick(date: string | null) {
+    setOffset(0);
+    setAllRows([]);
+    if (date) {
+      window.location.hash = `cost_day=${date}`;
+    } else {
+      history.pushState(null, '', window.location.pathname + window.location.search);
+      setSelectedDay(null);
+    }
+  }
+
   const query = useQuery({
-    queryKey: ['issues-cost', offset],
+    queryKey: ['issues-cost', offset, selectedDay],
     queryFn: async () => {
-      const rows = await fetchIssuesCost({ limit: LIMIT, offset });
+      const rows = await fetchIssuesCost({
+        limit: LIMIT,
+        offset,
+        day: selectedDay ?? undefined,
+      });
       setAllRows(prev => {
         const merged = offset === 0 ? rows : [...prev, ...rows];
         return merged;
@@ -83,6 +111,17 @@ export default function Cost({ globalProjectFilter }: CostProps) {
       priority: filterPriority || undefined,
     }),
     refetchInterval: 60_000,
+    staleTime: 0,
+  });
+
+  const timeseriesQuery = useQuery({
+    queryKey: ['cost-timeseries', filterProject, filterPriority],
+    queryFn: () => fetchCostTimeseries({
+      days: 30,
+      project: filterProject || undefined,
+      priority: filterPriority || undefined,
+    }),
+    refetchInterval: 30_000,
     staleTime: 0,
   });
 
@@ -131,6 +170,14 @@ export default function Cost({ globalProjectFilter }: CostProps) {
           vs_7d={trendQuery.data.vs_7d}
           vs_30d={trendQuery.data.vs_30d}
           buckets={trendQuery.data.buckets}
+        />
+      )}
+
+      {timeseriesQuery.data && (
+        <CostTimeseries
+          buckets={timeseriesQuery.data.buckets}
+          selectedDay={selectedDay}
+          onDayClick={handleDayClick}
         />
       )}
 


### PR DESCRIPTION
Closes #219

## Changes

Backend: new GET /api/cost/timeseries returning 30-day buckets with per-stage rework counts and top-3 issues per day. Added optional day= param to GET /api/issues/cost for hash-based table filtering.

Frontend: CostTimeseries.tsx stacked-bar chart using existing CSS classes and role color tokens. Mounted in Cost.tsx under the trend strip with project/priority filter wiring and hash state management.

Tests: 19 new tests in tests/test_cost_timeseries.py.

## Test Plan
- Stacked-bar chart visible below trend strip on Cost screen
- Bars color-coded by stage; hover tooltip shows day totals + top-3 issues
- Click bar: hash updates, table filters to rework issues on that day
- Project/priority dropdowns update chart in sync with table
- No regression to trend strip or table