### PR TITLE
Fix #196: make project and role required in ReportPayload

### DIFF
--- a/server/models.py
+++ b/server/models.py
@@ -16,8 +16,8 @@ class ReportPayload(BaseModel):
     core_version: Optional[str] = None
     timestamp: Optional[str] = None
 
-    project: Optional[str] = None
-    role: Optional[str] = None
+    project: str
+    role: str
     model: Optional[str] = None
     event_type: Optional[str] = None
     event: Optional[str] = None        # alias for event_type (v1.0 schema)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -221,3 +221,31 @@ def test_concurrent_reports_both_persisted(shared_client):
     feed = shared_client.get("/api/feed").json()
     roles = {e["role"] for e in feed if e["project"] == project}
     assert {"builder", "reviewer"}.issubset(roles)
+
+
+def test_missing_project_returns_422(isolated_client):
+    """POST /api/report without 'project' must be rejected (bug #196)."""
+    resp = isolated_client.post("/api/report", json={
+        "role": "dev",
+        "event_type": "dev_done",
+    })
+    assert resp.status_code == 422
+
+
+def test_missing_role_returns_422(isolated_client):
+    """POST /api/report without 'role' must be rejected (bug #196)."""
+    resp = isolated_client.post("/api/report", json={
+        "project": "p",
+        "event_type": "dev_done",
+    })
+    assert resp.status_code == 422
+
+
+def test_full_payload_returns_202(isolated_client):
+    """POST /api/report with both project and role present succeeds."""
+    resp = isolated_client.post("/api/report", json={
+        "project": "p",
+        "role": "dev",
+        "event_type": "dev_done",
+    })
+    assert resp.status_code == 202


### PR DESCRIPTION
## Problem

POST `/api/report` silently accepted payloads missing `project` and `role`, causing silent data loss — events were persisted without these critical identifiers.

## Fix

- **server/models.py**: Changed `project: Optional[str] = None` and `role: Optional[str] = None` to `project: str` and `role: str` (required, no default). This matches the existing pattern in `VerdictPayload` and ensures FastAPI returns 422 when either field is missing.

- **tests/test_ingest.py**: Added 3 test cases:
  - `test_missing_project_returns_422` — POST without `project` → 422
  - `test_missing_role_returns_422` — POST without `role` → 422
  - `test_full_payload_returns_202` — POST with both fields → 202

## Verification

All 3 new tests pass locally. Existing tests that already provided `project` and `role` are unaffected.

Closes #196