### PR TITLE
[LM-109] Add SQL-backed anomalies endpoint

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -17,6 +17,7 @@ app = FastAPI(title="Loop Monitor", lifespan=lifespan)
 
 from server.routes import (  # noqa: E402
     action_queue,
+    anomalies,
     analytics,
     analytics_velocity,
     board,
@@ -45,6 +46,7 @@ app.include_router(runs.router)
 app.include_router(stats.router)
 app.include_router(graph.router)
 app.include_router(action_queue.router)
+app.include_router(anomalies.router)
 app.include_router(claude_usage.router)
 app.include_router(issues_cost.router)
 app.include_router(logs.router)

--- a/server/routes/anomalies.py
+++ b/server/routes/anomalies.py
@@ -1,0 +1,72 @@
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from server.db import db_dep
+
+router = APIRouter()
+
+
+def _positive_float(value: Optional[str], name: str) -> float:
+    if value is None:
+        raise HTTPException(status_code=400, detail=f"{name} is required")
+    try:
+        parsed = float(value)
+    except ValueError:
+        raise HTTPException(status_code=400, detail=f"{name} must be numeric")
+    if parsed <= 0:
+        raise HTTPException(status_code=400, detail=f"{name} must be positive")
+    return parsed
+
+
+def _positive_int(value: Optional[str], name: str) -> int:
+    if value is None:
+        raise HTTPException(status_code=400, detail=f"{name} is required")
+    try:
+        parsed = int(value)
+    except ValueError:
+        raise HTTPException(status_code=400, detail=f"{name} must be an integer")
+    if parsed <= 0:
+        raise HTTPException(status_code=400, detail=f"{name} must be positive")
+    return parsed
+
+
+@router.get("/api/anomalies")
+def get_anomalies(
+    project: Optional[str] = Query(default=None),
+    window_hours: Optional[str] = Query(default=None),
+    threshold: Optional[str] = Query(default=None),
+    conn: sqlite3.Connection = Depends(db_dep),
+) -> list[dict]:
+    if not project:
+        raise HTTPException(status_code=400, detail="project is required")
+
+    parsed_window_hours = _positive_float(window_hours, "window_hours")
+    parsed_threshold = _positive_int(threshold, "threshold")
+    since = (datetime.now(timezone.utc) - timedelta(hours=parsed_window_hours)).isoformat()
+
+    rows = conn.execute(
+        """
+        SELECT issue_number, COUNT(*) AS touches
+        FROM events
+        WHERE project = :project
+          AND event_type IN ('label_transition', 'reconcile_check')
+          AND created_at > :since
+          AND issue_number IS NOT NULL
+        GROUP BY issue_number
+        HAVING COUNT(*) >= :threshold
+        ORDER BY touches DESC, issue_number ASC
+        """,
+        {
+            "project": project,
+            "since": since,
+            "threshold": parsed_threshold,
+        },
+    ).fetchall()
+
+    return [
+        {"issue_number": row["issue_number"], "touches": row["touches"]}
+        for row in rows
+    ]

--- a/tests/test_anomalies.py
+++ b/tests/test_anomalies.py
@@ -1,0 +1,115 @@
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+import server.db
+
+
+def _ts(hours_ago: float = 0) -> str:
+    return (datetime.now(timezone.utc) - timedelta(hours=hours_ago)).isoformat()
+
+
+def _insert_event(
+    conn: sqlite3.Connection,
+    project: str,
+    event_type: str,
+    issue_number: int | None,
+    created_at: str | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO events (project, role, event_type, issue_number, created_at)
+        VALUES (?, 'scanner', ?, ?, ?)
+        """,
+        (project, event_type, issue_number, created_at or _ts()),
+    )
+    conn.commit()
+
+
+def test_anomalies_empty_for_unknown_project(isolated_client):
+    response = isolated_client.get("/api/anomalies?project=unknown&window_hours=1&threshold=2")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_anomalies_returns_issue_over_threshold(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _insert_event(conn, "proj", "label_transition", 42)
+    _insert_event(conn, "proj", "reconcile_check", 42)
+    _insert_event(conn, "proj", "label_transition", 42)
+    conn.close()
+
+    response = isolated_client.get("/api/anomalies?project=proj&window_hours=1&threshold=3")
+
+    assert response.status_code == 200
+    assert response.json() == [{"issue_number": 42, "touches": 3}]
+
+
+def test_anomalies_excludes_issue_below_threshold(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _insert_event(conn, "proj", "label_transition", 41)
+    _insert_event(conn, "proj", "reconcile_check", 41)
+    conn.close()
+
+    response = isolated_client.get("/api/anomalies?project=proj&window_hours=1&threshold=3")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_anomalies_excludes_events_outside_window(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _insert_event(conn, "proj", "label_transition", 7, _ts(hours_ago=3))
+    _insert_event(conn, "proj", "reconcile_check", 7, _ts(hours_ago=3))
+    conn.close()
+
+    response = isolated_client.get("/api/anomalies?project=proj&window_hours=1&threshold=2")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_anomalies_ignores_other_event_types(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    _insert_event(conn, "proj", "dev_start", 99)
+    _insert_event(conn, "proj", "dev_done", 99)
+    _insert_event(conn, "proj", "qa_fail", 99)
+    conn.close()
+
+    response = isolated_client.get("/api/anomalies?project=proj&window_hours=1&threshold=2")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_anomalies_ignores_pr_only_rows(isolated_client):
+    conn = sqlite3.connect(server.db.DB_PATH)
+    conn.execute(
+        """
+        INSERT INTO events (project, role, event_type, pr_number, created_at)
+        VALUES ('proj', 'scanner', 'label_transition', 10, ?)
+        """,
+        (_ts(),),
+    )
+    conn.execute(
+        """
+        INSERT INTO events (project, role, event_type, pr_number, created_at)
+        VALUES ('proj', 'scanner', 'reconcile_check', 10, ?)
+        """,
+        (_ts(),),
+    )
+    conn.commit()
+    conn.close()
+
+    response = isolated_client.get("/api/anomalies?project=proj&window_hours=1&threshold=2")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_anomalies_returns_400_for_missing_or_invalid_params(isolated_client):
+    assert isolated_client.get("/api/anomalies").status_code == 400
+    assert isolated_client.get("/api/anomalies?project=proj&threshold=2").status_code == 400
+    assert isolated_client.get("/api/anomalies?project=proj&window_hours=1").status_code == 400
+    assert isolated_client.get("/api/anomalies?project=proj&window_hours=nope&threshold=2").status_code == 400
+    assert isolated_client.get("/api/anomalies?project=proj&window_hours=1&threshold=nope").status_code == 400


### PR DESCRIPTION
## Changes

- Adds `GET /api/anomalies?project=<slug>&window_hours=<N>&threshold=<M>` backed by the `events` table.
- Counts `label_transition` and `reconcile_check` events grouped by `issue_number` in the requested window.
- Returns an empty list for unknown/no-match projects and 400s for missing or invalid parameters.
- Adds pytest coverage for empty results, threshold behavior, window filtering, event-type filtering, PR-only rows, and invalid params.

Part of #109. Companion loop PR follows with the reconciler-side SQL path and log-mining fallback.
/claim #109

## Verification

- `python -m pytest tests/test_anomalies.py`
- `python -m pytest tests/test_anomalies.py tests/test_timeline.py tests/test_graph.py tests/test_stats.py`