### PR TITLE
[LM-311] Replace per-request gh filter with DB-only terminal-event tracking

### DIFF
--- a/scripts/reconciler.py
+++ b/scripts/reconciler.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
-"""Reconciler tick — checks SLO breaches and emits alerts.
+"""Reconciler tick — checks SLO breaches, emits alerts, and syncs closed-issue state.
 
 Intended to be invoked on a schedule (e.g. every 15 min by cron or the
 loop orchestrator).  Reads from bounty.db, checks each project with a
 configured SLO, and sends a Signal alert when a sustained breach is detected.
+Also emits `issue_closed` events for issues that GitHub reports as CLOSED but
+have no terminal event in the DB yet (eliminating per-request gh calls from
+the action_queue endpoint).
 
 Environment variables:
     DB_PATH            path to bounty.db (default: bounty.db)
@@ -13,6 +16,7 @@ Environment variables:
 """
 from __future__ import annotations
 
+import json
 import os
 import sqlite3
 import subprocess
@@ -116,6 +120,83 @@ def check_slo_breaches(conn: sqlite3.Connection) -> None:
         conn.commit()
 
 
+_TERMINAL_EVENTS = ("merge_done", "done", "issue_closed")
+
+
+def _fetch_closed_issue_numbers(repo: str) -> set[int] | None:
+    """Return the set of closed issue numbers for a repo via gh, or None on failure."""
+    try:
+        result = subprocess.run(
+            [
+                "gh", "issue", "list",
+                "--repo", repo,
+                "--state", "closed",
+                "--limit", "1000",
+                "--json", "number",
+                "--jq", "[.[].number]",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        return set(json.loads(result.stdout))
+    except (json.JSONDecodeError, ValueError, TypeError):
+        return None
+
+
+def emit_issue_closed_events(conn: sqlite3.Connection, projects: dict[str, str]) -> None:
+    """For each project, detect issues closed on GitHub with no terminal DB event.
+
+    Queries the DB for issue_numbers that have prior events but no terminal event,
+    then calls gh once per project to find which are CLOSED, and inserts
+    `issue_closed` events for them so the action_queue endpoint needs zero gh calls.
+    """
+    placeholders = ",".join("?" * len(_TERMINAL_EVENTS))
+    for slug, repo in projects.items():
+        candidates_rows = conn.execute(
+            f"""
+            SELECT DISTINCT issue_number
+            FROM events
+            WHERE project = ? AND issue_number IS NOT NULL
+              AND issue_number NOT IN (
+                SELECT DISTINCT issue_number
+                FROM events
+                WHERE project = ? AND issue_number IS NOT NULL
+                  AND event_type IN ({placeholders})
+              )
+            """,
+            (slug, slug, *_TERMINAL_EVENTS),
+        ).fetchall()
+
+        if not candidates_rows:
+            continue
+
+        candidate_numbers = {row[0] for row in candidates_rows}
+        closed_numbers = _fetch_closed_issue_numbers(repo)
+        if closed_numbers is None:
+            print(f"[reconciler] gh call failed for {repo}, skipping issue_closed sync", flush=True)
+            continue
+
+        to_close = candidate_numbers & closed_numbers
+        if not to_close:
+            continue
+
+        now = datetime.now(timezone.utc).isoformat()
+        for number in to_close:
+            conn.execute(
+                "INSERT INTO events (project, role, event_type, issue_number, created_at)"
+                " VALUES (?, 'reconciler', 'issue_closed', ?, ?)",
+                (slug, number, now),
+            )
+        conn.commit()
+        print(f"[reconciler] emitted issue_closed for {slug}: {sorted(to_close)}", flush=True)
+
+
 def main() -> int:
     db_path = os.environ.get("DB_PATH", "bounty.db")
     conn = sqlite3.connect(db_path)
@@ -124,6 +205,12 @@ def main() -> int:
     conn.execute("PRAGMA busy_timeout=10000")
     try:
         check_slo_breaches(conn)
+        try:
+            from server.constants import PROJECTS
+        except ImportError:
+            PROJECTS = {}
+        if PROJECTS:
+            emit_issue_closed_events(conn, PROJECTS)
         return 0
     except Exception as exc:
         print(f"reconciler error: {exc}", file=sys.stderr)

--- a/server/routes/action_queue.py
+++ b/server/routes/action_queue.py
@@ -2,8 +2,6 @@ import json
 import logging
 import os
 import sqlite3
-import subprocess
-import time
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -15,10 +13,6 @@ from server.helpers.github import fetch_failure_context
 from server.helpers.timeline import parse_ts
 
 logger = logging.getLogger(__name__)
-
-# Per-project open-set cache: repo -> ({"issue": set|None, "pr": set|None}, expires_at)
-_OPEN_SET_CACHE: dict[str, tuple[dict[str, Optional[set[int]]], float]] = {}
-_OPEN_SET_TTL = 60  # seconds
 
 router = APIRouter()
 
@@ -76,6 +70,7 @@ _EVENT_TO_STAGE: dict[str, Optional[str]] = {
     "review_done":    "needs-qa",
     "qa_pass":        None,
     "merge_done":     None,
+    "issue_closed":   None,
     "po_failed":      "blocked",
     "dev_failed":     "blocked",
     "review_failed":  "blocked",
@@ -150,54 +145,6 @@ def _action_queue_reason(
     return None
 
 
-def _fetch_open_numbers(repo: str, kind: str) -> Optional[set[int]]:
-    """Call gh to list open issues or PRs for a repo.
-
-    Returns None when the gh call fails (caller should include items conservatively).
-    Returns a set (possibly empty) when gh succeeds.
-    """
-    entity = "issue" if kind == "issue" else "pr"
-    try:
-        result = subprocess.run(
-            [
-                "gh", entity, "list",
-                "--repo", repo,
-                "--state", "open",
-                "--limit", "1000",
-                "--json", "number",
-                "--jq", "[.[].number]",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=15,
-        )
-    except Exception:
-        return None
-    if result.returncode != 0:
-        return None
-    try:
-        return set(json.loads(result.stdout))
-    except (json.JSONDecodeError, ValueError, TypeError):
-        return None
-
-
-def _get_open_set(repo: str) -> dict[str, Optional[set[int]]]:
-    """Return cached open issue/PR numbers for a repo, refreshing after TTL.
-
-    Values are None when the corresponding gh call failed — callers treat None
-    as "unknown" and include the item conservatively.
-    """
-    now = time.monotonic()
-    cached = _OPEN_SET_CACHE.get(repo)
-    if cached and now < cached[1]:
-        return cached[0]
-    open_set: dict[str, Optional[set[int]]] = {
-        "issue": _fetch_open_numbers(repo, "issue"),
-        "pr": _fetch_open_numbers(repo, "pr"),
-    }
-    _OPEN_SET_CACHE[repo] = (open_set, now + _OPEN_SET_TTL)
-    return open_set
-
 
 @router.get("/api/action_queue")
 def action_queue(conn: sqlite3.Connection = Depends(db_dep)):
@@ -232,6 +179,13 @@ def action_queue(conn: sqlite3.Connection = Depends(db_dep)):
             SELECT MAX(r2.id) FROM pipeline_runs r2
             WHERE r2.project = e.project
               AND (r2.issue_number = e.issue_number OR r2.pr_number = e.pr_number)
+        )
+        WHERE NOT EXISTS (
+            SELECT 1 FROM events t
+            WHERE t.project = latest.project
+              AND COALESCE(t.issue_number, -1) = latest.i
+              AND COALESCE(t.pr_number, -1) = latest.p
+              AND t.event_type IN ('merge_done', 'issue_closed')
         )
         """
     ).fetchall()
@@ -273,31 +227,8 @@ def action_queue(conn: sqlite3.Connection = Depends(db_dep)):
             "loop_id": r["loop_id"],
             "github_url": github_url,
         })
-    # Filter to only currently-open items on GitHub.
-    # Group candidates by project, fetch open-sets once per project per minute.
-    # When gh call fails (open_numbers is None), include conservatively.
-    before_count = len(result)
-    filtered: list[dict] = []
-    for item in result:
-        repo = PROJECTS.get(item["project"])
-        if repo is None:
-            # No repo mapping — cannot verify state, include conservatively.
-            filtered.append(item)
-            continue
-        open_set = _get_open_set(repo)
-        open_numbers = open_set.get(item["kind"])
-        if open_numbers is None or item["number"] in open_numbers:
-            filtered.append(item)
-    after_count = len(filtered)
-    if before_count != after_count:
-        logger.info(
-            "action_queue: filtered %d closed/merged items out of %d candidates (%d open remain)",
-            before_count - after_count,
-            before_count,
-            after_count,
-        )
-    filtered.sort(key=lambda x: x["age_seconds"], reverse=True)
-    return filtered
+    result.sort(key=lambda x: x["age_seconds"], reverse=True)
+    return result
 
 
 @router.get("/api/action_queue/{project}/{kind}/{number}/failure")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,14 +3,11 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from unittest.mock import MagicMock  # noqa: E402
-
 import pytest  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
 import server  # noqa: E402
 import server.db  # noqa: E402
-import server.routes.action_queue as _aq  # noqa: E402
 
 
 @pytest.fixture(scope="session")
@@ -26,14 +23,5 @@ def shared_client(tmp_path_factory):
 def isolated_client(tmp_path, monkeypatch):
     monkeypatch.setattr(server.db, "DB_PATH", str(tmp_path / "test.db"))
     server.apply_pending_migrations()
-    # Default: make gh open-set calls fail so the filter passes items through
-    # conservatively. LM-309 open-set tests patch subprocess.run themselves
-    # (via unittest.mock.patch) which overrides this mock for their block.
-    _fail = MagicMock()
-    _fail.returncode = 1
-    _subprocess_mock = MagicMock()
-    _subprocess_mock.run.return_value = _fail
-    monkeypatch.setattr(_aq, "subprocess", _subprocess_mock)
-    _aq._OPEN_SET_CACHE.clear()
     with TestClient(server.app) as c:
         yield c

--- a/tests/test_action_queue.py
+++ b/tests/test_action_queue.py
@@ -15,7 +15,6 @@ def test_action_queue_empty(isolated_client):
 
 
 def test_action_queue_blocked_label(isolated_client, monkeypatch):
-    from server.routes import action_queue as aq_module
     monkeypatch.setitem(aq_module.PROJECTS, "project_a", "example-org/project-a")
     server._insert_event(server.ReportPayload(
         project="project_a", role="dev", event_type="blocked", issue_number=42,
@@ -363,108 +362,98 @@ def test_failure_endpoint_invalid_kind(isolated_client):
     assert resp.status_code == 400
 
 
-# ── Open-set filtering tests (LM-309) ─────────────────────────────────────────
+# ── DB-only terminal-event filtering tests (LM-311) ───────────────────────────
 
-def _make_gh_open_side_effect(open_issues: list[int], open_prs: list[int]):
-    """Return a side_effect fn for subprocess.run that fakes gh issue/pr list output."""
-    def _side_effect(cmd, **kwargs):
-        mock = MagicMock()
-        mock.returncode = 0
-        if "issue" in cmd and "list" in cmd:
-            mock.stdout = json.dumps(open_issues)
-        else:
-            mock.stdout = json.dumps(open_prs)
-        return mock
-    return _side_effect
-
-
-def test_open_set_filter_removes_closed_candidate(isolated_client, monkeypatch):
-    """A candidate row with number=99 is excluded when gh reports only [1,2,3] open."""
-    monkeypatch.setitem(aq_module.PROJECTS, "project_a", "example-org/project-a")
-    aq_module._OPEN_SET_CACHE.clear()
-
+def test_terminal_issue_closed_skips_issue(isolated_client):
+    """dev_done followed by issue_closed → action_queue skips the issue entirely."""
     server._insert_event(server.ReportPayload(
-        project="project_a", role="dev", event_type="blocked", issue_number=99,
-        detail="stale blocked"
-    ))
-
-    with patch("server.routes.action_queue.subprocess.run",
-               side_effect=_make_gh_open_side_effect([1, 2, 3], [])):
-        resp = isolated_client.get("/api/action_queue")
-
-    assert resp.status_code == 200
-    data = resp.json()
-    assert all(item["number"] != 99 for item in data)
-
-
-def test_open_set_filter_keeps_open_issue(isolated_client, monkeypatch):
-    """A candidate with number=7 is returned when gh reports it as open."""
-    monkeypatch.setitem(aq_module.PROJECTS, "project_b", "example-org/project-b")
-    aq_module._OPEN_SET_CACHE.clear()
-
-    server._insert_event(server.ReportPayload(
-        project="project_b", role="dev", event_type="blocked", issue_number=7,
-        detail="really stuck"
-    ))
-
-    with patch("server.routes.action_queue.subprocess.run",
-               side_effect=_make_gh_open_side_effect([7, 8], [])):
-        resp = isolated_client.get("/api/action_queue")
-
-    assert resp.status_code == 200
-    data = resp.json()
-    items = [it for it in data if it["number"] == 7 and it["project"] == "project_b"]
-    assert len(items) == 1
-
-
-def test_open_set_filter_one_open_one_closed(isolated_client, monkeypatch):
-    """Integration: two issues at needs-review stage — only the OPEN one is returned."""
-    monkeypatch.setitem(aq_module.PROJECTS, "project_c", "example-org/project-c")
-    aq_module._OPEN_SET_CACHE.clear()
-    # Both issues end with dev_done → needs-review stage
-    server._insert_event(server.ReportPayload(
-        project="project_c", role="dev", event_type="dev_done", issue_number=51,
+        project="loop", role="dev", event_type="dev_done", issue_number=99,
     ))
     server._insert_event(server.ReportPayload(
-        project="project_c", role="dev", event_type="dev_done", issue_number=71,
+        project="loop", role="reconciler", event_type="issue_closed", issue_number=99,
     ))
-    # Backdate both so they exceed the review threshold
+    # Backdate dev_done to exceed the review timeout threshold
     conn = sqlite3.connect(server.db.DB_PATH)
     conn.execute(
-        "UPDATE events SET created_at = datetime('now', '-7200 seconds') "
-        "WHERE project = 'project_c'"
+        "UPDATE events SET created_at = datetime('now', '-7200 seconds')"
+        " WHERE issue_number = 99 AND event_type = 'dev_done'"
     )
     conn.commit()
     conn.close()
-
-    # Only issue 51 is open on GitHub; 71 is closed/merged
-    with patch("server.routes.action_queue.subprocess.run",
-               side_effect=_make_gh_open_side_effect([51], [])):
-        resp = isolated_client.get("/api/action_queue")
-
+    resp = isolated_client.get("/api/action_queue")
     assert resp.status_code == 200
-    data = resp.json()
-    numbers = {it["number"] for it in data if it["project"] == "project_c"}
-    assert 51 in numbers
-    assert 71 not in numbers
+    assert all(item["number"] != 99 for item in resp.json())
 
 
-def test_open_set_filter_no_repo_mapping_includes_conservatively(isolated_client, monkeypatch):
-    """Items from a project with no repo mapping pass through unfiltered."""
-    # Ensure "unmapped_proj" is NOT in PROJECTS
-    monkeypatch.delitem(aq_module.PROJECTS, "unmapped_proj", raising=False)
-    aq_module._OPEN_SET_CACHE.clear()
-
+def test_terminal_in_history_skips_despite_later_label_event(isolated_client, monkeypatch):
+    """issue_closed in history trumps a later label_transition — item still skipped."""
+    monkeypatch.setenv("HANDLER_TIMEOUT_REVIEW", "60")
     server._insert_event(server.ReportPayload(
-        project="unmapped_proj", role="dev", event_type="blocked", issue_number=500,
-        detail="blocked"
+        project="loop", role="dev", event_type="dev_done", issue_number=88,
     ))
-
-    with patch("server.routes.action_queue.subprocess.run") as mock_run:
-        resp = isolated_client.get("/api/action_queue")
-
+    server._insert_event(server.ReportPayload(
+        project="loop", role="reconciler", event_type="issue_closed", issue_number=88,
+    ))
+    # Later stale label_transition that would otherwise infer a non-None stage
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="label_transition", issue_number=88,
+        payload={
+            "target_kind": "issue",
+            "number": 88,
+            "before_labels": [],
+            "after_labels": ["needs-review"],
+            "op": "add",
+            "source": "reconciler",
+        }
+    ))
+    # Backdate all events so age exceeds threshold
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        "UPDATE events SET created_at = datetime('now', '-3600 seconds')"
+        " WHERE issue_number = 88"
+    )
+    conn.commit()
+    conn.close()
+    resp = isolated_client.get("/api/action_queue")
     assert resp.status_code == 200
-    data = resp.json()
-    items = [it for it in data if it["number"] == 500]
+    assert all(item["number"] != 88 for item in resp.json())
+
+
+def test_terminal_merge_done_skips_pr(isolated_client):
+    """merge_done event causes the PR to be excluded from the action queue."""
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="dev_done", pr_number=55,
+    ))
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="merge_done", pr_number=55,
+    ))
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        "UPDATE events SET created_at = datetime('now', '-7200 seconds')"
+        " WHERE pr_number = 55 AND event_type = 'dev_done'"
+    )
+    conn.commit()
+    conn.close()
+    resp = isolated_client.get("/api/action_queue")
+    assert resp.status_code == 200
+    assert all(item["number"] != 55 for item in resp.json())
+
+
+def test_no_terminal_event_issue_still_appears(isolated_client, monkeypatch):
+    """Issue with dev_done and no terminal event is still surfaced as timeout."""
+    monkeypatch.setenv("HANDLER_TIMEOUT_REVIEW", "60")
+    server._insert_event(server.ReportPayload(
+        project="loop", role="dev", event_type="dev_done", issue_number=77,
+    ))
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        "UPDATE events SET created_at = datetime('now', '-3600 seconds')"
+        " WHERE issue_number = 77"
+    )
+    conn.commit()
+    conn.close()
+    resp = isolated_client.get("/api/action_queue")
+    assert resp.status_code == 200
+    items = [it for it in resp.json() if it["number"] == 77]
     assert len(items) == 1
-    mock_run.assert_not_called()
+    assert items[0]["reason"] == "timeout"

--- a/tests/test_reconciler.py
+++ b/tests/test_reconciler.py
@@ -1,0 +1,129 @@
+import json
+import os
+import sqlite3
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scripts.reconciler import emit_issue_closed_events
+
+
+def _make_db(tmp_path) -> sqlite3.Connection:
+    db_path = str(tmp_path / "test.db")
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("""
+        CREATE TABLE events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            project TEXT NOT NULL,
+            role TEXT NOT NULL,
+            model TEXT,
+            event_type TEXT NOT NULL,
+            issue_number INTEGER,
+            pr_number INTEGER,
+            detail TEXT,
+            payload TEXT,
+            core_version TEXT,
+            loop_id TEXT,
+            created_at TEXT NOT NULL
+        )
+    """)
+    conn.commit()
+    return conn
+
+
+def _insert(conn, project, event_type, issue_number):
+    conn.execute(
+        "INSERT INTO events (project, role, event_type, issue_number, created_at)"
+        " VALUES (?, 'dev', ?, ?, datetime('now'))",
+        (project, event_type, issue_number),
+    )
+    conn.commit()
+
+
+def _make_gh_closed_side_effect(closed: list[int]):
+    def _side_effect(cmd, **kwargs):
+        mock = MagicMock()
+        mock.returncode = 0
+        mock.stdout = json.dumps(closed)
+        return mock
+    return _side_effect
+
+
+def test_emit_issue_closed_inserts_event(tmp_path):
+    """Reconciler inserts issue_closed when gh reports the candidate as CLOSED."""
+    conn = _make_db(tmp_path)
+    _insert(conn, "myproject", "dev_done", 42)
+
+    with patch("scripts.reconciler.subprocess.run",
+               side_effect=_make_gh_closed_side_effect([42, 99])):
+        emit_issue_closed_events(conn, {"myproject": "example-org/myproject"})
+
+    rows = conn.execute(
+        "SELECT event_type, issue_number FROM events"
+        " WHERE project = 'myproject' AND event_type = 'issue_closed'"
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["issue_number"] == 42
+
+
+def test_emit_issue_closed_skips_already_terminal(tmp_path):
+    """Reconciler does not insert issue_closed when merge_done already exists."""
+    conn = _make_db(tmp_path)
+    _insert(conn, "myproject", "dev_done", 10)
+    _insert(conn, "myproject", "merge_done", 10)
+
+    with patch("scripts.reconciler.subprocess.run") as mock_run:
+        emit_issue_closed_events(conn, {"myproject": "example-org/myproject"})
+
+    mock_run.assert_not_called()
+    rows = conn.execute(
+        "SELECT COUNT(*) AS cnt FROM events"
+        " WHERE project = 'myproject' AND event_type = 'issue_closed'"
+    ).fetchone()
+    assert rows["cnt"] == 0
+
+
+def test_emit_issue_closed_gh_failure_skips_project(tmp_path):
+    """When gh call fails, no issue_closed events are inserted."""
+    conn = _make_db(tmp_path)
+    _insert(conn, "proj", "dev_done", 7)
+
+    fail_mock = MagicMock()
+    fail_mock.returncode = 1
+    fail_mock.stdout = ""
+    with patch("scripts.reconciler.subprocess.run", return_value=fail_mock):
+        emit_issue_closed_events(conn, {"proj": "example-org/proj"})
+
+    rows = conn.execute(
+        "SELECT COUNT(*) AS cnt FROM events WHERE event_type = 'issue_closed'"
+    ).fetchone()
+    assert rows["cnt"] == 0
+
+
+def test_emit_issue_closed_open_issue_not_inserted(tmp_path):
+    """Candidate issue that gh reports as open (not in closed list) is not touched."""
+    conn = _make_db(tmp_path)
+    _insert(conn, "proj", "dev_done", 5)
+
+    with patch("scripts.reconciler.subprocess.run",
+               side_effect=_make_gh_closed_side_effect([99, 100])):
+        emit_issue_closed_events(conn, {"proj": "example-org/proj"})
+
+    rows = conn.execute(
+        "SELECT COUNT(*) AS cnt FROM events WHERE event_type = 'issue_closed'"
+    ).fetchone()
+    assert rows["cnt"] == 0
+
+
+def test_emit_issue_closed_no_candidates_skips_gh(tmp_path):
+    """When all issues already have terminal events, gh is never called."""
+    conn = _make_db(tmp_path)
+    _insert(conn, "proj", "dev_done", 3)
+    _insert(conn, "proj", "issue_closed", 3)
+
+    with patch("scripts.reconciler.subprocess.run") as mock_run:
+        emit_issue_closed_events(conn, {"proj": "example-org/proj"})
+
+    mock_run.assert_not_called()


### PR DESCRIPTION
Closes #311

## Changes

**`server/routes/action_queue.py`**
- Add `issue_closed → None` to `_EVENT_TO_STAGE` (terminal, no action needed)
- Update SQL query to exclude any `(project, issue/pr)` that has a `merge_done` or `issue_closed` event **anywhere in its history** (not just latest), via a `NOT EXISTS` subquery — this handles the case where a later stale `label_transition` overwrites a terminal event in the "latest event" view
- Remove `_OPEN_SET_CACHE`, `_OPEN_SET_TTL`, `_fetch_open_numbers`, `_get_open_set` — the per-request gh filter from LM-309/#310 is fully superseded
- Remove `subprocess` and `time` imports (no longer used in this module)

**`scripts/reconciler.py`**
- Add `emit_issue_closed_events(conn, projects)`: for each project, queries the DB for issue numbers with events but no terminal event (`merge_done`, `done`, `issue_closed`), calls `gh issue list --state closed` once per project, inserts `issue_closed` events for any intersection — keeping the DB current so the action_queue endpoint needs zero gh calls

**`tests/conftest.py`**
- Remove the `subprocess` mock (previously needed to keep the LM-309 gh filter from calling gh in tests)

**`tests/test_action_queue.py`**
- Remove superseded LM-309 open-set filter tests (`test_open_set_filter_*`)
- Add `test_terminal_issue_closed_skips_issue`: `dev_done` + `issue_closed` → skipped
- Add `test_terminal_in_history_skips_despite_later_label_event`: terminal in history wins over a later `label_transition`
- Add `test_terminal_merge_done_skips_pr`: `merge_done` skips a PR
- Add `test_no_terminal_event_issue_still_appears`: no terminal = still surfaced

**`tests/test_reconciler.py`** (new)
- 5 tests covering `emit_issue_closed_events`: inserts event, skips already-terminal, handles gh failure, ignores open issues, skips gh call when no candidates

## Cost reduction
- Request path: **0 GitHub API calls** (was ~18 calls/min when dashboard is open)
- Reconciler: **1 `gh issue list` call per project per tick** (~18 calls/hr total)

## Test Plan
- `ruff check .` — passes
- `npm run typecheck && npm run build` (web) — passes
- `pytest tests/test_action_queue.py tests/test_reconciler.py` — 28/29 pass (1 pre-existing failure in `test_failure_endpoint_with_marker` that fails on `main` too — missing `monkeypatch.setitem(PROJECTS, "loop", ...)` in that test)