### PR TITLE
[LM-129] fix: percentile P90 off-by-one in _percentile_stats

### DIFF
--- a/server/routes/stats.py
+++ b/server/routes/stats.py
@@ -1,3 +1,4 @@
+import math
 import json
 import sqlite3
 from datetime import datetime, timezone
@@ -194,8 +195,8 @@ def _percentile_stats(values: list) -> Optional[dict]:
     if n == 0:
         return None
     sorted_vals = sorted(values)
-    median = sorted_vals[int(0.5 * n)]
-    p90 = sorted_vals[int(0.9 * n)]
+    median = sorted_vals[(n - 1) // 2]
+    p90 = sorted_vals[min(math.ceil(0.9 * n), n) - 1]
     return {
         "median_seconds": median,
         "p90_seconds": p90,

--- a/tests/test_percentile_stats.py
+++ b/tests/test_percentile_stats.py
@@ -1,0 +1,33 @@
+from server.routes.stats import _percentile_stats
+
+def test_empty():
+    assert _percentile_stats([]) is None
+
+def test_single_value():
+    r = _percentile_stats([42])
+    assert r == {"median_seconds": 42, "p90_seconds": 42, "count": 1}
+
+def test_n5():
+    r = _percentile_stats([1, 2, 3, 4, 5])
+    assert r["median_seconds"] == 3
+    assert r["p90_seconds"] == 5
+
+def test_n9():
+    r = _percentile_stats(list(range(1, 10)))
+    assert r["median_seconds"] == 5
+    assert r["p90_seconds"] == 9
+
+def test_n10_regression():
+    r = _percentile_stats(list(range(1, 11)))
+    assert r["median_seconds"] == 5
+    assert r["p90_seconds"] == 9
+
+def test_n20():
+    r = _percentile_stats(list(range(1, 21)))
+    assert r["median_seconds"] == 10
+    assert r["p90_seconds"] == 18
+
+def test_unsorted_input():
+    r = _percentile_stats([10, 1, 5, 3, 7])
+    assert r["median_seconds"] == 5
+    assert r["p90_seconds"] == 10


### PR DESCRIPTION
Fix the off-by-one error in _percentile_stats where P90 formula returns max value for small sample sizes.

**Changes:**
- Fix median: sorted_vals[(n - 1) // 2] (lower median)
- Fix P90: sorted_vals[min(math.ceil(0.9 * n), n) - 1] (nearest-rank)
- New test file covering n=1,5,9,10,20

Closes #129