### PR TITLE
[LM-215] Add per-ticket timeline drill-down

### DIFF
--- a/server/routes/timeline.py
+++ b/server/routes/timeline.py
@@ -1,49 +1,234 @@
 import json
 import sqlite3
+from datetime import datetime, timezone
+from typing import Optional
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from server.db import db_dep
 
 router = APIRouter()
 
 
+def _parse_payload(value: Optional[str]) -> dict:
+    if not value:
+        return {}
+    try:
+        parsed = json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _parse_ts(value: str) -> float:
+    normalized = value.replace(" ", "T")
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        parsed = datetime.strptime(normalized[:19], "%Y-%m-%dT%H:%M:%S")
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.timestamp()
+
+
+def _event_role(event: dict) -> str:
+    role = event.get("role")
+    if role:
+        return role
+    event_type = event["event_type"]
+    if "_" not in event_type:
+        return "unknown"
+    return event_type.split("_", 1)[0]
+
+
+def _with_durations(events: list[dict]) -> list[dict]:
+    result = []
+    for idx, event in enumerate(events):
+        item = dict(event)
+        item["duration_seconds"] = None
+        if item["event_type"].endswith("_start"):
+            role = _event_role(item)
+            for next_event in events[idx + 1 :]:
+                if _event_role(next_event) == role and next_event["event_type"].endswith(("_done", "_pass")):
+                    item["duration_seconds"] = max(0, int(_parse_ts(next_event["created_at"]) - _parse_ts(item["created_at"])))
+                    break
+        result.append(item)
+    return result
+
+
+def _latest_stage(conn: sqlite3.Connection, project: str, kind: str, number: int) -> Optional[str]:
+    column = "issue_number" if kind == "issue" else "pr_number"
+    rows = conn.execute(
+        f"""
+        SELECT payload, detail
+        FROM events
+        WHERE project = ? AND {column} = ? AND event_type = 'label_transition'
+        ORDER BY created_at DESC, id DESC
+        """,
+        (project, number),
+    ).fetchall()
+    for row in rows:
+        payload = _parse_payload(row["payload"])
+        labels = payload.get("after_labels")
+        if isinstance(labels, list):
+            for label in labels:
+                if isinstance(label, str) and label.startswith("loop:stage:"):
+                    return label
+        if row["detail"] and str(row["detail"]).startswith("loop:stage:"):
+            return row["detail"]
+    return None
+
+
+def _totals(events: list[dict]) -> dict:
+    total_duration = sum(event["duration_seconds"] or 0 for event in events)
+    role_starts: dict[str, int] = {}
+    total_points = 0
+    verdict = None
+    for event in events:
+        if event["event_type"].endswith("_start"):
+            role = _event_role(event)
+            role_starts[role] = role_starts.get(role, 0) + 1
+        payload = _parse_payload(event.get("payload"))
+        points = payload.get("points")
+        if isinstance(points, int):
+            event["points"] = points
+            total_points += points
+        else:
+            event["points"] = None
+        if event["event_type"] in {"judge_done", "qa_pass", "merge_done"}:
+            verdict = event.get("detail") or event["event_type"]
+
+    return {
+        "total_duration_seconds": total_duration if events else None,
+        "total_points": total_points,
+        "rework_count": sum(max(0, count - 1) for count in role_starts.values()),
+        "verdict": verdict,
+    }
+
+
+def _github_url(project: str, kind: str, number: int) -> str:
+    path = "issues" if kind == "issue" else "pull"
+    return f"https://github.com/svv2014/{project}/{path}/{number}"
+
+
+def _legacy_response(events: list[dict]) -> dict:
+    legacy_events = []
+    for event in events:
+        entry = dict(event)
+        entry["ts"] = entry["created_at"]
+        entry["type"] = entry["event_type"]
+        if entry.get("payload"):
+            entry["payload"] = _parse_payload(entry["payload"])
+        legacy_events.append(entry)
+    return {"events": legacy_events}
+
+
 @router.get("/api/timeline")
 def timeline(
-    slug: str = Query(...),
-    num: int = Query(...),
+    project: Optional[str] = Query(None),
+    issue: Optional[int] = Query(None),
+    pr: Optional[int] = Query(None),
+    slug: Optional[str] = Query(None),
+    num: Optional[int] = Query(None),
     include_skips: bool = Query(False),
     conn: sqlite3.Connection = Depends(db_dep),
 ):
-    """Per-ticket event timeline ordered ascending by created_at."""
+    """Per-ticket event timeline.
+
+    Supports the newer project+issue/pr contract while preserving the older
+    slug+num response used by the current v2 screen.
+    """
+    legacy_mode = project is None and slug is not None and num is not None
+    if legacy_mode:
+        project = slug
+        issue = num
+
+    if project is None:
+        raise HTTPException(status_code=400, detail="project is required")
+    if (issue is None and pr is None) or (issue is not None and pr is not None):
+        raise HTTPException(status_code=400, detail="provide exactly one of issue or pr")
+
+    kind = "issue" if issue is not None else "pr"
+    number = issue if issue is not None else pr
+    assert number is not None
+    ticket_clause = "(issue_number = ? OR pr_number = ?)" if legacy_mode else (
+        "issue_number = ?" if kind == "issue" else "pr_number = ?"
+    )
+    ticket_params = (number, number) if legacy_mode else (number,)
     skip_clause = (
         ""
         if include_skips
         else "AND NOT (event_type = 'reconcile_check' AND json_extract(payload, '$.decision') = 'skip')"
     )
+
     rows = conn.execute(
         f"""
         SELECT id, project, role, model, event_type, issue_number, pr_number,
                detail, payload, core_version, loop_id, created_at
         FROM events
-        WHERE project = ?
-          AND (issue_number = ? OR pr_number = ?)
+        WHERE project = ? AND {ticket_clause}
           {skip_clause}
         ORDER BY created_at ASC, id ASC
         """,
-        (slug, num, num),
+        (project, *ticket_params),
     ).fetchall()
+    events = _with_durations([dict(row) for row in rows])
 
-    events = []
-    for r in rows:
-        entry = dict(r)
-        entry["ts"] = entry["created_at"]
-        entry["type"] = entry["event_type"]
-        if entry["payload"]:
-            try:
-                entry["payload"] = json.loads(entry["payload"])
-            except (json.JSONDecodeError, TypeError):
-                pass
-        events.append(entry)
+    if legacy_mode:
+        return _legacy_response(events)
 
-    return {"events": events}
+    title = next((event["detail"] for event in reversed(events) if event.get("detail")), None)
+    linked_pr = None
+    linked_issue = None
+    if kind == "issue":
+        row = conn.execute(
+            """
+            SELECT pr_number FROM events
+            WHERE project = ? AND issue_number = ? AND pr_number IS NOT NULL
+            ORDER BY created_at DESC, id DESC
+            LIMIT 1
+            """,
+            (project, number),
+        ).fetchone()
+        linked_pr = row["pr_number"] if row else None
+    else:
+        row = conn.execute(
+            """
+            SELECT issue_number FROM events
+            WHERE project = ? AND pr_number = ? AND issue_number IS NOT NULL
+            ORDER BY created_at DESC, id DESC
+            LIMIT 1
+            """,
+            (project, number),
+        ).fetchone()
+        linked_issue = row["issue_number"] if row else None
+
+    totals = _totals(events)
+    clean_events = [
+        {
+            "id": event["id"],
+            "role": event["role"],
+            "event_type": event["event_type"],
+            "model": event["model"],
+            "created_at": event["created_at"],
+            "duration_seconds": event["duration_seconds"],
+            "points": event["points"],
+            "detail": event["detail"],
+        }
+        for event in events
+    ]
+
+    return {
+        "project": project,
+        "kind": kind,
+        "number": number,
+        "title": title,
+        "github_url": _github_url(project, kind, number),
+        "stage": _latest_stage(conn, project, kind, number),
+        "linked_pr": linked_pr,
+        "linked_issue": linked_issue,
+        "events": clean_events,
+        "totals": totals,
+    }

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -106,3 +106,85 @@ def test_timeline_isolates_by_project(isolated_client):
     events = resp.json()["events"]
     assert all(e["project"] == "proj-a" for e in events)
     assert len(events) == 1
+
+
+def test_timeline_issue_contract_with_totals_and_stage(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _insert(conn, "proj-contract", "dev_start", issue_number=42, created_at="2026-01-01T00:00:00")
+    _insert(conn, "proj-contract", "dev_done", issue_number=42, payload={"points": 3}, created_at="2026-01-01T00:10:00")
+    _insert(conn, "proj-contract", "dev_start", issue_number=42, created_at="2026-01-01T00:20:00")
+    conn.execute(
+        """INSERT INTO events (project, role, event_type, issue_number, payload, created_at)
+           VALUES (?, 'scanner', 'label_transition', ?, ?, ?)""",
+        (
+            "proj-contract",
+            42,
+            json.dumps({"after_labels": ["loop:stage:dev"]}),
+            "2026-01-01T00:30:00",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    resp = isolated_client.get("/api/timeline?project=proj-contract&issue=42")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["project"] == "proj-contract"
+    assert data["kind"] == "issue"
+    assert data["number"] == 42
+    assert data["github_url"] == "https://github.com/svv2014/proj-contract/issues/42"
+    assert data["stage"] == "loop:stage:dev"
+    assert data["totals"]["total_duration_seconds"] == 600
+    assert data["totals"]["total_points"] == 3
+    assert data["totals"]["rework_count"] == 1
+    start = next(e for e in data["events"] if e["event_type"] == "dev_start")
+    assert start["duration_seconds"] == 600
+
+
+def test_timeline_requires_exactly_one_ticket_selector(isolated_client):
+    missing = isolated_client.get("/api/timeline?project=proj-contract")
+    assert missing.status_code == 400
+
+    both = isolated_client.get("/api/timeline?project=proj-contract&issue=1&pr=2")
+    assert both.status_code == 400
+
+
+def test_timeline_pr_contract_and_linked_issue(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _insert(
+        conn,
+        "proj-pr-contract",
+        "review_done",
+        issue_number=13,
+        pr_number=99,
+        created_at="2026-01-01T00:00:01",
+    )
+    conn.close()
+
+    resp = isolated_client.get("/api/timeline?project=proj-pr-contract&pr=99")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["kind"] == "pr"
+    assert data["number"] == 99
+    assert data["linked_issue"] == 13
+    assert data["linked_pr"] is None
+    assert data["github_url"] == "https://github.com/svv2014/proj-pr-contract/pull/99"
+
+
+def test_timeline_issue_contract_detects_linked_pr(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _insert(
+        conn,
+        "proj-link",
+        "merge_done",
+        issue_number=44,
+        pr_number=144,
+        created_at="2026-01-01T00:00:01",
+    )
+    conn.close()
+
+    resp = isolated_client.get("/api/timeline?project=proj-link&issue=44")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["linked_pr"] == 144
+    assert data["linked_issue"] is None

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,6 +11,7 @@ import WorkerDetail from './screens/WorkerDetail';
 import Cost from './screens/Cost';
 import Analytics from './screens/Analytics';
 import Timeline from './screens/Timeline';
+import TimelinePanel from './panels/Timeline';
 import { useHashRoute } from './router';
 import { fetchActive, fetchFeed, fetchHealth } from './lib/api';
 
@@ -170,6 +171,7 @@ export default function App() {
           </div>
         )}
       </main>
+      <TimelinePanel />
     </div>
   );
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -28,6 +28,7 @@ import type {
   CostTrend,
   QualityAnalyticsResponse,
   CostTimeseries,
+  Timeline,
 } from './types';
 import * as fx from './fixtures';
 
@@ -231,6 +232,12 @@ export async function fetchAnalyticsQuality(days = 30): Promise<QualityAnalytics
 
 export async function fetchSlo(project: string): Promise<SloConfig> {
   return get<SloConfig>(`/api/projects/${encodeURIComponent(project)}/slo`);
+}
+
+export async function fetchTimeline(project: string, kind: 'issue' | 'pr', number: number): Promise<Timeline> {
+  if (isFixtureMode()) return fx.getFixtureTimeline(project, kind, number);
+  const selector = kind === 'issue' ? 'issue' : 'pr';
+  return get<Timeline>(`/api/timeline?project=${encodeURIComponent(project)}&${selector}=${number}`);
 }
 
 export async function putSlo(project: string, body: { total_seconds: number | null; breach_grace_seconds: number }): Promise<SloConfig> {

--- a/web/src/lib/fixtures.ts
+++ b/web/src/lib/fixtures.ts
@@ -26,6 +26,7 @@ import type {
   ClaudeUsage,
   ScannerState,
   IssueCostRow,
+  Timeline,
 } from './types';
 
 interface FixtureProject { id: string; repo: string; color?: string }
@@ -425,5 +426,39 @@ export function getFixtureScannerState(): ScannerState {
       { project: 'project-b', kind: 'issue', number: 137, stage: 'po',  count: 1, max: 2 },
       { project: 'project-a', kind: 'issue', number: 142, stage: 'dev', count: 2, max: 2 },
     ],
+  };
+}
+
+export function getFixtureTimeline(project: string, kind: 'issue' | 'pr', number: number): Timeline {
+  const matching = HISTORY
+    .filter((event) => event.project === project)
+    .slice(0, 6)
+    .map((event, index) => ({
+      id: event.id,
+      role: event.role,
+      event_type: event.event_type,
+      model: event.model,
+      created_at: new Date(Date.now() - (index + 1) * 120_000).toISOString(),
+      duration_seconds: index % 2 === 0 ? randInt(45, 900) : null,
+      points: event.points,
+      detail: event.detail,
+    }));
+
+  return {
+    project,
+    kind,
+    number,
+    title: `Fixture ${kind} #${number}`,
+    github_url: `https://github.com/example-org/${project}/${kind === 'issue' ? 'issues' : 'pull'}/${number}`,
+    stage: 'loop:stage:dev',
+    linked_pr: kind === 'issue' ? number + 100 : null,
+    linked_issue: kind === 'pr' ? Math.max(1, number - 100) : null,
+    events: matching,
+    totals: {
+      total_duration_seconds: matching.reduce((sum, event) => sum + (event.duration_seconds ?? 0), 0),
+      total_points: matching.reduce((sum, event) => sum + (event.points ?? 0), 0),
+      rework_count: 1,
+      verdict: 'fixture',
+    },
   };
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -363,3 +363,34 @@ export interface CostTrend {
   trend: 'improving' | 'degrading' | 'stable';
   buckets: CostTrendBucket[];
 }
+
+export interface TimelineEvent {
+  id: number;
+  role: string;
+  event_type: string;
+  model: string | null;
+  created_at: string;
+  duration_seconds: number | null;
+  points: number | null;
+  detail: string | null;
+}
+
+export interface TimelineTotals {
+  total_duration_seconds: number | null;
+  total_points: number;
+  rework_count: number;
+  verdict: string | null;
+}
+
+export interface Timeline {
+  project: string;
+  kind: 'issue' | 'pr';
+  number: number;
+  title: string | null;
+  github_url: string;
+  stage: string | null;
+  linked_pr: number | null;
+  linked_issue: number | null;
+  events: TimelineEvent[];
+  totals: TimelineTotals;
+}

--- a/web/src/panels/Timeline.tsx
+++ b/web/src/panels/Timeline.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import Drawer from '../components/Drawer';
+import EventGlyph from '../components/EventGlyph';
+import RoleTag from '../components/RoleTag';
+import { fetchTimeline } from '../lib/api';
+import type { Timeline as TimelineData, TimelineEvent } from '../lib/types';
+import { durationFmt, parseServerTs, relTime } from '../lib/utils';
+
+function parseTimelineHash(hash: string): { project: string; kind: 'issue' | 'pr'; number: number } | null {
+  const raw = hash.startsWith('#') ? hash.slice(1) : hash;
+  const params = new URLSearchParams(raw);
+  const value = params.get('timeline');
+  if (!value) return null;
+  const [project, kind, numberRaw] = value.split('/');
+  const number = Number(numberRaw);
+  if (!project || (kind !== 'issue' && kind !== 'pr') || !Number.isInteger(number)) return null;
+  return { project, kind, number };
+}
+
+function clearTimelineHash() {
+  const raw = window.location.hash.startsWith('#') ? window.location.hash.slice(1) : window.location.hash;
+  const params = new URLSearchParams(raw);
+  params.delete('timeline');
+  const next = params.toString();
+  history.replaceState(null, '', window.location.pathname + window.location.search + (next ? `#${next}` : ''));
+  window.dispatchEvent(new HashChangeEvent('hashchange'));
+}
+
+function EventRow({ event }: { event: TimelineEvent }) {
+  const ts = parseServerTs(event.created_at);
+  return (
+    <div className="feed-row" style={{ alignItems: 'flex-start' }}>
+      <EventGlyph event={event.event_type} />
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+          <RoleTag role={event.role} />
+          <span className="mono" style={{ fontSize: 12 }}>{event.event_type}</span>
+          {event.model && <span className="muted mono" style={{ fontSize: 11 }}>{event.model}</span>}
+          {event.points != null && event.points > 0 && (
+            <span className="tag mono" style={{ color: 'var(--accent)' }}>+{event.points}</span>
+          )}
+        </div>
+        {event.detail && (
+          <div className="muted" style={{ fontSize: 11, marginTop: 2, wordBreak: 'break-word' }}>
+            {event.detail}
+          </div>
+        )}
+      </div>
+      <div className="mono muted" style={{ fontSize: 10, textAlign: 'right', flexShrink: 0 }}>
+        {event.duration_seconds != null && (
+          <div style={{ color: 'var(--fg-2)' }}>{durationFmt(event.duration_seconds * 1000)}</div>
+        )}
+        <div>{relTime(ts)}</div>
+      </div>
+    </div>
+  );
+}
+
+function TimelineBody({ data }: { data: TimelineData }) {
+  return (
+    <>
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+        <a className="btn" href={data.github_url} target="_blank" rel="noreferrer" style={{ textDecoration: 'none' }}>
+          GitHub
+        </a>
+        {data.stage && <span className="tag mono">{data.stage}</span>}
+      </div>
+      {data.events.length === 0 ? (
+        <div className="muted" style={{ fontSize: 12 }}>No events recorded</div>
+      ) : (
+        <div>{data.events.map((event) => <EventRow key={event.id} event={event} />)}</div>
+      )}
+      <div style={{ borderTop: '1px solid var(--border)', paddingTop: 'var(--pad-3)', fontSize: 12 }}>
+        <div className="mono">Total time: {data.totals.total_duration_seconds == null ? 'n/a' : durationFmt(data.totals.total_duration_seconds * 1000)}</div>
+        <div className="mono">Points: {data.totals.total_points}</div>
+        <div className="mono">Rework: {data.totals.rework_count}</div>
+        {data.totals.verdict && <div className="mono">Verdict: {data.totals.verdict}</div>}
+      </div>
+    </>
+  );
+}
+
+export default function TimelinePanel() {
+  const [target, setTarget] = useState(() => parseTimelineHash(window.location.hash));
+
+  useEffect(() => {
+    const onHash = () => setTarget(parseTimelineHash(window.location.hash));
+    window.addEventListener('hashchange', onHash);
+    return () => window.removeEventListener('hashchange', onHash);
+  }, []);
+
+  const query = useQuery({
+    queryKey: ['timeline-panel', target?.project, target?.kind, target?.number],
+    queryFn: () => fetchTimeline(target!.project, target!.kind, target!.number),
+    enabled: target != null,
+    staleTime: 30_000,
+  });
+
+  if (!target) return null;
+
+  const title = query.data?.title
+    ? `${query.data.project} ${query.data.kind} #${query.data.number} - ${query.data.title}`
+    : `${target.project} ${target.kind} #${target.number}`;
+
+  return (
+    <Drawer open={true} onClose={clearTimelineHash} title={title}>
+      {query.isLoading ? (
+        <div className="muted" style={{ fontSize: 12 }}>Loading timeline...</div>
+      ) : query.isError || !query.data ? (
+        <div style={{ fontSize: 12, color: 'var(--fail)' }}>Failed to load timeline</div>
+      ) : (
+        <TimelineBody data={query.data} />
+      )}
+    </Drawer>
+  );
+}


### PR DESCRIPTION
## Changes

- Adds the `GET /api/timeline?project=<slug>&issue=<n>` / `?pr=<n>` contract for per-ticket timeline drill-downs while preserving the existing `slug`/`num` response for the current screen.
- Returns ticket metadata, GitHub URL, stage, linked issue/PR, duration pairing, points, rework count, verdict, and ordered events.
- Adds a global hash-driven timeline drawer for `#timeline=<project>/<kind>/<n>` plus typed API/fixture support.
- Extends timeline tests for the new contract, invalid selectors, linked ticket detection, totals, stage parsing, and legacy compatibility.

Fixes #215
/claim #215

## Verification

- `python -m pytest tests/test_timeline.py tests/test_graph.py tests/test_stats.py`
- `cmd /c "npm run typecheck && npm run build"`