### PR TITLE
[LM-309] Filter action_queue to currently-open GitHub issues/PRs

### DIFF
--- a/server/routes/action_queue.py
+++ b/server/routes/action_queue.py
@@ -1,6 +1,9 @@
 import json
+import logging
 import os
 import sqlite3
+import subprocess
+import time
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -10,6 +13,12 @@ from server.constants import PROJECTS
 from server.db import db_dep
 from server.helpers.github import fetch_failure_context
 from server.helpers.timeline import parse_ts
+
+logger = logging.getLogger(__name__)
+
+# Per-project open-set cache: repo -> ({"issue": set|None, "pr": set|None}, expires_at)
+_OPEN_SET_CACHE: dict[str, tuple[dict[str, Optional[set[int]]], float]] = {}
+_OPEN_SET_TTL = 60  # seconds
 
 router = APIRouter()
 
@@ -141,11 +150,61 @@ def _action_queue_reason(
     return None
 
 
+def _fetch_open_numbers(repo: str, kind: str) -> Optional[set[int]]:
+    """Call gh to list open issues or PRs for a repo.
+
+    Returns None when the gh call fails (caller should include items conservatively).
+    Returns a set (possibly empty) when gh succeeds.
+    """
+    entity = "issue" if kind == "issue" else "pr"
+    try:
+        result = subprocess.run(
+            [
+                "gh", entity, "list",
+                "--repo", repo,
+                "--state", "open",
+                "--limit", "1000",
+                "--json", "number",
+                "--jq", "[.[].number]",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        return set(json.loads(result.stdout))
+    except (json.JSONDecodeError, ValueError, TypeError):
+        return None
+
+
+def _get_open_set(repo: str) -> dict[str, Optional[set[int]]]:
+    """Return cached open issue/PR numbers for a repo, refreshing after TTL.
+
+    Values are None when the corresponding gh call failed — callers treat None
+    as "unknown" and include the item conservatively.
+    """
+    now = time.monotonic()
+    cached = _OPEN_SET_CACHE.get(repo)
+    if cached and now < cached[1]:
+        return cached[0]
+    open_set: dict[str, Optional[set[int]]] = {
+        "issue": _fetch_open_numbers(repo, "issue"),
+        "pr": _fetch_open_numbers(repo, "pr"),
+    }
+    _OPEN_SET_CACHE[repo] = (open_set, now + _OPEN_SET_TTL)
+    return open_set
+
+
 @router.get("/api/action_queue")
 def action_queue(conn: sqlite3.Connection = Depends(db_dep)):
     """Items across all projects awaiting human input.
 
-    Derived from the latest event per (project, kind, number). No GitHub API call.
+    Derived from the latest event per (project, kind, number), then filtered
+    to only items currently open on GitHub (cached 60 s per project).
     """
     rows = conn.execute(
         """
@@ -214,8 +273,31 @@ def action_queue(conn: sqlite3.Connection = Depends(db_dep)):
             "loop_id": r["loop_id"],
             "github_url": github_url,
         })
-    result.sort(key=lambda x: x["age_seconds"], reverse=True)
-    return result
+    # Filter to only currently-open items on GitHub.
+    # Group candidates by project, fetch open-sets once per project per minute.
+    # When gh call fails (open_numbers is None), include conservatively.
+    before_count = len(result)
+    filtered: list[dict] = []
+    for item in result:
+        repo = PROJECTS.get(item["project"])
+        if repo is None:
+            # No repo mapping — cannot verify state, include conservatively.
+            filtered.append(item)
+            continue
+        open_set = _get_open_set(repo)
+        open_numbers = open_set.get(item["kind"])
+        if open_numbers is None or item["number"] in open_numbers:
+            filtered.append(item)
+    after_count = len(filtered)
+    if before_count != after_count:
+        logger.info(
+            "action_queue: filtered %d closed/merged items out of %d candidates (%d open remain)",
+            before_count - after_count,
+            before_count,
+            after_count,
+        )
+    filtered.sort(key=lambda x: x["age_seconds"], reverse=True)
+    return filtered
 
 
 @router.get("/api/action_queue/{project}/{kind}/{number}/failure")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,11 +3,14 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+from unittest.mock import MagicMock  # noqa: E402
+
 import pytest  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
 import server  # noqa: E402
 import server.db  # noqa: E402
+import server.routes.action_queue as _aq  # noqa: E402
 
 
 @pytest.fixture(scope="session")
@@ -23,5 +26,14 @@ def shared_client(tmp_path_factory):
 def isolated_client(tmp_path, monkeypatch):
     monkeypatch.setattr(server.db, "DB_PATH", str(tmp_path / "test.db"))
     server.apply_pending_migrations()
+    # Default: make gh open-set calls fail so the filter passes items through
+    # conservatively. LM-309 open-set tests patch subprocess.run themselves
+    # (via unittest.mock.patch) which overrides this mock for their block.
+    _fail = MagicMock()
+    _fail.returncode = 1
+    _subprocess_mock = MagicMock()
+    _subprocess_mock.run.return_value = _fail
+    monkeypatch.setattr(_aq, "subprocess", _subprocess_mock)
+    _aq._OPEN_SET_CACHE.clear()
     with TestClient(server.app) as c:
         yield c

--- a/tests/test_action_queue.py
+++ b/tests/test_action_queue.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import server
 import server.db
 import server.helpers.github as gh_helper
+import server.routes.action_queue as aq_module
 
 
 def test_action_queue_empty(isolated_client):
@@ -360,3 +361,110 @@ def test_failure_endpoint_invalid_kind(isolated_client):
     """Returns 400 for kind values other than 'issue' or 'pr'."""
     resp = isolated_client.get("/api/action_queue/loop/comment/42/failure")
     assert resp.status_code == 400
+
+
+# ── Open-set filtering tests (LM-309) ─────────────────────────────────────────
+
+def _make_gh_open_side_effect(open_issues: list[int], open_prs: list[int]):
+    """Return a side_effect fn for subprocess.run that fakes gh issue/pr list output."""
+    def _side_effect(cmd, **kwargs):
+        mock = MagicMock()
+        mock.returncode = 0
+        if "issue" in cmd and "list" in cmd:
+            mock.stdout = json.dumps(open_issues)
+        else:
+            mock.stdout = json.dumps(open_prs)
+        return mock
+    return _side_effect
+
+
+def test_open_set_filter_removes_closed_candidate(isolated_client, monkeypatch):
+    """A candidate row with number=99 is excluded when gh reports only [1,2,3] open."""
+    monkeypatch.setitem(aq_module.PROJECTS, "project_a", "example-org/project-a")
+    aq_module._OPEN_SET_CACHE.clear()
+
+    server._insert_event(server.ReportPayload(
+        project="project_a", role="dev", event_type="blocked", issue_number=99,
+        detail="stale blocked"
+    ))
+
+    with patch("server.routes.action_queue.subprocess.run",
+               side_effect=_make_gh_open_side_effect([1, 2, 3], [])):
+        resp = isolated_client.get("/api/action_queue")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert all(item["number"] != 99 for item in data)
+
+
+def test_open_set_filter_keeps_open_issue(isolated_client, monkeypatch):
+    """A candidate with number=7 is returned when gh reports it as open."""
+    monkeypatch.setitem(aq_module.PROJECTS, "project_b", "example-org/project-b")
+    aq_module._OPEN_SET_CACHE.clear()
+
+    server._insert_event(server.ReportPayload(
+        project="project_b", role="dev", event_type="blocked", issue_number=7,
+        detail="really stuck"
+    ))
+
+    with patch("server.routes.action_queue.subprocess.run",
+               side_effect=_make_gh_open_side_effect([7, 8], [])):
+        resp = isolated_client.get("/api/action_queue")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    items = [it for it in data if it["number"] == 7 and it["project"] == "project_b"]
+    assert len(items) == 1
+
+
+def test_open_set_filter_one_open_one_closed(isolated_client, monkeypatch):
+    """Integration: two issues at needs-review stage — only the OPEN one is returned."""
+    monkeypatch.setitem(aq_module.PROJECTS, "project_c", "example-org/project-c")
+    aq_module._OPEN_SET_CACHE.clear()
+    # Both issues end with dev_done → needs-review stage
+    server._insert_event(server.ReportPayload(
+        project="project_c", role="dev", event_type="dev_done", issue_number=51,
+    ))
+    server._insert_event(server.ReportPayload(
+        project="project_c", role="dev", event_type="dev_done", issue_number=71,
+    ))
+    # Backdate both so they exceed the review threshold
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        "UPDATE events SET created_at = datetime('now', '-7200 seconds') "
+        "WHERE project = 'project_c'"
+    )
+    conn.commit()
+    conn.close()
+
+    # Only issue 51 is open on GitHub; 71 is closed/merged
+    with patch("server.routes.action_queue.subprocess.run",
+               side_effect=_make_gh_open_side_effect([51], [])):
+        resp = isolated_client.get("/api/action_queue")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    numbers = {it["number"] for it in data if it["project"] == "project_c"}
+    assert 51 in numbers
+    assert 71 not in numbers
+
+
+def test_open_set_filter_no_repo_mapping_includes_conservatively(isolated_client, monkeypatch):
+    """Items from a project with no repo mapping pass through unfiltered."""
+    # Ensure "unmapped_proj" is NOT in PROJECTS
+    monkeypatch.delitem(aq_module.PROJECTS, "unmapped_proj", raising=False)
+    aq_module._OPEN_SET_CACHE.clear()
+
+    server._insert_event(server.ReportPayload(
+        project="unmapped_proj", role="dev", event_type="blocked", issue_number=500,
+        detail="blocked"
+    ))
+
+    with patch("server.routes.action_queue.subprocess.run") as mock_run:
+        resp = isolated_client.get("/api/action_queue")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    items = [it for it in data if it["number"] == 500]
+    assert len(items) == 1
+    mock_run.assert_not_called()


### PR DESCRIPTION
Closes #309

## Changes

**`server/routes/action_queue.py`**
- Added `_fetch_open_numbers(repo, kind)` — calls `gh issue/pr list --state open` for a repo, returns `Optional[set[int]]` (None on gh error, set on success).
- Added `_get_open_set(repo)` — per-project in-process cache with 60 s TTL; returns `{"issue": set|None, "pr": set|None}`.
- After building the candidate list in `action_queue()`, filter each item against its project's open-set. Items pass through conservatively when:
  - The project has no `owner/repo` mapping in `PROJECTS`
  - The gh call failed (returns `None`) — avoids false negatives on transient errors
- Logs how many items were filtered out per request for drift monitoring.

**`tests/test_action_queue.py`**
- `test_open_set_filter_removes_closed_candidate` — stubs gh with open=[1,2,3]; asserts number=99 is excluded.
- `test_open_set_filter_keeps_open_issue` — stubs gh with open=[7,8]; asserts number=7 is returned.
- `test_open_set_filter_one_open_one_closed` — integration: two issues at needs-review, gh reports only one open; only that one returned.
- `test_open_set_filter_no_repo_mapping_includes_conservatively` — unmapped project passes through without gh call.

## Test Plan
- `ruff check .` — passes
- `npm run typecheck && npm run build` — passes
- `pytest tests/test_action_queue.py` — 23/24 pass (1 pre-existing failure: `test_failure_endpoint_with_marker` was already red on main, unrelated to this change)
- Verify manually: `/api/action_queue` response drops from ~545 items to ~22 real stuck ones