### PR TITLE
[LM-248] Quality panel + /api/analytics/quality endpoint

### DIFF
--- a/server/routes/analytics.py
+++ b/server/routes/analytics.py
@@ -88,6 +88,141 @@ def _compute_lead_times(by_issue: dict) -> list[float]:
     return lead_times
 
 
+@router.get("/api/analytics/quality")
+def get_analytics_quality(
+    days: int = Query(30, ge=1, le=365),
+    conn: sqlite3.Connection = Depends(db_dep),
+) -> dict:
+    since = _since_iso(days)
+
+    # --- Failure type counts ---
+    fail_rows = conn.execute(
+        """SELECT event_type, COUNT(*) AS cnt
+           FROM events
+           WHERE event_type IN ('po_failed','dev_failed','qa_failed','review_failed','merge_failed')
+             AND created_at >= ?
+           GROUP BY event_type""",
+        (since,),
+    ).fetchall()
+    failure_counts = {r["event_type"]: r["cnt"] for r in fail_rows}
+    failure_types = {
+        "po_failed":     failure_counts.get("po_failed", 0),
+        "dev_failed":    failure_counts.get("dev_failed", 0),
+        "qa_fail":       failure_counts.get("qa_failed", 0),
+        "review_failed": failure_counts.get("review_failed", 0),
+        "merge_failed":  failure_counts.get("merge_failed", 0),
+    }
+
+    # --- Stage failure rate ---
+    _STAGES = ["po", "dev", "review", "qa", "merge"]
+    stage_agg = conn.execute(
+        """SELECT
+               SUM(CASE WHEN event_type = 'po_start'      THEN 1 ELSE 0 END) AS po_start,
+               SUM(CASE WHEN event_type = 'po_failed'     THEN 1 ELSE 0 END) AS po_failed,
+               SUM(CASE WHEN event_type = 'dev_start'     THEN 1 ELSE 0 END) AS dev_start,
+               SUM(CASE WHEN event_type = 'dev_failed'    THEN 1 ELSE 0 END) AS dev_failed,
+               SUM(CASE WHEN event_type = 'review_start'  THEN 1 ELSE 0 END) AS review_start,
+               SUM(CASE WHEN event_type = 'review_failed' THEN 1 ELSE 0 END) AS review_failed,
+               SUM(CASE WHEN event_type = 'qa_start'      THEN 1 ELSE 0 END) AS qa_start,
+               SUM(CASE WHEN event_type = 'qa_failed'     THEN 1 ELSE 0 END) AS qa_failed,
+               SUM(CASE WHEN event_type = 'merge_start'   THEN 1 ELSE 0 END) AS merge_start,
+               SUM(CASE WHEN event_type = 'merge_failed'  THEN 1 ELSE 0 END) AS merge_failed
+           FROM events
+           WHERE created_at >= ?""",
+        (since,),
+    ).fetchone()
+
+    stage_failure = []
+    for stage in _STAGES:
+        starts = stage_agg[f"{stage}_start"] or 0
+        fails = stage_agg[f"{stage}_failed"] or 0
+        if starts > 0:
+            stage_failure.append({
+                "stage": stage,
+                "fail_rate": round(fails / starts, 4),
+                "sample": starts,
+            })
+
+    # --- QA pass rate overall ---
+    qa_pass_cnt = conn.execute(
+        "SELECT COUNT(*) FROM events WHERE event_type IN ('qa_pass','qa_done') AND created_at >= ?",
+        (since,),
+    ).fetchone()[0] or 0
+    qa_fail_cnt = failure_counts.get("qa_failed", 0)
+    qa_total = qa_pass_cnt + qa_fail_cnt
+    qa_pass_rate: Optional[float] = round(qa_pass_cnt / qa_total, 4) if qa_total > 0 else None
+
+    # --- QA pass rate daily ---
+    today_dt = datetime.now(timezone.utc).date()
+    all_days = [(today_dt - timedelta(days=i)).isoformat() for i in range(days - 1, -1, -1)]
+
+    daily_rows = conn.execute(
+        """SELECT date(created_at) AS day,
+                  SUM(CASE WHEN event_type IN ('qa_pass','qa_done') THEN 1 ELSE 0 END) AS passes,
+                  SUM(CASE WHEN event_type = 'qa_failed' THEN 1 ELSE 0 END) AS fails
+           FROM events
+           WHERE event_type IN ('qa_pass','qa_done','qa_failed') AND created_at >= ?
+           GROUP BY day""",
+        (since,),
+    ).fetchall()
+    daily_qa: dict[str, tuple[int, int]] = {r["day"]: (r["passes"] or 0, r["fails"] or 0) for r in daily_rows}
+
+    qa_pass_rate_daily = []
+    for d in all_days:
+        passes, fails = daily_qa.get(d, (0, 0))
+        total = passes + fails
+        rate: Optional[float] = round(passes / total, 4) if total > 0 else None
+        qa_pass_rate_daily.append({"date": d, "rate": rate})
+
+    # --- Rework factor distribution (per issue, simplified formula: actual_runs/5) ---
+    rf_rows = conn.execute(
+        """SELECT project, issue_number,
+                  SUM(CASE WHEN event_type LIKE '%_start' THEN 1 ELSE 0 END) AS actual_runs
+           FROM events
+           WHERE issue_number IS NOT NULL AND created_at >= ?
+           GROUP BY project, issue_number
+           HAVING actual_runs > 0""",
+        (since,),
+    ).fetchall()
+
+    rework_factors = [round((r["actual_runs"] or 0) / 5, 4) for r in rf_rows]
+
+    # Verdict mix bucketed by rework factor
+    verdicts: dict[str, int] = {"clean": 0, "light_rework": 0, "heavy_rework": 0, "blocked": 0}
+    for rf in rework_factors:
+        if rf <= 1.0:
+            verdicts["clean"] += 1
+        elif rf <= 2.0:
+            verdicts["light_rework"] += 1
+        elif rf <= 4.0:
+            verdicts["heavy_rework"] += 1
+        else:
+            verdicts["blocked"] += 1
+
+    rf_pct = _pct_stats(rework_factors)
+    buckets = [
+        {"label": "<=1x", "count": verdicts["clean"]},
+        {"label": "1-2x", "count": verdicts["light_rework"]},
+        {"label": "2-4x", "count": verdicts["heavy_rework"]},
+        {"label": ">4x",  "count": verdicts["blocked"]},
+    ]
+    rework_dist: dict = {
+        "p50": rf_pct["p50"] if rf_pct else None,
+        "p75": rf_pct["p75"] if rf_pct else None,
+        "p95": rf_pct["p95"] if rf_pct else None,
+        "buckets": buckets,
+    }
+
+    return {
+        "verdicts": verdicts,
+        "qa_pass_rate": qa_pass_rate,
+        "qa_pass_rate_daily": qa_pass_rate_daily,
+        "stage_failure": stage_failure,
+        "rework_dist": rework_dist,
+        "failure_types": failure_types,
+    }
+
+
 @router.get("/api/analytics/cycle_time")
 def get_analytics_cycle_time(
     days: int = Query(30, ge=1, le=365),

--- a/tests/test_analytics_quality.py
+++ b/tests/test_analytics_quality.py
@@ -1,0 +1,176 @@
+import sqlite3
+
+import pytest
+
+import server.db
+
+
+def _insert_event(conn, project, role, event_type, issue_number=None, created_at="2026-01-10T12:00:00"):
+    conn.execute(
+        """INSERT INTO events (project, role, event_type, issue_number, created_at)
+           VALUES (?, ?, ?, ?, ?)""",
+        (project, role, event_type, issue_number, created_at),
+    )
+
+
+def test_quality_empty(isolated_client):
+    resp = isolated_client.get("/api/analytics/quality?days=30")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["verdicts"] == {"clean": 0, "light_rework": 0, "heavy_rework": 0, "blocked": 0}
+    assert data["qa_pass_rate"] is None
+    assert data["stage_failure"] == []
+    assert data["rework_dist"]["p50"] is None
+    assert data["rework_dist"]["buckets"] == [
+        {"label": "<=1x", "count": 0},
+        {"label": "1-2x", "count": 0},
+        {"label": "2-4x", "count": 0},
+        {"label": ">4x",  "count": 0},
+    ]
+    assert data["failure_types"] == {
+        "po_failed": 0, "dev_failed": 0, "qa_fail": 0,
+        "review_failed": 0, "merge_failed": 0,
+    }
+
+
+def test_quality_failure_types(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.row_factory = sqlite3.Row
+
+    _insert_event(conn, "proj", "po",     "po_failed",     created_at="2026-01-10T10:00:00")
+    _insert_event(conn, "proj", "dev",    "dev_failed",    created_at="2026-01-10T10:00:00")
+    _insert_event(conn, "proj", "dev",    "dev_failed",    created_at="2026-01-10T10:00:00")
+    _insert_event(conn, "proj", "qa",     "qa_failed",     created_at="2026-01-10T10:00:00")
+    _insert_event(conn, "proj", "review", "review_failed", created_at="2026-01-10T10:00:00")
+    _insert_event(conn, "proj", "merge",  "merge_failed",  created_at="2026-01-10T10:00:00")
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/analytics/quality?days=365")
+    assert resp.status_code == 200
+    ft = resp.json()["failure_types"]
+    assert ft["po_failed"] == 1
+    assert ft["dev_failed"] == 2
+    assert ft["qa_fail"] == 1
+    assert ft["review_failed"] == 1
+    assert ft["merge_failed"] == 1
+
+
+def test_quality_stage_failure_rate(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.row_factory = sqlite3.Row
+
+    # dev: 4 starts, 2 failures → 50%
+    for _ in range(4):
+        _insert_event(conn, "proj", "dev", "dev_start", created_at="2026-01-10T10:00:00")
+    for _ in range(2):
+        _insert_event(conn, "proj", "dev", "dev_failed", created_at="2026-01-10T10:00:00")
+
+    # qa: 5 starts, 1 failure → 20%
+    for _ in range(5):
+        _insert_event(conn, "proj", "qa", "qa_start", created_at="2026-01-10T10:00:00")
+    _insert_event(conn, "proj", "qa", "qa_failed", created_at="2026-01-10T10:00:00")
+
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/analytics/quality?days=365")
+    assert resp.status_code == 200
+    sf = {s["stage"]: s for s in resp.json()["stage_failure"]}
+
+    assert "dev" in sf
+    assert sf["dev"]["fail_rate"] == pytest.approx(0.5, rel=0.01)
+    assert sf["dev"]["sample"] == 4
+
+    assert "qa" in sf
+    assert sf["qa"]["fail_rate"] == pytest.approx(0.2, rel=0.01)
+    assert sf["qa"]["sample"] == 5
+
+
+def test_quality_qa_pass_rate(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.row_factory = sqlite3.Row
+
+    # 3 qa_pass + 1 qa_failed → 75% pass rate
+    for _ in range(3):
+        _insert_event(conn, "proj", "qa", "qa_pass", created_at="2026-01-10T10:00:00")
+    _insert_event(conn, "proj", "qa", "qa_failed", created_at="2026-01-10T10:00:00")
+
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/analytics/quality?days=365")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["qa_pass_rate"] == pytest.approx(0.75, rel=0.01)
+
+
+def test_quality_rework_dist_and_verdicts(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.row_factory = sqlite3.Row
+
+    # issue 1: 5 starts → rf = 5/5 = 1.0 → clean (<=1.0)
+    for _ in range(5):
+        _insert_event(conn, "proj", "dev", "dev_start", issue_number=1, created_at="2026-01-10T10:00:00")
+
+    # issue 2: 8 starts → rf = 8/5 = 1.6 → light_rework (1<rf<=2)
+    for _ in range(8):
+        _insert_event(conn, "proj", "dev", "dev_start", issue_number=2, created_at="2026-01-10T10:00:00")
+
+    # issue 3: 15 starts → rf = 15/5 = 3.0 → heavy_rework (2<rf<=4)
+    for _ in range(15):
+        _insert_event(conn, "proj", "dev", "dev_start", issue_number=3, created_at="2026-01-10T10:00:00")
+
+    # issue 4: 25 starts → rf = 25/5 = 5.0 → blocked (>4)
+    for _ in range(25):
+        _insert_event(conn, "proj", "dev", "dev_start", issue_number=4, created_at="2026-01-10T10:00:00")
+
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/analytics/quality?days=365")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["verdicts"]["clean"] == 1
+    assert data["verdicts"]["light_rework"] == 1
+    assert data["verdicts"]["heavy_rework"] == 1
+    assert data["verdicts"]["blocked"] == 1
+
+    rd = data["rework_dist"]
+    assert rd["p50"] is not None
+    assert rd["p75"] is not None
+    assert rd["p95"] is not None
+    assert len(rd["buckets"]) == 4
+    assert rd["buckets"][0]["label"] == "<=1x"
+    assert rd["buckets"][0]["count"] == 1
+    assert rd["buckets"][3]["label"] == ">4x"
+    assert rd["buckets"][3]["count"] == 1
+
+
+def test_quality_days_filter(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.row_factory = sqlite3.Row
+
+    # Old events (>60 days) — should be excluded
+    _insert_event(conn, "proj", "qa", "qa_failed", created_at="2024-01-01T00:00:00")
+    _insert_event(conn, "proj", "qa", "qa_pass",   created_at="2024-01-01T00:00:00")
+
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/analytics/quality?days=30")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["qa_pass_rate"] is None
+    assert data["failure_types"]["qa_fail"] == 0
+
+
+def test_quality_qa_pass_rate_daily_shape(isolated_client):
+    resp = isolated_client.get("/api/analytics/quality?days=7")
+    assert resp.status_code == 200
+    daily = resp.json()["qa_pass_rate_daily"]
+    assert len(daily) == 7
+    for entry in daily:
+        assert "date" in entry
+        assert "rate" in entry

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -26,6 +26,7 @@ import type {
   CycleTimeAnalyticsResponse,
   SloConfig,
   CostTrend,
+  QualityAnalyticsResponse,
 } from './types';
 import * as fx from './fixtures';
 
@@ -210,6 +211,10 @@ export async function fetchCycleTimes(project: string): Promise<CycleTimesRespon
 
 export async function fetchAnalyticsCycleTime(days = 30): Promise<CycleTimeAnalyticsResponse> {
   return get<CycleTimeAnalyticsResponse>(`/api/analytics/cycle_time?days=${days}`);
+}
+
+export async function fetchAnalyticsQuality(days = 30): Promise<QualityAnalyticsResponse> {
+  return get<QualityAnalyticsResponse>(`/api/analytics/quality?days=${days}`);
 }
 
 export async function fetchSlo(project: string): Promise<SloConfig> {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -274,6 +274,53 @@ export interface IssueCostRow {
   github_url: string | null;
 }
 
+export interface QualityVerdicts {
+  clean: number;
+  light_rework: number;
+  heavy_rework: number;
+  blocked: number;
+}
+
+export interface QualityStageFailure {
+  stage: string;
+  fail_rate: number;
+  sample: number;
+}
+
+export interface QualityReworkBucket {
+  label: string;
+  count: number;
+}
+
+export interface QualityReworkDist {
+  p50: number | null;
+  p75: number | null;
+  p95: number | null;
+  buckets: QualityReworkBucket[];
+}
+
+export interface QualityFailureTypes {
+  po_failed: number;
+  dev_failed: number;
+  qa_fail: number;
+  review_failed: number;
+  merge_failed: number;
+}
+
+export interface QualityDailyRate {
+  date: string;
+  rate: number | null;
+}
+
+export interface QualityAnalyticsResponse {
+  verdicts: QualityVerdicts;
+  qa_pass_rate: number | null;
+  qa_pass_rate_daily: QualityDailyRate[];
+  stage_failure: QualityStageFailure[];
+  rework_dist: QualityReworkDist;
+  failure_types: QualityFailureTypes;
+}
+
 export interface CostTrendBucket {
   date: string;
   median_rework_factor: number | null;

--- a/web/src/panels/Quality.tsx
+++ b/web/src/panels/Quality.tsx
@@ -1,0 +1,264 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell,
+  LineChart, Line, ReferenceLine,
+} from 'recharts';
+import { fetchAnalyticsQuality } from '../lib/api';
+import type {
+  QualityAnalyticsResponse,
+  QualityStageFailure,
+  QualityDailyRate,
+  QualityReworkBucket,
+} from '../lib/types';
+
+const C = {
+  clean:       'oklch(0.72 0.17 145)',
+  light:       'oklch(0.82 0.16 80)',
+  heavy:       'oklch(0.78 0.17 40)',
+  blocked:     'oklch(0.62 0.22 20)',
+  accent:      'oklch(0.82 0.18 145)',
+  qa:          'oklch(0.82 0.15 75)',
+  warn:        'oklch(0.82 0.16 80)',
+  err:         'oklch(0.62 0.22 20)',
+  fg3:         'oklch(0.58 0.008 250)',
+  bg2:         'oklch(0.205 0.007 250)',
+  border:      'oklch(0.275 0.008 250)',
+};
+
+const TOOLTIP_STYLE = {
+  background: C.bg2,
+  border: `1px solid ${C.border}`,
+  borderRadius: 2,
+  fontSize: 11,
+  fontFamily: 'var(--font-mono)',
+  color: 'oklch(0.96 0.005 250)',
+};
+
+const VERDICT_COLORS = [C.clean, C.light, C.heavy, C.blocked];
+
+function pct(n: number, total: number): string {
+  return total === 0 ? '0%' : `${Math.round((n / total) * 100)}%`;
+}
+
+function VerdictBar({ data }: { data: QualityAnalyticsResponse['verdicts'] }) {
+  const total = data.clean + data.light_rework + data.heavy_rework + data.blocked;
+  const segments = [
+    { key: 'clean',        label: 'clean',       value: data.clean,        color: C.clean },
+    { key: 'light_rework', label: 'light rework', value: data.light_rework, color: C.light },
+    { key: 'heavy_rework', label: 'heavy rework', value: data.heavy_rework, color: C.heavy },
+    { key: 'blocked',      label: 'blocked',      value: data.blocked,      color: C.blocked },
+  ];
+
+  return (
+    <div>
+      <div style={{ display: 'flex', height: 10, borderRadius: 2, overflow: 'hidden', gap: 1 }}>
+        {segments.map(s => (
+          <div
+            key={s.key}
+            style={{
+              flex: s.value,
+              background: s.color,
+              minWidth: s.value > 0 ? 2 : 0,
+            }}
+          />
+        ))}
+        {total === 0 && <div style={{ flex: 1, background: C.border }} />}
+      </div>
+      <div style={{ display: 'flex', gap: 'var(--pad-3)', marginTop: 6, flexWrap: 'wrap' }}>
+        {segments.map(s => (
+          <span key={s.key} style={{ fontSize: 11, color: C.fg3, display: 'flex', alignItems: 'center', gap: 4 }}>
+            <span style={{ display: 'inline-block', width: 8, height: 8, borderRadius: 1, background: s.color }} />
+            {s.label}
+            <span style={{ color: s.color, fontFamily: 'var(--font-mono)' }}>
+              {s.value} <span style={{ color: C.fg3 }}>({pct(s.value, total)})</span>
+            </span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function QaSparkline({ daily }: { daily: QualityDailyRate[] }) {
+  const chartData = daily.map(d => ({ date: d.date.slice(5), rate: d.rate != null ? Math.round(d.rate * 100) : null }));
+  return (
+    <ResponsiveContainer width="100%" height={60}>
+      <LineChart data={chartData} margin={{ top: 4, right: 4, left: -32, bottom: 0 }}>
+        <XAxis dataKey="date" tick={false} axisLine={false} tickLine={false} />
+        <YAxis domain={[0, 100]} tick={{ fill: C.fg3, fontSize: 9 }} axisLine={false} tickLine={false} />
+        <Tooltip
+          contentStyle={TOOLTIP_STYLE}
+          formatter={(v) => [`${v}%`, 'QA pass']}
+          labelFormatter={(l) => l}
+        />
+        <ReferenceLine y={80} stroke={C.border} strokeDasharray="3 3" />
+        <Line
+          type="monotone"
+          dataKey="rate"
+          stroke={C.qa}
+          dot={false}
+          strokeWidth={1.5}
+          connectNulls={false}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}
+
+function StageFailureChart({ rows }: { rows: QualityStageFailure[] }) {
+  const data = rows.map(r => ({
+    stage: r.stage,
+    fail_pct: Math.round(r.fail_rate * 100),
+    sample: r.sample,
+  }));
+  return (
+    <ResponsiveContainer width="100%" height={120}>
+      <BarChart data={data} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+        <XAxis dataKey="stage" tick={{ fill: C.fg3, fontSize: 9 }} axisLine={false} tickLine={false} />
+        <YAxis tick={{ fill: C.fg3, fontSize: 9 }} axisLine={false} tickLine={false} unit="%" domain={[0, 100]} />
+        <Tooltip
+          contentStyle={TOOLTIP_STYLE}
+          formatter={(v, _name, props) => [
+            `${v}% (n=${(props.payload as { sample?: number })?.sample ?? 0})`,
+            'fail rate',
+          ]}
+        />
+        <Bar dataKey="fail_pct" name="fail rate" radius={[2, 2, 0, 0]} maxBarSize={40}>
+          {data.map(d => (
+            <Cell
+              key={d.stage}
+              fill={d.fail_pct > 30 ? C.err : d.fail_pct > 10 ? C.warn : C.accent}
+            />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+function ReworkHistogram({ buckets }: { buckets: QualityReworkBucket[] }) {
+  return (
+    <ResponsiveContainer width="100%" height={100}>
+      <BarChart data={buckets} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+        <XAxis dataKey="label" tick={{ fill: C.fg3, fontSize: 9 }} axisLine={false} tickLine={false} />
+        <YAxis tick={{ fill: C.fg3, fontSize: 9 }} axisLine={false} tickLine={false} allowDecimals={false} />
+        <Tooltip contentStyle={TOOLTIP_STYLE} formatter={(v) => [v, 'issues']} />
+        <Bar dataKey="count" name="issues" radius={[2, 2, 0, 0]} maxBarSize={40}>
+          {buckets.map((b, i) => (
+            <Cell key={b.label} fill={VERDICT_COLORS[i] ?? C.accent} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+interface QualityPanelProps {
+  days?: number;
+}
+
+export default function QualityPanel({ days = 30 }: QualityPanelProps) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['analytics-quality', days],
+    queryFn: () => fetchAnalyticsQuality(days),
+    staleTime: 60_000,
+    refetchInterval: 300_000,
+  });
+
+  return (
+    <div className="panel" id="quality">
+      <div className="panel-h">
+        <span>Quality · last {days}d</span>
+        {data && (
+          <span className="muted mono" style={{ fontSize: 10 }}>
+            {data.verdicts.clean + data.verdicts.light_rework + data.verdicts.heavy_rework + data.verdicts.blocked} issues
+            {data.qa_pass_rate != null && ` · QA ${Math.round(data.qa_pass_rate * 100)}%`}
+          </span>
+        )}
+      </div>
+
+      {isLoading && (
+        <div className="muted" style={{ padding: 'var(--pad-3)' }}>Loading…</div>
+      )}
+
+      {isError && (
+        <div style={{ padding: 'var(--pad-3)', color: 'var(--role-err)', fontSize: 12 }}>
+          Failed to load quality data.
+        </div>
+      )}
+
+      {data && (
+        <div style={{ padding: 'var(--pad-3)', display: 'grid', gap: 'var(--pad-3)' }}>
+
+          {/* Verdict mix */}
+          <div>
+            <div className="muted" style={{ fontSize: 11, marginBottom: 6 }}>Verdict mix</div>
+            <VerdictBar data={data.verdicts} />
+          </div>
+
+          {/* QA pass rate */}
+          <div>
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 4 }}>
+              <span className="muted" style={{ fontSize: 11 }}>QA pass rate</span>
+              {data.qa_pass_rate != null ? (
+                <span style={{ fontSize: 14, fontWeight: 600, fontFamily: 'var(--font-mono)', color: data.qa_pass_rate >= 0.8 ? C.clean : data.qa_pass_rate >= 0.5 ? C.warn : C.err }}>
+                  {Math.round(data.qa_pass_rate * 100)}%
+                </span>
+              ) : (
+                <span className="muted" style={{ fontSize: 12 }}>—</span>
+              )}
+            </div>
+            {data.qa_pass_rate_daily.some(d => d.rate != null) && (
+              <QaSparkline daily={data.qa_pass_rate_daily} />
+            )}
+          </div>
+
+          {/* Stage failure */}
+          {data.stage_failure.length > 0 && (
+            <div>
+              <div className="muted" style={{ fontSize: 11, marginBottom: 4 }}>Stage failure rate</div>
+              <StageFailureChart rows={data.stage_failure} />
+            </div>
+          )}
+
+          {/* Rework factor distribution */}
+          <div>
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 4 }}>
+              <span className="muted" style={{ fontSize: 11 }}>Rework factor</span>
+              {data.rework_dist.p50 != null && (
+                <span style={{ fontSize: 11, fontFamily: 'var(--font-mono)', color: C.fg3 }}>
+                  p50 {data.rework_dist.p50.toFixed(2)}x · p75 {data.rework_dist.p75?.toFixed(2)}x · p95 {data.rework_dist.p95?.toFixed(2)}x
+                </span>
+              )}
+            </div>
+            <ReworkHistogram buckets={data.rework_dist.buckets} />
+          </div>
+
+          {/* Failure types */}
+          <div>
+            <div className="muted" style={{ fontSize: 11, marginBottom: 6 }}>Failure counts</div>
+            <div style={{ display: 'flex', gap: 'var(--pad-3)', flexWrap: 'wrap' }}>
+              {(
+                [
+                  ['PO',     data.failure_types.po_failed],
+                  ['Dev',    data.failure_types.dev_failed],
+                  ['QA',     data.failure_types.qa_fail],
+                  ['Review', data.failure_types.review_failed],
+                  ['Merge',  data.failure_types.merge_failed],
+                ] as [string, number][]
+              ).map(([label, count]) => (
+                <div key={label} style={{ textAlign: 'center' }}>
+                  <div style={{ fontSize: 18, fontWeight: 600, fontFamily: 'var(--font-mono)', color: count > 0 ? C.warn : C.fg3 }}>
+                    {count}
+                  </div>
+                  <div style={{ fontSize: 10, color: C.fg3 }}>{label} fail</div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/screens/Analytics.tsx
+++ b/web/src/screens/Analytics.tsx
@@ -1,4 +1,5 @@
 import CycleTimePanel from '../panels/CycleTime';
+import QualityPanel from '../panels/Quality';
 
 export default function Analytics() {
   return (
@@ -8,6 +9,7 @@ export default function Analytics() {
       </div>
       <div style={{ padding: 'var(--pad-4)', display: 'grid', gap: 'var(--pad-3)' }}>
         <CycleTimePanel days={30} />
+        <QualityPanel days={30} />
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #248

## Changes

**Backend (`server/routes/analytics.py`)**
- Added `GET /api/analytics/quality?days=30` endpoint returning verdict mix, QA pass rate (overall + daily), per-stage failure rates, rework-factor distribution, and failure-type counts
- Verdict mix derived from per-issue rework factors (same simplified formula as Cost trend: `actual_runs / 5`) bucketed into clean/light_rework/heavy_rework/blocked
- Stage failure rate computed as `X_failed / X_start` across po/dev/review/qa/merge
- QA pass rate uses `qa_pass`+`qa_done` events vs `qa_failed`

**Frontend**
- `web/src/lib/types.ts`: Added `QualityAnalyticsResponse` and related interfaces
- `web/src/lib/api.ts`: Added `fetchAnalyticsQuality(days)`
- `web/src/panels/Quality.tsx`: New panel with verdict stacked bar, QA sparkline, stage-failure bar chart, rework histogram, and failure-type counters
- `web/src/screens/Analytics.tsx`: Mounted `QualityPanel` below `CycleTimePanel`

**Tests (`tests/test_analytics_quality.py`)**
- 7 tests covering empty state, failure types, stage fail rate, QA pass rate, rework distribution/verdict mix, days filter, and daily shape

## Test Plan
- `GET /api/analytics/quality?days=30` returns all required fields
- All 7 new tests pass (`pytest tests/test_analytics_quality.py`)
- `ruff check` clean on changed files
- TypeScript typecheck passes
- Vite build succeeds